### PR TITLE
feat(cassandra): install arbitrary versions/branches onto a live cluster without an AMI rebuild

### DIFF
--- a/.github/workflows/packer-lint.yml
+++ b/.github/workflows/packer-lint.yml
@@ -13,6 +13,9 @@ on:
       - ".github/workflows/packer-lint.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate-packer:
     name: Validate Packer HCL Files
@@ -22,7 +25,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Packer
-        uses: hashicorp/setup-packer@main
+        uses: hashicorp/setup-packer@v3.1.0
         with:
           version: "latest"
 
@@ -51,7 +54,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@2.0.0
         with:
           scandir: "./packer"
           severity: error

--- a/.github/workflows/packer-test.yml
+++ b/.github/workflows/packer-test.yml
@@ -29,6 +29,31 @@ jobs:
       - name: Run ref-resolution unit tests
         run: bash .github/cassandra-image/resolve-ref.test.sh
 
+  test-cassandra-install-scripts:
+    name: Test Cassandra install/use script logic
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      # Not `snap install yq`: the snap is strictly confined and gets a private /tmp, so it
+      # cannot read the mktemp -d fixtures these tests build. Pinned to the version the AMI
+      # bakes (packer/base/install/install_yq.sh) so CI exercises the same yq the nodes run.
+      - name: Install yq
+        run: |
+          curl -fsSL --retry 3 \
+            https://github.com/mikefarah/yq/releases/download/v4.41.1/yq_linux_amd64 -o /tmp/yq
+          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
+
+      - name: Test install-cassandra-version
+        run: bash packer/cassandra/bin/install-cassandra-version.test.sh
+
+      - name: Test the bake-time install loop
+        run: bash packer/cassandra/install/install_cassandra.test.sh
+
+      - name: Test use-cassandra
+        run: bash packer/cassandra/bin/use-cassandra.test.sh
+
   test-profiling-reconciler:
     name: Test edl-profiling-reconcile
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,19 @@ Test packer provisioning scripts locally using Docker (no AWS required):
 ./gradlew testPackerScript -Pscript=cassandra/install/install_cassandra_easy_stress.sh
 ```
 
+Shell scripts whose logic (argument handling, already-installed short-circuits, JDK selection)
+matters more than their side effects also have plain shell unit tests that stub `sudo`/`curl`/`git`
+and need no Docker:
+
+```bash
+./gradlew testCassandraScripts
+```
+
+Scripts in `packer/cassandra/bin/` are **not bake-time-only** — the AMI puts them on the node's
+`PATH` and the CLI invokes them over SSH against a running cluster (`cassandra install`,
+`cassandra use`). Their flags and output are a contract with Kotlin callers; see
+[`commands/CLAUDE.md`](src/main/kotlin/com/rustyrazorblade/easydblab/commands/CLAUDE.md).
+
 For more details, see [packer/README.md](packer/README.md) and [packer/TESTING.md](packer/TESTING.md).
 
 ## Documentation & Specifications

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,6 +308,13 @@ Scripts in `packer/cassandra/bin/` are **not bake-time-only** — the AMI puts t
 `cassandra use`). Their flags and output are a contract with Kotlin callers; see
 [`commands/CLAUDE.md`](src/main/kotlin/com/rustyrazorblade/easydblab/commands/CLAUDE.md).
 
+`packer/cassandra/lib/edl-cassandra-agents.sh` (installed to `/usr/local/lib/`) picks the AxonOps
+and MCAC metrics agents from the release's own jar name. It is sourced by `cassandra.in.sh`, which
+Cassandra's `bin/cassandra` runs under **`/bin/sh` (dash), not bash** — so it must stay POSIX sh.
+A bashism there does not degrade to "no metrics"; dash fails to parse the file and Cassandra will
+not start. `edl-cassandra-agents.test.sh` exercises the functions through a real `/bin/sh` for
+exactly this reason.
+
 For more details, see [packer/README.md](packer/README.md) and [packer/TESTING.md](packer/TESTING.md).
 
 ## Documentation & Specifications

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -381,6 +381,38 @@ tasks.register<Exec>("testCassandraResolveRef") {
     commandLine = listOf("bash", ".github/cassandra-image/resolve-ref.test.sh")
 }
 
+// Unit-test install-cassandra-version's decisions (argument handling, already-installed no-op,
+// source-build guards, JDK selection). sudo/curl/git/dpkg are stubbed; no Docker, no network.
+tasks.register<Exec>("testCassandraInstallScript") {
+    group = "Verification"
+    description = "Unit-test the install-cassandra-version script"
+    workingDir = file(".")
+    commandLine = listOf("bash", "packer/cassandra/bin/install-cassandra-version.test.sh")
+}
+
+// Unit-test the bake-time loop's version resolution (yq-driven flags, lazy skip). Sources
+// install_cassandra.sh without INSTALL_CASSANDRA, so none of its effects run.
+tasks.register<Exec>("testCassandraInstallLoop") {
+    group = "Verification"
+    description = "Unit-test the bake-time Cassandra version install loop"
+    workingDir = file(".")
+    commandLine = listOf("bash", "packer/cassandra/install/install_cassandra.test.sh")
+}
+
+// Unit-test use-cassandra's guard against selecting a version the node never installed.
+tasks.register<Exec>("testCassandraUseScript") {
+    group = "Verification"
+    description = "Unit-test the use-cassandra script"
+    workingDir = file(".")
+    commandLine = listOf("bash", "packer/cassandra/bin/use-cassandra.test.sh")
+}
+
+tasks.register("testCassandraScripts") {
+    group = "Verification"
+    description = "Run all Cassandra shell script unit tests"
+    dependsOn("testCassandraInstallScript", "testCassandraInstallLoop", "testCassandraUseScript")
+}
+
 // Unit-test the node-resident profiling reconciler (decision table, chunk shipping, retention).
 // `asprof`, `cassandra-pid` and `curl` are stubbed and the clock is injected, so there is no
 // Docker, no network, and no real JVM.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -407,10 +407,25 @@ tasks.register<Exec>("testCassandraUseScript") {
     commandLine = listOf("bash", "packer/cassandra/bin/use-cassandra.test.sh")
 }
 
+// Unit-test the agent selection cassandra.in.sh runs on every Cassandra start: deriving X.Y from
+// the release jar name (every shape, including the unparseable one) and mapping it to the AxonOps
+// and MCAC agents. Pure functions; no Docker, no network, no node.
+tasks.register<Exec>("testCassandraAgentSelection") {
+    group = "Verification"
+    description = "Unit-test Cassandra version derivation and metrics-agent selection"
+    workingDir = file(".")
+    commandLine = listOf("bash", "packer/cassandra/lib/edl-cassandra-agents.test.sh")
+}
+
 tasks.register("testCassandraScripts") {
     group = "Verification"
     description = "Run all Cassandra shell script unit tests"
-    dependsOn("testCassandraInstallScript", "testCassandraInstallLoop", "testCassandraUseScript")
+    dependsOn(
+        "testCassandraInstallScript",
+        "testCassandraInstallLoop",
+        "testCassandraUseScript",
+        "testCassandraAgentSelection",
+    )
 }
 
 // Unit-test the node-resident profiling reconciler (decision table, chunk shipping, retention).

--- a/docs/development/building-cassandra-refs.md
+++ b/docs/development/building-cassandra-refs.md
@@ -111,8 +111,16 @@ Pin the release's tarball URL in `packer/cassandra/cassandra_versions.yaml`:
   python: "3.11.9"
 ```
 
-`install_cassandra.sh` downloads the URL and expects it to unpack into a single
-top-level `*cassandra*` directory, which the `ant artifacts` tarball satisfies.
+`install-cassandra-version` downloads the URL and expects it to unpack into a
+single top-level `*cassandra*` directory, which the `ant artifacts` tarball
+satisfies. The same script runs at AMI bake time and at runtime, so you can skip
+the rebuild entirely and install the tarball onto a running cluster:
+
+```bash
+easy-db-lab cassandra install my-branch \
+  --url https://github.com/<owner>/<repo>/releases/download/.../apache-cassandra-<version>-<short-sha>-bin.tar.gz \
+  --java 17
+```
 
 ## Image assembly
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -198,6 +198,44 @@ easy-db-lab cassandra use <version> [options]
 
 Versions: 3.0, 3.11, 4.0, 4.1, 5.0, 5.0-HEAD, 6.0-HEAD, trunk
 
+Fails if the version is not installed on a targeted node — install it first with
+`cassandra install`.
+
+### cassandra install
+
+Install an additional Cassandra version onto a running cluster, without rebuilding the AMI.
+
+```bash
+easy-db-lab cassandra install <version> [options]
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--url` | Tarball URL (`.tar.gz`) or git repository URL (with `--branch`) | from the declared entry |
+| `--branch` | Git branch to clone and build, requires `--url` | from the declared entry |
+| `--java`, `-j` | Java version to build and run this version with | from the declared entry |
+| `--python` | Python version cqlsh runs under | `3.11.9` |
+| `--ant-flags` | Extra flags passed to ant when building from a branch | from the declared entry |
+| `--hosts` | Filter to specific hosts | all Cassandra nodes |
+
+Each option falls back to the version's `cassandra_versions.yaml` entry when not supplied, so a
+declared version needs no options at all. Every targeted node is attempted regardless of what
+happens on the others, and each node's outcome is reported individually.
+
+A version already installed on a node is never rebuilt:
+
+- Asking for the parameters it was built with is a no-op.
+- Asking for different `--java`, `--python`, or `--ant-flags` changes nothing on that node, reports
+  which fields disagree, and exits non-zero. To run the existing build under a different JDK, use
+  `cassandra use <version> --java <version>` instead.
+
+A failure on any node also exits non-zero, with the reason reported against that node. A token
+embedded in `--url` is used for the clone but never persisted to the node and never appears in logs,
+errors, or events.
+
+See [Configuring Cassandra](../user-guide/installing-cassandra.md#custom-builds) for the full
+workflow.
+
 ### cassandra write-config
 
 Generate a new configuration patch file.
@@ -294,6 +332,9 @@ easy-db-lab cassandra list
 ```
 
 **Aliases:** `ls`
+
+Versions installed on the node are listed first. A version declared with `lazy: true` that is not
+installed on that node is listed too, marked `(declared, not installed)`.
 
 ---
 

--- a/docs/reference/ports.md
+++ b/docs/reference/ports.md
@@ -26,7 +26,7 @@ This page documents the ports used by easy-db-lab and the services it provisions
 
 | Port | Service |
 |------|---------|
-| 9000 | MAAC metrics agent (Prometheus) — Cassandra 4.0, 4.1, 5.0 only |
+| 9000 | MAAC metrics agent (Prometheus) — Cassandra 4.0, 4.1, 5.0, 6.0, 7.0/trunk |
 
 ## Observability Ports (All Nodes — DaemonSets)
 

--- a/docs/user-guide/installing-cassandra.md
+++ b/docs/user-guide/installing-cassandra.md
@@ -55,17 +55,28 @@ This command:
 2. Downloads current configuration files locally
 3. Applies any existing `cassandra.patch.yaml`
 
+It fails if the version is not installed on a targeted node rather than leaving
+the node pointed at something that isn't there. Install it first — see
+[Custom Builds](#custom-builds).
+
 ### Specify Java Version
 
 ```bash
 easy-db-lab cassandra use 5.0 --java 11
 ```
 
+This selects the JDK the already-installed build runs under. It does not
+reinstall or rebuild anything.
+
 ### List Available Versions
 
 ```bash
 easy-db-lab ls
 ```
+
+Versions installed on the node are listed first. A version declared with
+`lazy: true` that has not been installed is listed too, marked
+`(declared, not installed)`.
 
 ## Configuration
 
@@ -182,8 +193,98 @@ Configuration is located at `/etc/cassandra-sidecar/cassandra-sidecar.yaml` on e
 ## Custom Builds
 
 To run a custom Cassandra build (your own fork, a feature branch, or a prebuilt
-tarball), add a version entry and rebuild the AMI. easy-db-lab bakes every listed
-version into the image — there is no separate build-from-path command.
+tarball), you can either install it onto a cluster that is already running, or
+bake it into the AMI so every future cluster has it.
+
+### Install onto a running cluster
+
+```bash
+easy-db-lab cassandra install <version>
+easy-db-lab cassandra use <version>
+```
+
+This downloads (or clones and builds) the version on every Cassandra node and
+records it in each node's version list, so `cassandra use` works afterward. It
+never rebuilds the AMI, so nothing is preserved across a `down`/`up` cycle —
+install it again on the new cluster.
+
+Where the install parameters come from:
+
+- **A declared entry** (the default): whatever you declared in your profile's
+  extras directory, described below. Nothing else to pass.
+- **CLI options**, for a genuinely one-off test with no file to edit:
+
+  ```bash
+  easy-db-lab cassandra install my-build \
+    --url https://example.com/apache-cassandra-my-build-bin.tar.gz \
+    --java 11
+  ```
+
+  Or from a branch, built with ant on each node:
+
+  ```bash
+  easy-db-lab cassandra install my-build \
+    --url https://github.com/myuser/cassandra.git \
+    --branch my-feature-branch \
+    --java 11 \
+    --ant-flags "-Duse.jdk11=true"
+  ```
+
+  An option you pass overrides the declared entry's value for that field;
+  anything you leave out falls back to the declared entry. `--python` defaults
+  to `3.11.9`.
+
+Useful details:
+
+- `--hosts db0,db1` installs on a subset of nodes only.
+- Re-installing a version a node already has is a no-op, as long as you ask for
+  the same parameters it was built with. See
+  [Re-installing with different options](#re-installing-with-different-options).
+- If a node fails, the command exits non-zero and names the node and the reason;
+  nodes that succeeded keep their install.
+- A branch build runs a full `ant` build on every targeted node, which is
+  CPU-heavy and takes several minutes. It is safe while Cassandra is running —
+  the install only writes to `/usr/local/cassandra/<version>` — but it is not
+  free. Tarball installs are much cheaper.
+
+#### Re-installing with different options
+
+A version that is already on a node is never rebuilt. If you re-run `install`
+for it with options that contradict what the node recorded when it was built —
+a different `--java`, `--python`, or `--ant-flags` — the command changes nothing,
+names the node and the fields that disagree, and exits non-zero:
+
+```
+db0: my-build is already installed, built with the parameters this node declares —
+java: declared 11, requested 17. Nothing was changed. To change the java version
+in use, run: cassandra use my-build --java <version>
+```
+
+This is deliberate: the bits on disk were compiled against Java 11, so silently
+recording them as a Java 17 build would leave every later `cassandra use`
+picking the wrong JDK.
+
+What to do instead depends on what you actually want:
+
+- **Run the existing build under a different JDK** — no reinstall needed:
+
+  ```bash
+  easy-db-lab cassandra use my-build --java 17
+  ```
+
+- **Genuinely rebuild with the new options** — install it under a different
+  version name (`my-build-jdk17`), or remove `/usr/local/cassandra/<version>` on
+  the affected nodes and install again.
+
+```admonish tip title="Credentials in --url"
+A `--url` pointing at a private fork may carry a token
+(`https://<token>@github.com/...`). The token is used for the clone and is never
+written to the node's version list, never stored in the cluster workspace, and is
+stripped from log lines, error messages, and emitted events. It does still live
+in your shell history like any other command argument.
+```
+
+### Bake into the AMI
 
 You don't edit the repository's `cassandra_versions.yaml`. Instead, drop one or
 more YAML files into your profile's extras directory:
@@ -233,6 +334,25 @@ easy-db-lab build-cassandra
 ```bash
 easy-db-lab cassandra use my-build
 ```
+
+### Declaring a version without baking it
+
+Add `lazy: true` to an entry to declare a version without spending AMI build
+time on it:
+
+```yaml
+- version: "my-build"
+  java: "11"
+  python: "3.11.9"
+  url: "https://github.com/myuser/cassandra.git"
+  branch: "my-feature-branch"
+  lazy: true
+```
+
+The AMI build skips the download/clone/build for that entry, but the entry
+still ships in the image. `easy-db-lab cassandra list` shows it as
+`(declared, not installed)`, and `easy-db-lab cassandra install my-build`
+installs it on a running cluster without you re-specifying any of its fields.
 
 ## Next Steps
 

--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -93,7 +93,12 @@ A single-pane-of-glass summary of the most important Cassandra metrics, powered 
 - **Cluster Overview:** Nodes up/down, compaction rates, CQL request throughput, dropped messages, connected clients, timeouts, hints, data size, GC time
 - **Condensed Metrics:** Request throughput, coordinator latency percentiles, memtable space, compaction activity, table-level latency, streaming bandwidth
 
-Requires the MAAC agent to be loaded (Cassandra 4.0, 4.1, or 5.0). Metrics are exposed on port 9000 and scraped by the OTel collector.
+Requires the MAAC agent to be loaded (Cassandra 4.0, 4.1, 5.0, 6.0, or 7.0/trunk). Metrics are exposed on port 9000 and scraped by the OTel collector.
+
+The agent is chosen at Cassandra startup from the release's own jar name, so a version installed
+with `cassandra install --url` or `--branch` gets the right agent too. If a release has no agent,
+or the agent cannot start, Cassandra says so on stderr at startup — check `journalctl -u cassandra`
+on the node when a dashboard is empty.
 
 ### Cassandra Overview
 

--- a/openspec/changes/issue-876/.openspec.yaml
+++ b/openspec/changes/issue-876/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/issue-876/design.md
+++ b/openspec/changes/issue-876/design.md
@@ -1,0 +1,221 @@
+## Context
+
+Today, testing an experimental Cassandra build means either adding an entry to
+`cassandra_versions.yaml` and baking a whole new AMI (tens of minutes, touches every future
+cluster), or manually SSHing in and improvising. `install_cassandra_version()`
+(`packer/cassandra/install/install_cassandra.sh:138-301`) already contains all the logic to install
+one version — it's just trapped inside a bake-time-only loop.
+
+Two things discovered while reading the actual code (not just the groomed issue text) materially
+changed the shape of this design:
+
+1. **The issue's own "two drifted `cassandra_versions.yaml` files" concern is stale.** Only one
+   file exists today: `packer/cassandra/cassandra_versions.yaml`. The repo-root copy the issue
+   references no longer exists. Nothing to reconcile.
+2. **A typed load/merge/write mechanism for this exact file already exists and is already used at
+   AMI-bake time**, just not exposed to a live cluster. `Packer.kt:225-231` calls
+   `CassandraVersion.loadFromMainAndExtras(mainFile, context.cassandraVersionsExtra)` for
+   non-release builds — merging the committed `cassandra_versions.yaml` with any `*.yaml` files an
+   operator drops into their profile's `cassandra_versions/` extras directory, deduping by
+   `version` and erroring on a genuine collision (`DuplicateVersionException`). `CassandraVersion`
+   (Jackson + YAML, already carries `url`/`branch`/`antFlags`/`java`/`python`) has a tested
+   `write()`. Reusing this exact mechanism for `cassandra install`'s version resolution means "what
+   can be baked into an AMI" and "what's installable live" are always the same candidate set — no
+   new config surface to maintain in parallel.
+
+A parallel Cassandra-domain consult surfaced several mechanics that shape the extraction:
+
+- `use-cassandra` (`packer/cassandra/bin/use-cassandra:20-28`) hard-exits if `java`/`python` are
+  empty for the target version — and the node's `/etc/cassandra_versions.yaml` is frozen at bake
+  time. A version installed at runtime that doesn't push its `java`/`python` fields into that file
+  breaks a later `cassandra use` confusingly, not loudly.
+- The git-branch install path (`url:`+`branch:`) is dead code today — zero entries in the current
+  `cassandra_versions.yaml` use it. **This change does not remove it** — the owner was explicit
+  that both install modes must keep working; nothing about extracting the function into a
+  standalone script should artificially restrict which mode `cassandra install` can drive. In
+  practice, day-to-day usage of the new command is expected to be tarball-only (installing
+  pre-built artifacts, e.g. from `build-cassandra-ref.yml`, #729), but that's a usage pattern, not
+  a code-level restriction — this design does not special-case one mode to block the other. It
+  does mean the git-branch path gets its first real production exercise through whichever caller
+  (bake time or `cassandra install`) first uses it against a real entry; budget time to debug it.
+- JDK selection for the build path must come from the target version's own `java:` field per
+  invocation, not the node's current default JDK alternative, and must not call
+  `update-java-alternatives` as a side effect (that would disturb whatever version is currently
+  active on the node).
+- The bake-time script does several things beyond fetch+build that any install must reproduce or
+  the node ends up silently degraded: appending `/tmp/cassandra.in.sh` into the version's
+  `bin/cassandra.in.sh` (Pyroscope/MAAC/GC-logging/log-dir config), `cp -R conf conf.orig`,
+  `chown -R cassandra:cassandra`, and cqlsh removal for 2.x/3.x. It must *not* reproduce `rm -rf
+  ~/.m2` — that's already a global, once-per-bake cleanup that runs *after* the version loop in
+  `install_cassandra.sh` today, not inside `install_cassandra_version()` itself; the extracted
+  script preserves that separation, so a runtime install never touches `~/.m2` and bake time keeps
+  cleaning it up exactly once, same as today.
+
+Separately, reading `HostOperationsService.withHosts` for the per-host reporting this issue's
+acceptance criteria require surfaced a latent gap unrelated to Cassandra specifically: its
+`parallel = true` path fires each host's action on its own thread and just `.join()`s them — an
+uncaught exception inside that thread dies silently; `.join()` never rethrows, so the command
+reports success regardless of what happened on any individual host. Every existing `parallel =
+true` caller (`UseCassandra`, `SetupInstance`, `ExecStop`, `ExecList`, `ExecRun`) has this gap
+today, but none of them currently need per-host failure reporting the way `cassandra install`'s
+ACs explicitly do. Fixed at the shared helper rather than worked around locally in
+`CassandraInstall`, per owner decision (fold into this change rather than a separate issue).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Install one additional Cassandra version onto an already-running cluster without an AMI rebuild.
+- Extract the existing install logic — both modes, unchanged in capability — into one place used
+  identically by the bake-time loop and the new runtime command, rather than duplicating it.
+- Make `/etc/cassandra_versions.yaml` push-up type-safe, reusing the existing `CassandraVersion`
+  load/write machinery rather than building YAML mutations from raw Kotlin strings.
+- Make `cassandra use` against an uninstalled version fail clearly instead of silently leaving a
+  dangling symlink.
+- Make per-host failure reporting for parallel host operations actually work, for `cassandra
+  install` and every other `parallel = true` caller.
+
+**Non-Goals** (decided at grooming, do not relitigate in this change):
+
+- No CI orchestration — `cassandra install` never triggers or polls `build-cassandra-ref.yml`.
+- No persistence of a runtime-installed version across cluster teardown/recreate.
+- No wiring into AMI rebuild or containerized cluster mode.
+- No `--force`/reinstall-in-place support — re-running install for an existing version is a no-op.
+  (A parallel domain consult noted this collides somewhat with iterative branch testing — pushing a
+  new commit to the same branch has no way to be picked up short of a new version name. Flagged for
+  awareness; the exclusion itself stands as already decided.)
+
+## Decisions
+
+### D1: Version-source resolution — declared entry, with CLI-flag override
+
+Two ways to name a version's install parameters:
+
+1. **Declared** (default): `cassandra install <version>` resolves `java`/`python`/`url`/`branch`/
+   `ant_flags` via `CassandraVersion.loadFromMainAndExtras`, the same call `Packer.kt` already
+   makes for non-release AMI builds. An operator declares the version once (optionally
+   `lazy: true`, in the committed `cassandra_versions.yaml` or a personal
+   `<profileDir>/cassandra_versions/*.yaml` extras file) and it becomes discoverable via
+   `cassandra list` before it's ever installed anywhere.
+2. **CLI-flag override**: `--url`, `--branch`, `--java`, `--python`, `--ant-flags` let an operator
+   install without touching any yaml file — true zero-file-edit, useful for a genuinely one-off
+   test. **Owner decision:** support both, CLI flags take precedence when supplied. A CLI-flag
+   install does not appear in `cassandra list`'s lazy-declared set (nothing was declared), but shows
+   up post-install like any other installed version.
+
+`--python` was missing from the issue's own stated schema-fields list, but `use-cassandra`
+hard-requires it (see Context) and every existing declared entry sets it. Default: `3.11.9`
+(matching every current entry) when not supplied via CLI flag or a declared entry.
+
+### D2: Push-up mechanism — typed download/merge/write, not `yq -i`
+
+Alternative considered: a scoped `yq -i` mutation on the Kotlin side, mirroring
+`set-java-version:27-31`'s existing precedent for in-place remote yaml edits.
+
+**Chosen:** download the node's current `/etc/cassandra_versions.yaml`, parse via the existing
+`CassandraVersion.loadFromFile`, and — when `<version>` is not already listed — append the resolved
+entry and `CassandraVersion.write()` the whole list back, uploading it to overwrite the file. This
+reuses existing, tested code and avoids constructing a `yq` expression from arbitrary (potentially
+special-character-bearing) git URLs, branch names, and ant flags — which is exactly the raw-string
+YAML construction this repo's conventions rule out in favor of typed data classes.
+
+**Corrected during implementation review:** this design originally made "already present in the
+node's `cassandra_versions.yaml`" the idempotency check. That is the wrong signal.
+`cassandra.pkr.hcl` copies the *whole* committed `cassandra_versions.yaml` into every AMI's
+`/etc/cassandra_versions.yaml`, `lazy: true` entries included — so a lazy version is always already
+listed on a node that has never installed it, and the check made `cassandra install` a silent no-op
+for exactly the versions this change exists to install. The idempotency check is instead whether
+the version is on disk (`test -d /usr/local/cassandra/<version>`, matching the guard
+`install-cassandra-version` already applies to itself); the push-up is purely input to the install.
+
+**Refined during implementation review (three further corrections):**
+
+1. **The declaration is never rolled back on a failed install.** An earlier revision of this design
+   rolled the list back so the attempt could be retried. That is backwards. *Declared but not
+   installed* is the harmless state — it is precisely what a `lazy: true` entry looks like, and the
+   next attempt overwrites it anyway. *Installed but not declared* is the unrepairable one: every
+   retry short-circuits on the on-disk check before it can re-declare, leaving `cassandra use`
+   permanently unable to find the version's java/python.
+2. **A mismatched declaration is reported, not overwritten.** When the version is already on disk
+   *and* the node's own declaration disagrees with the flags just resolved (`java`, `python`,
+   `ant_flags`), nothing is changed and the host is reported via
+   `Event.Cassandra.VersionDeclarationMismatch`, which exits the command non-zero. Rewriting the
+   declaration would make it describe a build that was never performed — the bits on disk were
+   compiled against the JDK the node declares — and a later `cassandra use` would then select the
+   wrong JDK. Changing the JDK an existing build *runs* under is `cassandra use --java`'s job, not
+   install's. Where the version is on disk but undeclared entirely, there is no declaration to
+   contradict and the missing entry is simply repaired.
+3. **`url`/`branch` are stripped before the entry is written to the node.** `use-cassandra` reads
+   only `java`/`python`, so those fields have no remote consumer — and a git URL routinely carries a
+   token, which persisting would park in `/etc/cassandra_versions.yaml` indefinitely.
+
+### D3: Script extraction — standalone flag-driven script, both modes preserved
+
+`install_cassandra.sh`'s current structure has a hard boundary (its own header comment) between
+pure function definitions and the effectful bake-time driver below it — the target function already
+sits on the wrong side of that line for safe standalone sourcing. Extract
+`install_cassandra_version` (plus its `download_cassandra_version` dependency and the
+S3-cache-with-fallback sourcing) **unchanged in capability** into
+`packer/cassandra/bin/install-cassandra-version`: baked onto the AMI like `use-cassandra`, taking
+`<version>` plus `--url`/`--branch`/`--java`/`--ant-flags` as needed, safe to invoke directly over
+SSH (from `cassandra install`) or from the bake-time loop. Bake-only global setup (user/directory
+creation, installing cqlsh via `uv`, the initial pinned-JDK default) stays in `install_cassandra.sh`
+and is not re-run at install time — re-running `useradd`, for one, would simply error.
+
+`install_cassandra.sh`'s bake-time loop is rewritten to call this script per version (resolving
+each version's fields from `/etc/cassandra_versions.yaml` via `yq`, same as it does today, just to
+build the script's flags instead of driving inline logic), in the same
+parallel-background-job shape it uses now — one code path, not two kept in sync by hand.
+
+The extracted script diverges from the original inline function in exactly two ways, both required
+by the domain findings above: it selects `JAVA_HOME` from the target version's own `java` field for
+its own `ant` invocation (never the node's current default alternative, and never calls
+`update-java-alternatives`), and — matching the current code's existing structure, not a new
+behavior — it does not `rm -rf ~/.m2` itself; that cleanup stays a once-per-bake step in
+`install_cassandra.sh`, run after the whole version loop completes, exactly as today.
+
+`java`/`python` are relevant only to the git-build mode's JDK selection inside the script; they're
+also separately pushed into the node's `/etc/cassandra_versions.yaml` by `CassandraInstall` (D2) so
+`cassandra use` works afterward regardless of which install mode was used.
+
+### D4: `HostOperationsService.withHosts` per-host result collection
+
+`parallel = true` currently fires bare threads with no result channel. Fix: the action lambda's
+per-host outcome (success, or the caught exception) is collected into a thread-safe structure and
+returned to the caller, so a caller can decide how to report/fail. `CassandraInstall` is the first
+caller to actually need this; existing callers (`UseCassandra`, etc.) keep their current
+throw-on-failure behavior.
+
+**As implemented:** a separate `collectFromHosts` returns one `HostResult` (host + `Result`) per
+targeted host and throws nothing; `withHosts` is reimplemented on top of it and keeps its
+abort-the-command contract. Two refinements came out of implementation review:
+
+- `withHosts` previously lost every failure — the bare threads swallowed them — so it now rethrows
+  the first with the remaining ones attached as suppressed exceptions. An operator fixing a
+  multi-node problem sees all of it in one run rather than one host per run.
+- Results are keyed by **position**, not alias. Two hosts sharing an alias would otherwise overwrite
+  each other's outcome and misattribute a failure.
+
+## Risks / Trade-offs
+
+- **Behavior-identity risk to the packer bake path.** D3 rewrites the bake-time loop to call an
+  external script instead of an inline function — the risk is a subtle behavioral difference
+  between "inline function call" and "external script invocation" (working directory, environment
+  variables, `set -x`/`set -euo pipefail` scoping). Mitigated by the loop still doing its own
+  per-version logging/backgrounding exactly as today, just calling out to the script instead of an
+  inline function body; needs explicit bake-path verification (packer Docker test), not just
+  runtime-path testing.
+- **The git-branch install mode is genuinely untested in production today, and this change keeps
+  it fully available** (an explicit owner decision — not something to relitigate). Expect real
+  debugging if/when it's actually exercised, whether that happens via the bake-time loop or via
+  `cassandra install`.
+- **Concurrent installs across nodes** each run a full `ant realclean && ant` build when the
+  git-branch mode is used (~3–10 minutes, CPU-saturating). Acceptable per domain consult —
+  installing while Cassandra is running is safe (install only ever writes to
+  `/usr/local/cassandra/<version>`, untouched by the running process) but not free; the command
+  should warn, not refuse. Tarball-mode installs are far cheaper and carry no such concern.
+- **`HostOperationsService` change touches every existing `parallel = true` caller's failure
+  semantics**, even though only `CassandraInstall` needs it today. Reviewed and accepted as the
+  right scope by the owner (folded into this change rather than a separate issue) specifically
+  because those callers were already silently swallowing failures — this fixes a real bug for them,
+  it doesn't introduce new risk.

--- a/openspec/changes/issue-876/proposal.md
+++ b/openspec/changes/issue-876/proposal.md
@@ -1,0 +1,112 @@
+## Why
+
+Testing an experimental Cassandra build (a git branch, or a tarball from the existing
+`build-cassandra-ref.yml` Action, #729) currently requires adding it to `cassandra_versions.yaml`
+and baking an entirely new AMI. `install_cassandra_version()`
+(`packer/cassandra/install/install_cassandra.sh:138-301`) already knows how to install a single
+version — download tarball, or git-clone+ant-build — but it is only ever invoked from a loop over
+every entry in `/etc/cassandra_versions.yaml`, gated by `INSTALL_CASSANDRA=1` and run exactly once,
+at packer bake time. There is no way to install one additional version onto a node that is already
+running.
+
+`cassandra use <version>` (`UseCassandra.kt`) only switches which pre-baked version is active on a
+node — it never installs anything, and today it does so unconditionally (`use-cassandra:6`'s
+`ln -vfns` has no existence check), leaving a dangling symlink and a confusing later failure when
+pointed at a version that was never installed. (GitHub issue #876.)
+
+## What Changes
+
+- **One script, used identically at bake time and at runtime — both existing install modes
+  preserved unchanged.** Extract `install_cassandra_version()`'s full logic (official-release
+  download-by-prefix, arbitrary tarball `url:`, and git `url:`+`branch:` clone-and-`ant`-build — all
+  three, nothing removed) into a new standalone, flag-driven script,
+  `packer/cassandra/bin/install-cassandra-version`, baked onto the AMI the same way
+  `use-cassandra`/`set-java-version` already are. It takes `<version>` plus `--url`, `--branch`,
+  `--java`, `--ant-flags` as needed for whichever mode applies, downloads/builds to
+  `/usr/local/cassandra/<version>`, and applies the same post-install configuration every version
+  needs (conf backup, `cassandra.in.sh` append, chown, cqlsh removal for 2.x/3.x, JDK selection from
+  the `--java` flag rather than the node's current default for the build path).
+  **`install_cassandra.sh`'s bake-time loop is rewritten to call this same script, with the same
+  flags, instead of running its own inline copy of the logic** — one code path, not two kept in sync
+  by hand. This is a refactor of *how* the existing logic is invoked, not a reduction of what it
+  can do.
+- **New `cassandra install <version>` subcommand** (`CassandraInstall.kt`, following
+  `UseCassandra.kt`'s shape): installs one version onto an already-provisioned, running cluster —
+  all Cassandra nodes, or a `--hosts`-filtered subset — by invoking the same
+  `install-cassandra-version` script remotely, with the same flags the bake-time loop uses. It
+  works generically with whatever mode a resolved version's entry declares (tarball or git branch)
+  — no special-casing to allow one mode and block the other. In practice, expected day-to-day usage
+  is tarball-only (installing pre-built artifacts, e.g. from `build-cassandra-ref.yml`, #729), but
+  that is a usage pattern, not a code-level restriction.
+- **Version resolution, two ways:**
+  - By default, resolves the version's `java`/`python`/`url`/`branch`/`ant_flags` from a declared
+    `cassandra_versions.yaml` entry — the same merged candidate set
+    (`CassandraVersion.loadFromMainAndExtras`, main file + profile `cassandra_versions/` extras
+    directory) `packer/cassandra/cassandra.pkr.hcl`'s non-release build already resolves for AMI
+    bakes. Declaring a version here (optionally `lazy: true`) is what makes it discoverable via
+    `cassandra list` before it's ever installed.
+  - `--url`, `--branch`, `--java`, `--python`, `--ant-flags` CLI options let an operator install a
+    version with **no yaml edit at all** — a true zero-file-edit path for a one-off test. A
+    CLI-flag install is not yaml-declared, so it will not appear in `cassandra list` as a
+    lazy-declared version; it exists once actually installed and reported per host.
+  - `--java`/`--python` are validated non-blank before any host is touched; `--python` defaults to
+    `3.11.9` (matching every existing declared entry) when not supplied, since `use-cassandra`
+    hard-exits without it and it is missing from the issue's own stated schema-fields list — this
+    default closes that gap.
+- **Push the resolved entry into `/etc/cassandra_versions.yaml` on each targeted node** before
+  installing — download the node's current file, parse via the existing typed `CassandraVersion`
+  loader, skip (idempotent no-op, "already present") if the version is already there, otherwise
+  append and re-upload the whole file via the existing typed `CassandraVersion.write()`. This is
+  the first push-up path for a file that today is baked in once and only ever read down
+  (`Up.kt:631-647`).
+- **`lazy: true` field on a `cassandra_versions.yaml` entry**: ships to every node's
+  `/etc/cassandra_versions.yaml` at bake time exactly as today (the whole file is copied
+  unconditionally — no change needed there), but the bake-time install loop skips actually running
+  `install_cassandra_version` for it, costing nothing at AMI-build time.
+- **`cassandra list` extended** to show lazy-declared-but-not-yet-installed versions (resolved via
+  the same `loadFromMainAndExtras` candidate set), distinguishable from versions actually installed
+  on the queried node.
+- **`cassandra use <version>` fails loudly** when the version is not installed on the targeted
+  node, instead of silently succeeding with a dangling symlink — fixes the missing existence check
+  in `use-cassandra`.
+- **Fix `HostOperationsService.withHosts(parallel = true)`** to stop silently swallowing exceptions
+  raised inside a per-host action thread. Today an uncaught exception in a parallel host action
+  just kills that thread; `.join()` doesn't rethrow, so the command reports success regardless.
+  `cassandra install` needs real per-host failure reporting (an AC of this issue), and this gap
+  affects every existing `parallel = true` caller (`UseCassandra`, `SetupInstance`, `ExecStop`,
+  `ExecList`, `ExecRun`) — fixed once, at the shared helper, rather than worked around locally.
+- Update `openspec/specs/cassandra/spec.md` (`REQ-CA-001`, and a new "Runtime Version Installation"
+  requirement) and relevant `docs/`.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `cassandra`: `REQ-CA-001` no longer requires multi-version support to live exclusively "on the
+  same AMI" — a version can also be installed onto a running node at runtime. Adds a new "Runtime
+  Version Installation" requirement, and a new scenario under `REQ-CA-001` covering `cassandra use`
+  against an uninstalled version.
+
+### New Capabilities
+
+<!-- None. This extends the existing `cassandra` capability; no new top-level capability. -->
+
+## Impact
+
+- **New files:** `packer/cassandra/bin/install-cassandra-version`,
+  `src/main/kotlin/.../commands/cassandra/CassandraInstall.kt`.
+- **Modified files:** `packer/cassandra/install/install_cassandra.sh` (bake-time loop rewritten to
+  call the new script — same logic, same both install modes — instead of its own inline copy;
+  `lazy: true` skip),
+  `packer/cassandra/bin/use-cassandra` (existence check before the symlink swap),
+  `packer/cassandra/cassandra_versions.yaml` (`lazy` field support),
+  `configuration/CassandraVersion.kt` (`lazy: Boolean = false` field), `ListVersions.kt`,
+  `HostOperationsService.kt` (parallel exception propagation), `Cassandra.kt` (subcommand
+  registration).
+- **Out of scope (decided at grooming, do not relitigate):** no CI orchestration (no
+  triggering/polling `build-cassandra-ref.yml`); no persistence of a runtime-installed version
+  across cluster teardown/recreate; no wiring into AMI rebuild or containerized cluster mode; no
+  changes to `build-cassandra-ref.yml` itself (#765, unrelated); no `--force`/reinstall support.
+- **Related, already shipped:** #729 (`build-cassandra-ref.yml` — this issue's `--url`/tarball mode
+  consumes its output). #763/#775/#821/#824 (hand-wired specific nightly versions into
+  `cassandra_versions.yaml`) — this issue generalizes that into a reusable command.

--- a/openspec/changes/issue-876/specs/cassandra/spec.md
+++ b/openspec/changes/issue-876/specs/cassandra/spec.md
@@ -1,0 +1,179 @@
+## MODIFIED Requirements
+
+### REQ-CA-001: Multi-Version Support
+
+The system MUST support multiple Cassandra versions (3.0 through trunk). A version MAY be
+pre-baked onto the AMI, or installed onto an already-provisioned, running cluster at runtime
+without rebuilding the AMI (see the new "Runtime Version Installation" requirement below).
+
+#### Scenario: Select a Cassandra version
+
+- **GIVEN** a running cluster
+- **WHEN** the user selects a Cassandra version
+- **THEN** that version is activated with appropriate Java and Python runtime versions.
+
+#### Scenario: Start cluster on selected version
+
+- **GIVEN** a selected version
+- **WHEN** the user starts the cluster
+- **THEN** all nodes run the selected Cassandra version and join the ring.
+
+#### Scenario: Select an uninstalled version fails clearly
+
+- **GIVEN** a running cluster where a version is declared (e.g. via `cassandra list`) but not
+  installed on the targeted node(s)
+- **WHEN** the user attempts to select that version
+- **THEN** the command fails with a clear message directing the user to run
+  `cassandra install <version>` first
+- **AND** no symlink or other node state is changed by the failed attempt.
+
+## ADDED Requirements
+
+### Requirement: Runtime Version Installation
+
+The system MUST support installing an additional Cassandra version onto an already-provisioned,
+running cluster without rebuilding the AMI, via `cassandra install <version>`.
+
+The system MUST support both existing install mechanisms for a version: downloading a tarball from
+a `url:` (including an official release resolved from a version prefix when no `url:` is set), and
+cloning a git `url:`+`branch:` and building it with `ant`. The same mechanism MUST be used whether
+the version is installed at AMI bake time or via `cassandra install` at runtime — one
+implementation, not two kept in sync by hand.
+
+The system MUST resolve a version's install parameters (`java`, `python`, `url`/`branch`,
+`ant_flags`) from a declared `cassandra_versions.yaml` entry (including profile-local extras) by
+default, and MUST allow those parameters to be supplied directly via CLI options instead, without
+requiring any yaml declaration.
+
+The system MUST support targeting all Cassandra nodes or a `--hosts`-filtered subset, matching the
+targeting mechanism `cassandra use` already provides.
+
+The system MUST write the resolved version's install parameters into the targeted node's
+`/etc/cassandra_versions.yaml` before installing, so that `cassandra use` for that version
+succeeds afterward without further changes.
+
+The system MUST treat installing an already-installed version as a safe no-op — no re-download,
+no re-build, no error.
+
+The system MUST report success or failure per targeted host, and MUST fail the overall command
+when any targeted host fails to install, without leaving other hosts partially configured beyond
+what each host's own install actually completed.
+
+A `cassandra_versions.yaml` entry MAY declare `lazy: true`. Such an entry MUST be skipped by the
+AMI bake-time install process (no download/clone/build time spent at bake), while still being
+written into the resulting AMI's `/etc/cassandra_versions.yaml` so `cassandra install` can resolve
+it later without the operator re-specifying its fields.
+
+#### Scenario: Install from a declared git branch entry
+
+- **GIVEN** a `cassandra_versions.yaml` entry for a version not yet present on the targeted node(s),
+  with a git `url:` and `branch:`
+- **WHEN** the user runs `cassandra install <version>`
+- **THEN** the branch is cloned and built with `ant` on each targeted node
+- **AND** the built artifact lands at `/usr/local/cassandra/<version>`
+- **AND** the command reports success per targeted host.
+
+#### Scenario: Install from a declared tarball entry
+
+- **GIVEN** a `cassandra_versions.yaml` entry for a version not yet present, with a tarball `url:`
+- **WHEN** the user runs `cassandra install <version>`
+- **THEN** the tarball is downloaded and extracted to `/usr/local/cassandra/<version>` on each
+  targeted node.
+
+#### Scenario: Install an official release with no `url:` declared
+
+- **GIVEN** a `cassandra_versions.yaml` entry for a version prefix (e.g. `5.0`) with no `url:` set
+- **WHEN** the user runs `cassandra install <version>`
+- **THEN** the latest matching official release tarball is resolved, downloaded, and extracted to
+  `/usr/local/cassandra/<version>` on each targeted node.
+
+#### Scenario: Install via CLI flags with no yaml declaration
+
+- **GIVEN** a version with no entry anywhere in `cassandra_versions.yaml` or the profile's extras
+  directory
+- **WHEN** the user runs `cassandra install <version> --url <tarball-or-git-url> [--branch <b>]
+  --java <j>`
+- **THEN** the version installs using the supplied parameters exactly as if they had come from a
+  declared entry
+- **AND** `--python` defaults to `3.11.9` when not supplied.
+
+#### Scenario: Targeting a host subset
+
+- **GIVEN** a cluster with multiple Cassandra nodes
+- **WHEN** the user runs `cassandra install <version> --hosts <subset>`
+- **THEN** only the targeted nodes have `/etc/cassandra_versions.yaml` updated and the version
+  installed
+- **AND** untargeted nodes are unaffected.
+
+#### Scenario: Installed version becomes usable
+
+- **GIVEN** a version successfully installed via `cassandra install`
+- **WHEN** the user runs `cassandra use <version>` on the same node afterward
+- **THEN** it succeeds unchanged, using the `java`/`python` fields written by install.
+
+#### Scenario: Re-running install for an already-installed version is a no-op
+
+- **GIVEN** a version already installed on a node, declared there with the same parameters being
+  requested
+- **WHEN** the user runs `cassandra install <version>` again against that node
+- **THEN** the command does not error, does not re-download or re-build, and reports the version as
+  already present.
+
+#### Scenario: Re-running install with parameters the installed build contradicts
+
+- **GIVEN** a version already installed on a node, declared there with `java: 11`
+- **WHEN** the user runs `cassandra install <version> --java 17` against that node
+- **THEN** nothing on that node is changed — neither the on-disk install nor its declaration
+- **AND** the host is reported with the fields that disagree (`java: declared 11, requested 17`)
+- **AND** the command exits non-zero.
+
+Rationale: the bits on disk were built against the declared JDK, so recording them as a Java 17
+build would make every later `cassandra use` select the wrong JDK. Changing the JDK an existing
+build runs under is `cassandra use --java`'s job.
+
+#### Scenario: Repairing an installed-but-undeclared version
+
+- **GIVEN** a version present on disk at `/usr/local/cassandra/<version>` but absent from that
+  node's `/etc/cassandra_versions.yaml`
+- **WHEN** the user runs `cassandra install <version>` against that node
+- **THEN** the resolved entry is added to the node's version list so `cassandra use` can find its
+  `java`/`python`
+- **AND** the on-disk install is not re-downloaded or re-built
+- **AND** the command reports the version as already present and does not error.
+
+#### Scenario: A credential in `--url` is not persisted or echoed
+
+- **GIVEN** a `--url` whose userinfo carries a token (e.g. `https://<token>@github.com/owner/repo.git`)
+- **WHEN** `cassandra install <version> --url <that-url> --branch <branch>` runs
+- **THEN** the entry written to the node's `/etc/cassandra_versions.yaml` contains no `url`/`branch`
+  field at all
+- **AND** the token does not appear in any log line, error message, or emitted event, whether the
+  install succeeds or fails.
+
+#### Scenario: Install failure is reported per host, loudly
+
+- **GIVEN** a version whose install fails on one targeted node (bad branch, unreachable/404 tarball
+  URL, or ant build failure) while succeeding on another
+- **WHEN** `cassandra install <version>` completes
+- **THEN** the command exits non-zero
+- **AND** the failure is reported against the specific host it occurred on, naming the version and
+  the failure reason
+- **AND** the successful host's install is left in place — no rollback of a host that already
+  succeeded.
+
+#### Scenario: Lazy entries are skipped at bake time but installable afterward
+
+- **GIVEN** a `cassandra_versions.yaml` entry with `lazy: true`
+- **WHEN** a new AMI is baked
+- **THEN** the bake-time install process does not download, clone, or build that version
+- **AND** the entry still appears in the resulting AMI's `/etc/cassandra_versions.yaml`
+- **AND** `cassandra install <that-version>` succeeds against a cluster running that AMI without
+  the operator re-specifying `url`/`branch`/`java`/`ant_flags`.
+
+#### Scenario: `cassandra list` distinguishes declared-but-uninstalled versions
+
+- **GIVEN** a `cassandra_versions.yaml` entry with `lazy: true` that has not been installed on the
+  queried node
+- **WHEN** the user runs `cassandra list`
+- **THEN** that version is shown, marked distinguishably from versions actually installed on the
+  node.

--- a/openspec/changes/issue-876/tasks.md
+++ b/openspec/changes/issue-876/tasks.md
@@ -1,0 +1,110 @@
+## 1. `HostOperationsService` per-host result collection
+
+- [x] 1.1 Add per-host result collection to `HostOperationsService.withHosts(parallel = true)` —
+  each host's action outcome (success or the caught exception) collected thread-safely and made
+  available to the caller, instead of the current fire-and-`.join()` with no result channel
+- [x] 1.2 Verify existing `parallel = true` callers (`UseCassandra`, `SetupInstance`, `ExecStop`,
+  `ExecList`, `ExecRun`) keep their current externally-observable behavior — they should now
+  correctly fail loudly on a swallowed exception that previously died silently, not change
+  behavior otherwise
+
+## 2. Extract the standalone install script
+
+- [x] 2.1 Create `packer/cassandra/bin/install-cassandra-version`, containing
+  `install_cassandra_version()` and `download_cassandra_version()` extracted from
+  `install_cassandra.sh:11-301`, plus the S3-cache-with-fallback sourcing block
+- [x] 2.2 Diverge from the bake-time version in exactly two ways: select `JAVA_HOME` from the
+  target version's own `java` field per invocation (never the node's current default alternative,
+  never call `update-java-alternatives`); do not `rm -rf ~/.m2` after a build
+- [x] 2.3 Update `install_cassandra.sh` to source the new script and call the same function from
+  its bake-time loop — no duplicated logic
+- [x] 2.4 Add the `lazy: true` skip to the bake-time install loop (`install_cassandra.sh`'s `for
+  version in $VERSIONS` loop) — entry still gets written to `/etc/cassandra_versions.yaml` via the
+  existing unconditional file-copy step in `cassandra.pkr.hcl`, only the install itself is skipped
+- [x] 2.5 Bake `install-cassandra-version` onto the AMI alongside `use-cassandra`/`set-java-version`
+  (`cassandra.pkr.hcl`)
+
+## 3. Fix `use-cassandra`'s missing existence check
+
+- [x] 3.1 Add an existence check to `packer/cassandra/bin/use-cassandra` before the `ln -vfns`
+  symlink swap — fail with a message directing to `cassandra install <version>` when
+  `/usr/local/cassandra/<version>` doesn't exist
+
+## 4. Data model — `CassandraVersion.lazy`
+
+- [x] 4.1 Add `lazy: Boolean = false` to `CassandraVersion` (`configuration/CassandraVersion.kt`)
+- [x] 4.2 No `lazy: true` entry committed to `packer/cassandra/cassandra_versions.yaml` — unit
+  coverage uses a temp-file fixture, and a committed entry would show up as a phantom
+  declared-but-uninstalled version in every user's `cassandra list`. Documented in
+  `docs/` instead; manual bake verification (8.10) adds one via the profile extras directory
+
+## 5. `cassandra install <version>` command
+
+- [x] 5.1 Create `CassandraInstall.kt` in `commands/cassandra/`: `@Parameters version: String`,
+  `@Mixin HostsMixin`, `--url`, `--branch`, `--java`, `--python` (default `3.11.9`),
+  `--ant-flags` options, `@RequireProfileSetup`
+- [x] 5.2 Version resolution: CLI flags take precedence when supplied; otherwise resolve via
+  `CassandraVersion.loadFromMainAndExtras(context.packerHome + "cassandra/cassandra_versions.yaml",
+  context.cassandraVersionsExtra)`, matching on `version`; error clearly if neither source has an
+  entry
+- [x] 5.3 Per targeted host (via the fixed `HostOperationsService.withHosts(parallel = true)`):
+  skip (already-installed no-op) when `/usr/local/cassandra/<version>` exists on the node —
+  **not** when the version appears in the node's yaml, since every AMI ships the whole
+  cassandra_versions.yaml including `lazy: true` entries. Otherwise download
+  `/etc/cassandra_versions.yaml`, parse via `CassandraVersion.loadFromFile`, and
+  `CassandraVersion.write()` + upload the whole file back whenever the node's entry for this
+  version differs from the resolved one (url/branch stripped — the node never reads them)
+- [x] 5.4 Invoke `install-cassandra-version <version>` remotely via `RemoteOperationsService
+  .executeRemotely` for each targeted host after the yaml push-up, passing whichever of
+  `--url`/`--branch`/`--java`/`--ant-flags` the resolved entry (declared or CLI-flag) carries
+- [x] 5.5 Collect and report per-host outcome (installed / already-present / failed-with-reason);
+  exit non-zero if any host failed
+- [x] 5.6 Register `CassandraInstall` as the `install` subcommand in `Cassandra.kt`
+
+## 6. `cassandra list` — show lazy-declared versions
+
+- [x] 6.1 Extend `ListVersions.kt` to also resolve the merged candidate set via
+  `loadFromMainAndExtras`, and mark any `lazy: true` entry not present in the queried host's
+  `ls /usr/local/cassandra` output as declared-but-not-installed, distinguishable in the output
+
+## 7. Spec and docs
+
+- [x] 7.1 `openspec/changes/issue-876/specs/cassandra/spec.md` already carries the REQ-CA-001
+  rewording and the new "Runtime Version Installation" requirement; verified the implementation
+  against every scenario in it. Applied to `openspec/specs/cassandra/spec.md` at archive time
+- [x] 7.2 Document `cassandra install` usage (declared-entry and CLI-flag paths, `--hosts`
+  targeting, `lazy: true`) in the appropriate `docs/` page
+
+## 8. Verification
+
+- [x] 8.1 Unit tests: `CassandraVersion` `lazy` field round-trips through `loadFromFile`/`write`
+- [x] 8.2 Unit tests: `CassandraInstall`'s version-resolution precedence (CLI flags override
+  declared entry; error when neither source has an entry)
+- [x] 8.3 Unit tests: `HostOperationsService.withHosts(parallel = true)` result collection —
+  a per-host exception is captured and surfaced, not silently dropped
+- [ ] 8.4 Integration/manual: install a declared tarball-mode version onto a live cluster, confirm
+  `cassandra use` succeeds afterward — **script half verified** in a container (official-release
+  and `--url` tarball both install, configure, and chown correctly); the live-cluster leg still
+  needs a real run
+- [ ] 8.5 Integration/manual: install a git-branch-mode version (first real exercise of this path
+  outside packer) — confirm build succeeds and the artifact lands correctly; budget time to debug,
+  per design.md's noted risk. **Not exercised locally** — needs a real `ant` build
+- [ ] 8.6 Integration/manual: `--hosts`-filtered install only touches the targeted node(s) — host
+  filtering itself is unit-tested (`HostOperationsServiceTest`); the live leg still needs a run
+- [x] 8.7 Re-running install for an already-installed version is a no-op — verified twice: the
+  on-disk short-circuit is unit-tested (`CassandraInstallTest`), and the script's own directory
+  guard is covered by `install-cassandra-version.test.sh` and was verified in a container,
+  including that a failure mid-install cleans up rather than leaving a half-configured directory a
+  retry would skip
+- [ ] 8.8 Integration/manual: a deliberately broken install (bad branch / 404 URL) fails loudly
+  with a per-host message, and a healthy host's prior success is untouched — unit-tested at the
+  command level; the live leg still needs a run
+- [x] 8.9 `cassandra use` against an uninstalled version fails clearly instead of leaving a
+  dangling symlink — verified in a container against the real `use-cassandra` script
+- [ ] 8.10 Integration/manual: a `lazy: true` version is skipped at bake time (verify bake logs show
+  no install work for it) but installs successfully at runtime afterward — the bake loop's `yq`
+  resolution and lazy skip were verified locally against a sample yaml; the bake itself still needs
+  a run
+- [ ] 8.11 Integration/manual: `cassandra list` shows a lazy-declared-but-uninstalled version,
+  distinguishable from installed ones — rendering is unit-tested (`ListVersionsTest`); the live leg
+  still needs a run

--- a/packer/README.md
+++ b/packer/README.md
@@ -20,6 +20,40 @@ This directory contains packer configurations and testing tools for building eas
 ./gradlew testPackerScript -Pscript=cassandra/install/install_cassandra_easy_stress.sh
 ```
 
+## Shell Unit Tests (no Docker)
+
+Scripts whose value is in their *decisions* rather than their side effects have unit tests that
+stub `sudo`/`curl`/`git`/`dpkg` and assert on what would have run. They need no Docker and no
+network:
+
+```shell
+# Run them all
+./gradlew testCassandraScripts
+
+# Or individually
+./gradlew testCassandraInstallScript   # bin/install-cassandra-version
+./gradlew testCassandraInstallLoop     # the bake-time version loop in install_cassandra.sh
+./gradlew testCassandraUseScript       # bin/use-cassandra
+```
+
+Each test lives next to its script as `<script>.test.sh` and also runs in CI
+(`.github/workflows/packer-test.yml`). This is the tier to extend when changing argument handling,
+already-installed short-circuits, or JDK selection — the Docker tiers above are for scripts that
+must actually install something.
+
+## Scripts Invoked At Runtime, Not Just At Bake Time
+
+`cassandra/bin/` holds scripts the AMI build puts on the node's `PATH` and which the CLI then
+invokes over SSH against a *running* cluster:
+
+- `install-cassandra-version` — one install code path shared by the bake-time loop and
+  `easy-db-lab cassandra install <version>`
+- `use-cassandra` — selects the active version, called by `easy-db-lab cassandra use`
+
+Their flags and output are a contract with Kotlin callers in
+`src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/`. Changing them without updating
+the caller breaks a CLI command, not just a build.
+
 ### Using test-script.sh Directly
 
 ```shell
@@ -94,6 +128,7 @@ packer/
 │   └── install/            # Base installation scripts
 ├── cassandra/              # Cassandra AMI configuration
 │   ├── cassandra.pkr.hcl  # Packer config for Cassandra image
+│   ├── bin/                # Scripts placed on the node's PATH, also called at runtime
 │   └── install/            # Cassandra installation scripts
 ├── Dockerfile              # Test environment (mimics Ubuntu 24.04 AMI)
 ├── docker-compose.yml      # Test orchestration

--- a/packer/cassandra/bin/install-cassandra-version
+++ b/packer/cassandra/bin/install-cassandra-version
@@ -1,0 +1,369 @@
+#!/bin/bash
+#
+# Installs a single Cassandra version into /usr/local/cassandra/<version>.
+#
+# Used identically at AMI bake time (install_cassandra.sh's version loop) and at runtime
+# (`easy-db-lab cassandra install <version>`), so there is one install code path rather than two
+# kept in sync by hand.
+#
+# Usage:
+#   install-cassandra-version <version> [--url URL] [--branch BRANCH] [--java N] [--ant-flags FLAGS]
+#
+# Install mode is chosen from the flags, matching a cassandra_versions.yaml entry:
+#   no --url, no --branch  -> download the latest official patch release for <version>
+#   --url ending in .tar.gz -> download and unpack that tarball
+#   --url + --branch        -> git clone the branch and build it with ant (--java selects the JDK)
+#
+# Re-running for an already-installed version is a no-op.
+
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage: install-cassandra-version <version> [options]
+
+Options:
+  --url URL           Tarball URL (.tar.gz) or git repository URL (with --branch)
+  --branch BRANCH     Git branch to clone and build (requires --url)
+  --java VERSION      JDK major version used for the ant build (e.g. 8, 11, 17, 21)
+  --ant-flags FLAGS   Extra flags passed to ant (e.g. "-Duse.jdk11=true")
+USAGE
+}
+
+VERSION=""
+URL=""
+BRANCH=""
+JAVA_VERSION=""
+ANT_FLAGS=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --url) URL="$2"; shift 2 ;;
+        --branch) BRANCH="$2"; shift 2 ;;
+        --java) JAVA_VERSION="$2"; shift 2 ;;
+        --ant-flags) ANT_FLAGS="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        --*) echo "ERROR: unknown option $1" >&2; usage >&2; exit 1 ;;
+        *)
+            if [ -z "$VERSION" ]; then
+                VERSION="$1"; shift
+            else
+                echo "ERROR: unexpected argument $1" >&2; usage >&2; exit 1
+            fi
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "ERROR: <version> is required" >&2
+    usage >&2
+    exit 1
+fi
+
+# A tarball is unpacked as-is; there is nothing to check a branch out of. Silently ignoring
+# --branch here would install something other than what was asked for.
+if [[ -n "$BRANCH" && "$URL" == *.tar.gz ]]; then
+    echo "ERROR: --branch $BRANCH cannot be used with a tarball --url ($URL); pass a git repository URL" >&2
+    exit 1
+fi
+
+# Written into every installed version's bin/cassandra.in.sh (Pyroscope, MAAC, GC logging, log
+# dirs). Installed to this durable path by install_cassandra.sh at bake time so a runtime install
+# can find it too - /tmp does not survive a reboot.
+CASSANDRA_IN_SH_SNIPPET=${CASSANDRA_IN_SH_SNIPPET:-/usr/local/share/easy-db-lab/cassandra.in.sh}
+
+# Where versions land. Overridable so the script can be exercised outside a node.
+CASSANDRA_INSTALL_DIR=${CASSANDRA_INSTALL_DIR:-/usr/local/cassandra}
+
+# Private working directory for this run, removed on every exit path — not just the successful
+# one. A failed git clone leaves the credentialed remote behind in <workdir>/<version>/.git/config,
+# and a failed build is the common case when testing an unmerged branch.
+WORKDIR=""
+trap 'cd /; [ -n "$WORKDIR" ] && rm -rf "$WORKDIR"' EXIT
+
+# Shared S3 download cache (provides cached_fetch). Falls back to a direct download when the cache
+# lib is absent (local script tests / no cache).
+if [ -f /usr/local/lib/edl-cache.sh ]; then
+    # shellcheck disable=SC1091
+    source /usr/local/lib/edl-cache.sh
+else
+    cached_fetch() { echo "no S3 cache; downloading $1"; curl -fsSL --retry 3 "$1" -o "$3"; }
+fi
+
+## Downloads the latest patch release of a cassandra version
+## This saves us from having to update cassandra_versions.yaml
+## every time a new patch release is made
+download_cassandra_version() {
+    # Check if version prefix is provided
+    if [ -z "$1" ]; then
+        echo "Usage: download_cassandra_version <version-prefix>"
+        return 1
+    fi
+
+    # Assign the version prefix from the first argument
+    version_prefix="$1"
+
+    # Get the list of versions from the Cassandra download page
+    versions=$(curl -s https://dlcdn.apache.org/cassandra/ | grep -o 'href="[0-9]\+\.[0-9]\+\.[0-9]\+/\"' | sed 's/href="//' | sed 's/\/"//')
+
+    # Find the latest version that matches the given prefix
+    full_version=$(echo "$versions" | grep "^$version_prefix" | sort -V | tail -n 1)
+
+    # Check if a version was found
+    if [ -z "$full_version" ]; then
+        echo "ERROR: No matching version found for prefix $version_prefix" >&2
+        return 1
+    fi
+
+    # Construct the download URL
+    archive="apache-cassandra-$full_version-bin.tar.gz"
+    download_url="https://dlcdn.apache.org/cassandra/$full_version/$archive"
+
+    # Download the file (via S3 cache, keyed by the resolved patch version)
+    echo "Downloading Cassandra version $full_version from $download_url..."
+    cached_fetch "$download_url" "cassandra-dist/$full_version/$archive" "$archive" || {
+        echo "ERROR: Failed to download Cassandra version $full_version from $download_url" >&2
+        return 1
+    }
+
+    # Verify download was successful and file is not empty
+    if [[ ! -f "$archive" || ! -s "$archive" ]]; then
+        echo "ERROR: Downloaded file $archive is missing or empty for version $full_version" >&2
+        return 1
+    fi
+
+    echo "Download completed successfully."
+
+    # Extract the archive (quiet: verbose file listing floods packer's SSH stream and drops it)
+    tar zxf "$archive" || {
+        echo "ERROR: Failed to extract $archive for version $full_version" >&2
+        return 1
+    }
+
+    # Move and verify
+    mv "apache-cassandra-$full_version" "$version_prefix" || {
+        echo "ERROR: Failed to rename apache-cassandra-$full_version to $version_prefix" >&2
+        return 1
+    }
+
+    # Verify the directory exists
+    if [[ ! -d "$version_prefix" ]]; then
+        echo "ERROR: Directory $version_prefix does not exist after extraction and rename" >&2
+        return 1
+    fi
+
+    return 0
+}
+
+## Resolves JAVA_HOME for a JDK major version. The build must use the JDK the version declares,
+## never the node's current default alternative, and must not change that default - switching it
+## would disturb whichever Cassandra version is currently active on the node.
+resolve_java_home() {
+    local java_version="$1"
+    local arch
+    arch=$(dpkg --print-architecture)
+
+    local candidate
+    for candidate in \
+        "/usr/lib/jvm/java-${java_version}-openjdk-${arch}" \
+        "/usr/lib/jvm/java-1.${java_version}.0-openjdk-${arch}"; do
+        if [ -x "$candidate/bin/java" ]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+
+    echo "ERROR: No JDK found on this node for java version $java_version" >&2
+    return 1
+}
+
+## Installs a single Cassandra version end-to-end: download (or git build), place under
+## /usr/local/cassandra/$version, and apply the per-version configuration.
+##
+## Safe to run as a background job: it operates in its own private temp working directory
+## (so concurrent versions never share extraction state, e.g. the `find . -name '*cassandra*'`
+## below only ever sees its own tarball) and otherwise writes only version-specific paths.
+## Genuinely shared/global steps (user + directory creation, the Maven cache cleanup) are the
+## caller's responsibility.
+install_cassandra_version() {
+  local version="$1"
+
+  if [[ -d "$CASSANDRA_INSTALL_DIR/$version" ]]; then
+    echo "Version $version is already installed at $CASSANDRA_INSTALL_DIR/$version, nothing to do"
+    return 0
+  fi
+
+  if [[ ! -f "$CASSANDRA_IN_SH_SNIPPET" ]]; then
+      echo "ERROR: Missing $CASSANDRA_IN_SH_SNIPPET, cannot configure version $version" >&2
+      return 1
+  fi
+
+  # Script-scoped, not local: the EXIT trap below runs after this function has returned.
+  WORKDIR=$(mktemp -d) || {
+      echo "ERROR: Failed to create temp working directory for version $version" >&2
+      return 1
+  }
+
+  cd "$WORKDIR" || {
+      echo "ERROR: Cannot change to working directory $WORKDIR for version $version" >&2
+      return 1
+  }
+
+  echo "Configuring version: $version"
+
+  sudo mkdir -p "$CASSANDRA_INSTALL_DIR"
+
+  # if $version is set, $URL is blank, and $BRANCH is blank
+  if [[ $version != "" && $URL == "" && $BRANCH == "" ]]; then
+    download_cassandra_version "$version" || {
+        echo "ERROR: download_cassandra_version failed for version $version" >&2
+        return 1
+    }
+
+    # check if $version exists in the current directory
+    if [[ ! -d $version ]]; then
+      echo "ERROR: Failed to download Cassandra version $version - directory not found" >&2
+      return 1
+    fi
+
+    sudo mv "$version" "$CASSANDRA_INSTALL_DIR/$version" || {
+        echo "ERROR: Failed to move $version to $CASSANDRA_INSTALL_DIR/" >&2
+        return 1
+    }
+
+  # if a URL is set and ends in .tar.gz, download it (via the S3 cache, version-keyed)
+  elif [[ $URL == *.tar.gz ]]; then
+    echo "Downloading $URL for version $version"
+
+    local archive_file
+    archive_file=$(basename "$URL")
+
+    # Route the tarball through the S3 download cache (keyed by version) so it is not re-fetched
+    # cold from GitHub on every build. cached_fetch falls back to a direct download when no cache
+    # bucket is configured (local packer Docker tests).
+    cached_fetch "$URL" "cassandra-dist/$version/$archive_file" "$archive_file" || {
+        echo "ERROR: Failed to download version $version from $URL" >&2
+        return 1
+    }
+
+    # Verify download succeeded and file is not empty
+    if [[ ! -f "$archive_file" || ! -s "$archive_file" ]]; then
+        echo "ERROR: Downloaded file $archive_file is missing or empty for version $version" >&2
+        return 1
+    fi
+
+    echo "Extracting $archive_file"
+    tar zxf "$archive_file" || {
+        echo "ERROR: Failed to extract $archive_file for version $version" >&2
+        return 1
+    }
+
+    rm -f "$archive_file"
+
+    # Find the extracted directory (should be the only directory created)
+    # Look for directories starting with 'apache-cassandra' or 'cassandra'
+    local f
+    f=$(find . -maxdepth 1 -type d -name '*cassandra*' ! -name '.' -printf '%f\n' | head -n 1)
+
+    # Verify extracted directory exists
+    if [[ -z "$f" || ! -d "$f" ]]; then
+        echo "ERROR: Could not find extracted Cassandra directory for version $version" >&2
+        echo "Available directories:"
+        ls -la
+        return 1
+    fi
+
+    echo "Found extracted directory: $f"
+
+    sudo mv "$f" "$CASSANDRA_INSTALL_DIR/$version" || {
+        echo "ERROR: Failed to move $f to $CASSANDRA_INSTALL_DIR/$version" >&2
+        return 1
+    }
+
+  else
+    # Clone the git repo specified by --url, check out --branch, and build it with ant.
+    if [[ -z "$URL" || -z "$BRANCH" ]]; then
+        echo "ERROR: Building version $version from source requires both --url and --branch" >&2
+        return 1
+    fi
+    if [[ -z "$JAVA_VERSION" ]]; then
+        echo "ERROR: Building version $version from source requires --java" >&2
+        return 1
+    fi
+
+    local java_home
+    java_home=$(resolve_java_home "$JAVA_VERSION") || return 1
+    echo "Building version $version with JDK $JAVA_VERSION at $java_home"
+
+    echo "Cloning repo for version $version from $URL branch $BRANCH"
+    git clone --depth=1 --single-branch --branch "$BRANCH" "$URL" "$version" || {
+        echo "ERROR: Git clone failed for version $version from $URL branch $BRANCH" >&2
+        return 1
+    }
+
+    # Verify clone was successful
+    if [[ ! -d "$version/.git" ]]; then
+        echo "ERROR: Git clone incomplete for version $version - .git directory not found" >&2
+        return 1
+    fi
+
+    echo "Building version $version with ant"
+    # Per-version build log so concurrent builds do not clobber a shared file.
+    local ant_log="/tmp/ant-build-$version.log"
+    (
+      cd "$version" || exit 1
+      export JAVA_HOME="$java_home"
+      export PATH="$java_home/bin:$PATH"
+      # Quiet: ant output is voluminous and floods packer's SSH stream
+      # shellcheck disable=SC2086
+      ant realclean >"$ant_log" 2>&1 && ant -Dno-checkstyle=true $ANT_FLAGS >>"$ant_log" 2>&1 || exit 1
+      rm -rf .git
+    ) || {
+        echo "ERROR: Ant build failed for version $version, see $ant_log" >&2
+        tail -n 50 "$ant_log" >&2 || true
+        return 1
+    }
+
+    sudo mv "$version" "$CASSANDRA_INSTALL_DIR/$version" || {
+        echo "ERROR: Failed to move built version $version to $CASSANDRA_INSTALL_DIR/" >&2
+        return 1
+    }
+  fi
+
+  # Verify the version was successfully moved into place
+  if [[ ! -d "$CASSANDRA_INSTALL_DIR/$version" ]]; then
+      echo "ERROR: Version $version not found in $CASSANDRA_INSTALL_DIR/ after installation" >&2
+      return 1
+  fi
+
+  # at this point the $version is in place, however it was installed
+  # do any general customizations in the below subshell
+  echo "Configuring version $version"
+  (
+      cd "$CASSANDRA_INSTALL_DIR/$version" || exit 1
+      rm -rf data
+      cp -R conf conf.orig
+      # create a pristine backup of the original conf
+      sudo cp conf/cassandra.yaml conf/cassandra.orig.yaml
+      cat "$CASSANDRA_IN_SH_SNIPPET" >> bin/cassandra.in.sh
+  ) || {
+      # Leave nothing behind: the directory's existence is what marks a version installed, so a
+      # half-configured one would make every retry a no-op.
+      sudo rm -rf "$CASSANDRA_INSTALL_DIR/$version"
+      echo "ERROR: Configuration failed for version $version" >&2
+      return 1
+  }
+
+  # Remove bundled cqlsh from Cassandra 2.x and 3.x to use uv-installed version
+  if [[ "$version" == 2.* || "$version" == 3.* ]]; then
+    echo "Removing bundled cqlsh from Cassandra $version (using uv-installed version instead)"
+    rm -f "$CASSANDRA_INSTALL_DIR/$version/bin/cqlsh"
+    rm -f "$CASSANDRA_INSTALL_DIR/$version/bin/cqlsh.py"
+  fi
+
+  sudo chown -R cassandra:cassandra "$CASSANDRA_INSTALL_DIR/$version"
+
+  echo "✓ Successfully installed and configured version $version"
+}
+
+install_cassandra_version "$VERSION"

--- a/packer/cassandra/bin/install-cassandra-version
+++ b/packer/cassandra/bin/install-cassandra-version
@@ -36,36 +36,38 @@ BRANCH=""
 JAVA_VERSION=""
 ANT_FLAGS=""
 
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --url) URL="$2"; shift 2 ;;
-        --branch) BRANCH="$2"; shift 2 ;;
-        --java) JAVA_VERSION="$2"; shift 2 ;;
-        --ant-flags) ANT_FLAGS="$2"; shift 2 ;;
-        -h|--help) usage; exit 0 ;;
-        --*) echo "ERROR: unknown option $1" >&2; usage >&2; exit 1 ;;
-        *)
-            if [ -z "$VERSION" ]; then
-                VERSION="$1"; shift
-            else
-                echo "ERROR: unexpected argument $1" >&2; usage >&2; exit 1
-            fi
-            ;;
-    esac
-done
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --url) URL="$2"; shift 2 ;;
+            --branch) BRANCH="$2"; shift 2 ;;
+            --java) JAVA_VERSION="$2"; shift 2 ;;
+            --ant-flags) ANT_FLAGS="$2"; shift 2 ;;
+            -h|--help) usage; exit 0 ;;
+            --*) echo "ERROR: unknown option $1" >&2; usage >&2; exit 1 ;;
+            *)
+                if [ -z "$VERSION" ]; then
+                    VERSION="$1"; shift
+                else
+                    echo "ERROR: unexpected argument $1" >&2; usage >&2; exit 1
+                fi
+                ;;
+        esac
+    done
 
-if [ -z "$VERSION" ]; then
-    echo "ERROR: <version> is required" >&2
-    usage >&2
-    exit 1
-fi
+    if [ -z "$VERSION" ]; then
+        echo "ERROR: <version> is required" >&2
+        usage >&2
+        exit 1
+    fi
 
-# A tarball is unpacked as-is; there is nothing to check a branch out of. Silently ignoring
-# --branch here would install something other than what was asked for.
-if [[ -n "$BRANCH" && "$URL" == *.tar.gz ]]; then
-    echo "ERROR: --branch $BRANCH cannot be used with a tarball --url ($URL); pass a git repository URL" >&2
-    exit 1
-fi
+    # A tarball is unpacked as-is; there is nothing to check a branch out of. Silently ignoring
+    # --branch here would install something other than what was asked for.
+    if [[ -n "$BRANCH" && "$URL" == *.tar.gz ]]; then
+        echo "ERROR: --branch $BRANCH cannot be used with a tarball --url ($URL); pass a git repository URL" >&2
+        exit 1
+    fi
+}
 
 # Written into every installed version's bin/cassandra.in.sh (Pyroscope, MAAC, GC logging, log
 # dirs). Installed to this durable path by install_cassandra.sh at bake time so a runtime install
@@ -89,6 +91,51 @@ if [ -f /usr/local/lib/edl-cache.sh ]; then
 else
     cached_fetch() { echo "no S3 cache; downloading $1"; curl -fsSL --retry 3 "$1" -o "$3"; }
 fi
+
+## Puts netty-codec-http in an installed version's lib directory when it is missing.
+##
+## The MCAC metrics agent serves its Prometheus endpoint from a Netty HTTP server, but
+## netty-codec-http is `provided` in the agent build and is not bundled in the agent jar - the
+## upstream k8ssandra images add it to Cassandra's lib for exactly this reason. Cassandra 4.x got
+## away without it because its fat netty-all-4.1.58 contained the codec-http classes. From 5.0 the
+## distribution ships granular netty modules plus an empty netty-all aggregator, so the endpoint
+## died on NoClassDefFoundError io/netty/handler/codec/http/HttpServerCodec and the node published
+## no metrics at all, quietly, on every release from 5.0 onwards.
+##
+## The version is taken from the release's own netty-common jar, so a Cassandra build that moves to
+## a new Netty always gets the matching codec-http rather than a pinned one.
+ensure_netty_codec_http() {
+  local lib_dir="$1"
+  local netty_common netty_version jar url
+
+  if compgen -G "${lib_dir}/netty-codec-http-*.jar" >/dev/null; then
+    return 0
+  fi
+
+  # No netty-common means the fat netty-all layout (4.0/4.1), which already carries codec-http.
+  netty_common=$(find "$lib_dir" -maxdepth 1 -name 'netty-common-*.jar' | head -n 1)
+  if [ -z "$netty_common" ]; then
+    return 0
+  fi
+
+  netty_version=$(basename "$netty_common" | sed -E 's/^netty-common-(.+)\.jar$/\1/')
+  if [ -z "$netty_version" ]; then
+    echo "ERROR: could not read a Netty version from $netty_common" >&2
+    return 1
+  fi
+
+  jar="netty-codec-http-${netty_version}.jar"
+  url="https://repo1.maven.org/maven2/io/netty/netty-codec-http/${netty_version}/${jar}"
+
+  echo "Adding ${jar} for the MCAC metrics endpoint"
+  cached_fetch "$url" "netty/${netty_version}/${jar}" "/tmp/${jar}" || {
+    echo "ERROR: Failed to download ${url}; the MCAC metrics endpoint will not start" >&2
+    return 1
+  }
+
+  sudo cp "/tmp/${jar}" "${lib_dir}/${jar}"
+  rm -f "/tmp/${jar}"
+}
 
 ## Downloads the latest patch release of a cassandra version
 ## This saves us from having to update cassandra_versions.yaml
@@ -346,6 +393,7 @@ install_cassandra_version() {
       # create a pristine backup of the original conf
       sudo cp conf/cassandra.yaml conf/cassandra.orig.yaml
       cat "$CASSANDRA_IN_SH_SNIPPET" >> bin/cassandra.in.sh
+      ensure_netty_codec_http "$CASSANDRA_INSTALL_DIR/$version/lib"
   ) || {
       # Leave nothing behind: the directory's existence is what marks a version installed, so a
       # half-configured one would make every retry a no-op.
@@ -366,4 +414,8 @@ install_cassandra_version() {
   echo "✓ Successfully installed and configured version $version"
 }
 
-install_cassandra_version "$VERSION"
+# Sourced by the unit tests for the functions above; then nothing here runs.
+if [ -z "${INSTALL_CASSANDRA_VERSION_SOURCE_ONLY:-}" ]; then
+    parse_args "$@"
+    install_cassandra_version "$VERSION"
+fi

--- a/packer/cassandra/bin/install-cassandra-version.test.sh
+++ b/packer/cassandra/bin/install-cassandra-version.test.sh
@@ -181,6 +181,92 @@ assert_fails_with "a missing cassandra.in.sh snippet is reported" \
 assert_no_reach_out "a missing snippet fails before downloading anything"
 mv "${SANDBOX}/held" "$CASSANDRA_IN_SH_SNIPPET"
 
+# --- netty-codec-http is added to the releases that need it ------------------
+# The MCAC metrics agent's Prometheus endpoint is a Netty HTTP server and netty-codec-http is not
+# bundled in the agent jar. Cassandra 4.x carried the classes inside its fat netty-all; 5.0 and
+# later do not, so without this step the endpoint dies on NoClassDefFoundError HttpServerCodec and
+# the node publishes no metrics.
+#
+# Sourcing brings in the functions only (see INSTALL_CASSANDRA_VERSION_SOURCE_ONLY). It also
+# brings the script's `set -euo pipefail`, which this harness does not want.
+INSTALL_CASSANDRA_VERSION_SOURCE_ONLY=1
+export INSTALL_CASSANDRA_VERSION_SOURCE_ONLY
+# shellcheck source=/dev/null
+source "$SCRIPT"
+set +eu
+
+# Stand in for the S3-cached download: record what was asked for and produce a file.
+FETCH_LOG="${SANDBOX}/fetches.log"
+cached_fetch() {
+  echo "$1 $2 $3" >>"$FETCH_LOG"
+  echo "stub jar" >"$3"
+}
+
+make_lib() {
+  local dir="${SANDBOX}/lib-$1"
+  rm -rf "$dir"
+  mkdir -p "$dir"
+  shift
+  local jar
+  for jar in "$@"; do
+    echo "stub" >"${dir}/${jar}"
+  done
+  echo "$dir"
+}
+
+# 5.0+ layout: granular netty modules, no codec-http.
+: >"$FETCH_LOG"
+LIB="$(make_lib granular netty-common-4.1.130.Final.jar netty-transport-4.1.130.Final.jar netty-all-4.1.130.Final.jar)"
+if ensure_netty_codec_http "$LIB" >/dev/null 2>&1; then
+  pass "a granular-netty release is handled"
+else
+  fail "a granular-netty release should succeed"
+fi
+
+if [[ -f "${LIB}/netty-codec-http-4.1.130.Final.jar" ]]; then
+  pass "netty-codec-http lands in the release's lib directory"
+else
+  fail "expected netty-codec-http-4.1.130.Final.jar in ${LIB}, got: $(ls "$LIB")"
+fi
+
+# The version must come from the release's own netty-common, not a pinned constant, or a Cassandra
+# build that moves to a new Netty gets a mismatched codec-http.
+if grep -q "io/netty/netty-codec-http/4.1.130.Final/netty-codec-http-4.1.130.Final.jar" "$FETCH_LOG"; then
+  pass "the codec-http version is taken from the release's netty-common"
+else
+  fail "expected a 4.1.130.Final codec-http download, got: $(cat "$FETCH_LOG")"
+fi
+
+# A different Netty must produce a different download, not the one above.
+: >"$FETCH_LOG"
+LIB="$(make_lib newer netty-common-4.2.7.Final.jar)"
+ensure_netty_codec_http "$LIB" >/dev/null 2>&1
+if [[ -f "${LIB}/netty-codec-http-4.2.7.Final.jar" ]]; then
+  pass "a release on a different Netty gets the matching codec-http"
+else
+  fail "expected netty-codec-http-4.2.7.Final.jar in ${LIB}, got: $(ls "$LIB")"
+fi
+
+# 4.0/4.1 layout: one fat netty-all that already contains the codec-http classes.
+: >"$FETCH_LOG"
+LIB="$(make_lib fat netty-all-4.1.58.Final.jar)"
+ensure_netty_codec_http "$LIB" >/dev/null 2>&1
+if [[ -s "$FETCH_LOG" ]]; then
+  fail "a fat netty-all release must not download codec-http, but did: $(cat "$FETCH_LOG")"
+else
+  pass "a fat netty-all release downloads nothing"
+fi
+
+# Already present (a re-run, or a distribution that ships it): leave it alone.
+: >"$FETCH_LOG"
+LIB="$(make_lib present netty-common-4.1.130.Final.jar netty-codec-http-4.1.130.Final.jar)"
+ensure_netty_codec_http "$LIB" >/dev/null 2>&1
+if [[ -s "$FETCH_LOG" ]]; then
+  fail "an existing codec-http must not be re-downloaded, but was: $(cat "$FETCH_LOG")"
+else
+  pass "an existing codec-http is left alone"
+fi
+
 echo
 echo "${tests_run} tests, ${tests_failed} failed"
 [[ "$tests_failed" -eq 0 ]]

--- a/packer/cassandra/bin/install-cassandra-version.test.sh
+++ b/packer/cassandra/bin/install-cassandra-version.test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# Unit tests for install-cassandra-version — the one script both the AMI bake and
+# `easy-db-lab cassandra install` use to install a single Cassandra version.
+#
+# These cover the decisions the script makes before it touches the network: argument handling,
+# the already-installed early return, the guards on building from source, and JDK selection. The
+# install paths themselves (download/extract/build) are exercised against a real container, not
+# here. No network, no Docker, no root: sudo/dpkg/curl/git are stubbed on PATH and the install
+# directory is redirected into a temp dir.
+#
+# Run directly:  ./install-cassandra-version.test.sh
+# Or via gradle: ./gradlew testCassandraInstallScript
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${SCRIPT_DIR}/install-cassandra-version"
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+BIN="${SANDBOX}/bin"
+mkdir -p "$BIN"
+
+# sudo runs the command directly; the test never needs root.
+cat >"${BIN}/sudo" <<'SHIM'
+#!/bin/bash
+exec "$@"
+SHIM
+
+# Record any network or VCS reach so a test can assert the script never got that far.
+for tool in curl git ant; do
+  cat >"${BIN}/${tool}" <<SHIM
+#!/bin/bash
+echo "${tool} \$*" >> "${SANDBOX}/reached-out.log"
+exit 1
+SHIM
+done
+
+# dpkg is Debian-only; the script only asks it for the architecture.
+cat >"${BIN}/dpkg" <<'SHIM'
+#!/bin/bash
+echo amd64
+SHIM
+
+chmod +x "${BIN}"/*
+export PATH="${BIN}:${PATH}"
+
+export CASSANDRA_INSTALL_DIR="${SANDBOX}/cassandra"
+export CASSANDRA_IN_SH_SNIPPET="${SANDBOX}/cassandra.in.sh"
+# The script's working directory comes from mktemp -d, so point that at the sandbox to make what
+# it leaves behind observable.
+export TMPDIR="${SANDBOX}/tmp"
+mkdir -p "$CASSANDRA_INSTALL_DIR" "$TMPDIR"
+echo '# test snippet' >"$CASSANDRA_IN_SH_SNIPPET"
+
+# GNU mktemp (the nodes, and CI) honors TMPDIR; BSD mktemp (macOS) ignores it and uses the
+# per-user Darwin temp dir, which would make the cleanup assertion below silently vacuous.
+probe="$(mktemp -d)"
+case "$probe" in
+  "${TMPDIR}"/*) tmpdir_observable=true ;;
+  *) tmpdir_observable=false ;;
+esac
+rmdir "$probe"
+
+tests_run=0
+tests_failed=0
+
+pass() {
+  tests_run=$((tests_run + 1))
+  echo "ok   - $1"
+}
+
+fail() {
+  tests_run=$((tests_run + 1))
+  tests_failed=$((tests_failed + 1))
+  echo "FAIL - $1"
+}
+
+# Runs the script, capturing combined output in $OUTPUT and the exit code in $STATUS.
+run_script() {
+  rm -f "${SANDBOX}/reached-out.log"
+  OUTPUT="$(bash "$SCRIPT" "$@" 2>&1)"
+  STATUS=$?
+}
+
+assert_fails_with() {
+  local desc="$1" expected="$2"
+  shift 2
+  run_script "$@"
+  if [[ "$STATUS" -eq 0 ]]; then
+    fail "$desc: expected non-zero exit, got 0"
+  elif [[ "$OUTPUT" != *"$expected"* ]]; then
+    fail "$desc: expected output to contain [$expected], got [$OUTPUT]"
+  else
+    pass "$desc"
+  fi
+}
+
+assert_no_reach_out() {
+  local desc="$1"
+  if [[ -f "${SANDBOX}/reached-out.log" ]]; then
+    fail "$desc: script reached out — $(cat "${SANDBOX}/reached-out.log")"
+  else
+    pass "$desc"
+  fi
+}
+
+# --- argument handling --------------------------------------------------------
+assert_fails_with "unknown flag is rejected" "unknown option --bogus" 5.0 --bogus
+assert_fails_with "a second positional argument is rejected" "unexpected argument" 5.0 6.0
+assert_fails_with "missing version is rejected" "<version> is required"
+
+run_script --help
+if [[ "$STATUS" -eq 0 && "$OUTPUT" == *"Usage: install-cassandra-version"* ]]; then
+  pass "--help exits 0 with usage"
+else
+  fail "--help should exit 0 with usage, got status ${STATUS}"
+fi
+
+# --- already installed is a no-op --------------------------------------------
+mkdir -p "${CASSANDRA_INSTALL_DIR}/5.0"
+run_script 5.0
+if [[ "$STATUS" -eq 0 && "$OUTPUT" == *"already installed"* ]]; then
+  pass "an installed version exits 0 without reinstalling"
+else
+  fail "an installed version should exit 0 as a no-op, got status ${STATUS}: ${OUTPUT}"
+fi
+assert_no_reach_out "an installed version downloads nothing"
+
+# --- building from source needs both a repo and a JDK ------------------------
+assert_fails_with "a branch with no url is rejected" "requires both --url and --branch" \
+  from-source --branch trunk --java 17
+assert_no_reach_out "a branch with no url clones nothing"
+
+assert_fails_with "building from source with no --java is rejected" "requires --java" \
+  from-source --url https://github.com/apache/cassandra.git --branch trunk
+assert_no_reach_out "building with no --java clones nothing"
+
+# --- a branch cannot be checked out of a tarball ------------------------------
+assert_fails_with "a branch against a tarball url is rejected, not silently ignored" \
+  "cannot be used with a tarball" \
+  from-tarball --url https://example.com/apache-cassandra-x-bin.tar.gz --branch trunk --java 17
+assert_no_reach_out "a branch against a tarball url downloads nothing"
+
+# --- JDK selection comes from --java, and never switches the node's default ---
+assert_fails_with "an unavailable JDK is reported, not silently substituted" \
+  "No JDK found on this node for java version 99" \
+  from-source --url https://github.com/apache/cassandra.git --branch trunk --java 99
+assert_no_reach_out "an unavailable JDK clones nothing"
+
+if grep -q "update-java-alternatives" "$SCRIPT"; then
+  fail "the script must never switch the node's default JDK (update-java-alternatives)"
+else
+  pass "the script never switches the node's default JDK"
+fi
+
+# --- a failed install leaves no working directory behind ---------------------
+# The working directory holds the git clone, so a failed build would otherwise strand the
+# credentialed remote in <workdir>/<version>/.git/config for the life of the node.
+run_script leftovers --url https://example.com/apache-cassandra-leftovers-bin.tar.gz --java 11
+if [[ "$STATUS" -eq 0 ]]; then
+  fail "expected the download to fail (curl is stubbed to fail)"
+else
+  pass "a failing download exits non-zero"
+fi
+
+if [[ "$tmpdir_observable" != true ]]; then
+  echo "skip - mktemp here ignores TMPDIR (BSD); this assertion runs on the nodes and in CI"
+elif [[ -z "$(find "$TMPDIR" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+  pass "a failed install removes its working directory"
+else
+  fail "a failed install left $(find "$TMPDIR" -mindepth 1 -maxdepth 1) behind"
+fi
+
+# --- the config snippet is required, and checked before any download ---------
+mv "$CASSANDRA_IN_SH_SNIPPET" "${SANDBOX}/held"
+assert_fails_with "a missing cassandra.in.sh snippet is reported" \
+  "Missing ${CASSANDRA_IN_SH_SNIPPET}" 4.1
+assert_no_reach_out "a missing snippet fails before downloading anything"
+mv "${SANDBOX}/held" "$CASSANDRA_IN_SH_SNIPPET"
+
+echo
+echo "${tests_run} tests, ${tests_failed} failed"
+[[ "$tests_failed" -eq 0 ]]

--- a/packer/cassandra/bin/use-cassandra
+++ b/packer/cassandra/bin/use-cassandra
@@ -1,21 +1,36 @@
 #!/bin/bash
 
-CASSANDRA_VERSIONS="/etc/cassandra_versions.yaml"
+# Node paths. Each defaults to where it lives on a real node; they are overridable only so
+# use-cassandra.test.sh can exercise this script in a sandbox instead of against /usr/local.
+CASSANDRA_VERSIONS="${CASSANDRA_VERSIONS:-/etc/cassandra_versions.yaml}"
+CASSANDRA_INSTALL_DIR="${CASSANDRA_INSTALL_DIR:-/usr/local/cassandra}"
+CASSANDRA_CONF_LINK="${CASSANDRA_CONF_LINK:-/etc/cassandra}"
+PYTHON_BIN_DIR="${PYTHON_BIN_DIR:-/usr/bin}"
+
+# Fail before the symlink swap rather than leaving the `current` symlink dangling, which
+# surfaces later as a confusing startup failure instead of a missing version.
+if [ ! -d "$CASSANDRA_INSTALL_DIR/$1" ]; then
+  echo "Cassandra version $1 is not installed on this node ($CASSANDRA_INSTALL_DIR/$1 does not exist)."
+  echo "Installed versions:"
+  ls "$CASSANDRA_INSTALL_DIR"
+  echo "Run 'easy-db-lab cassandra install $1' to install it first."
+  exit 1
+fi
 
 # set cassandra version to $1
-sudo ln -vfns /usr/local/cassandra/$1 /usr/local/cassandra/current
-sudo ln -vfns /usr/local/cassandra/$1/conf /etc/cassandra
+sudo ln -vfns "$CASSANDRA_INSTALL_DIR/$1" "$CASSANDRA_INSTALL_DIR/current"
+sudo ln -vfns "$CASSANDRA_INSTALL_DIR/$1/conf" "$CASSANDRA_CONF_LINK"
 
 # hacky, not really what I want long term but whatever.
-sudo chown -R cassandra:cassandra /usr/local/cassandra
+sudo chown -R cassandra:cassandra "$CASSANDRA_INSTALL_DIR"
 
 # set the java version
 export VERSION=$1
 
-export JAVA_VERSION=$(yq e '.[] | select(.version == env(VERSION)).java' $CASSANDRA_VERSIONS)
+export JAVA_VERSION=$(yq e '.[] | select(.version == env(VERSION)).java' "$CASSANDRA_VERSIONS")
 echo "Using java version from cassandra_versions.yaml: $JAVA_VERSION"
 
-export PY_VERSION=$(yq e '.[] | select(.version == env(VERSION)).python' $CASSANDRA_VERSIONS)
+export PY_VERSION=$(yq e '.[] | select(.version == env(VERSION)).python' "$CASSANDRA_VERSIONS")
 
 if [ -z "$JAVA_VERSION" ]; then
   echo "No java version found for $VERSION"
@@ -58,7 +73,7 @@ fi
 # set python version using update-alternatives
 # Extract major.minor version from full version (e.g., "3.10.6" -> "3.10", "2.7.18" -> "2.7")
 PY_MAJOR_MINOR=$(echo "$PY_VERSION" | cut -d. -f1,2)
-PY_ALTERNATIVE="/usr/bin/python${PY_MAJOR_MINOR}"
+PY_ALTERNATIVE="${PYTHON_BIN_DIR}/python${PY_MAJOR_MINOR}"
 
 # Validate that the requested Python version is installed
 if [ ! -f "$PY_ALTERNATIVE" ]; then

--- a/packer/cassandra/bin/use-cassandra.test.sh
+++ b/packer/cassandra/bin/use-cassandra.test.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+#
+# Unit tests for use-cassandra — the script that points a node at one of its installed Cassandra
+# versions. The guard these cover is the one that stops it pointing `current` at a version that was
+# never installed, which used to leave a dangling symlink and surface much later as a confusing
+# startup failure.
+#
+# sudo/update-java-alternatives/update-alternatives are stubbed on PATH and every node path is
+# redirected into a temp dir, so this needs no root and touches nothing outside the sandbox.
+#
+# Run directly:  ./use-cassandra.test.sh
+# Or via gradle: ./gradlew testCassandraUseScript
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${SCRIPT_DIR}/use-cassandra"
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "SKIP - yq is not installed; use-cassandra reads the version list with it"
+  exit 0
+fi
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+BIN="${SANDBOX}/bin"
+mkdir -p "$BIN"
+
+cat >"${BIN}/sudo" <<'SHIM'
+#!/bin/bash
+exec "$@"
+SHIM
+
+# Record the alternatives switches so a test can assert which JDK was selected.
+for tool in update-java-alternatives update-alternatives; do
+  cat >"${BIN}/${tool}" <<SHIM
+#!/bin/bash
+echo "${tool} \$*" >> "${SANDBOX}/alternatives.log"
+SHIM
+done
+
+# The sandbox has no cassandra user/group.
+cat >"${BIN}/chown" <<'SHIM'
+#!/bin/bash
+exit 0
+SHIM
+
+# The script maps the node's architecture; nodes are Linux, so report what one reports.
+cat >"${BIN}/uname" <<'SHIM'
+#!/bin/bash
+if [[ "${1:-}" == "-m" ]]; then echo x86_64; else exec /usr/bin/uname "$@"; fi
+SHIM
+
+chmod +x "${BIN}"/*
+export PATH="${BIN}:${PATH}"
+
+export CASSANDRA_INSTALL_DIR="${SANDBOX}/cassandra"
+export CASSANDRA_CONF_LINK="${SANDBOX}/etc-cassandra"
+export CASSANDRA_VERSIONS="${SANDBOX}/cassandra_versions.yaml"
+export PYTHON_BIN_DIR="${SANDBOX}/pybin"
+
+mkdir -p "${CASSANDRA_INSTALL_DIR}/5.0/conf" "$PYTHON_BIN_DIR"
+touch "${PYTHON_BIN_DIR}/python3.11"
+cat >"$CASSANDRA_VERSIONS" <<'YAMLFIXTURE'
+- version: "5.0"
+  java: "11"
+  python: "3.11.9"
+YAMLFIXTURE
+
+tests_run=0
+tests_failed=0
+
+pass() {
+  tests_run=$((tests_run + 1))
+  echo "ok   - $1"
+}
+
+fail() {
+  tests_run=$((tests_run + 1))
+  tests_failed=$((tests_failed + 1))
+  echo "FAIL - $1"
+}
+
+run_script() {
+  rm -f "${SANDBOX}/alternatives.log"
+  OUTPUT="$(bash "$SCRIPT" "$@" 2>&1)"
+  STATUS=$?
+}
+
+# --- an uninstalled version is refused before anything is changed ------------
+run_script 9.9
+if [[ "$STATUS" -eq 0 ]]; then
+  fail "an uninstalled version should exit non-zero"
+else
+  pass "an uninstalled version exits non-zero"
+fi
+
+if [[ "$OUTPUT" == *"is not installed on this node"* ]]; then
+  pass "an uninstalled version says so plainly"
+else
+  fail "expected a not-installed message, got: ${OUTPUT}"
+fi
+
+if [[ "$OUTPUT" == *"cassandra install 9.9"* ]]; then
+  pass "an uninstalled version points at 'cassandra install'"
+else
+  fail "expected the install hint, got: ${OUTPUT}"
+fi
+
+if [[ "$OUTPUT" == *"5.0"* ]]; then
+  pass "an uninstalled version lists what the node does have"
+else
+  fail "expected the installed versions to be listed, got: ${OUTPUT}"
+fi
+
+if [[ -e "${CASSANDRA_INSTALL_DIR}/current" ]]; then
+  fail "a refused version must not leave a dangling 'current' symlink"
+else
+  pass "a refused version leaves no dangling symlink"
+fi
+
+if [[ -f "${SANDBOX}/alternatives.log" ]]; then
+  fail "a refused version must not switch the node's java or python"
+else
+  pass "a refused version switches nothing"
+fi
+
+# --- an installed version is selected ----------------------------------------
+run_script 5.0
+if [[ "$STATUS" -eq 0 ]]; then
+  pass "an installed version exits 0"
+else
+  fail "an installed version should exit 0, got ${STATUS}: ${OUTPUT}"
+fi
+
+if [[ "$(readlink "${CASSANDRA_INSTALL_DIR}/current")" == "${CASSANDRA_INSTALL_DIR}/5.0" ]]; then
+  pass "an installed version becomes 'current'"
+else
+  fail "expected current -> 5.0, got $(readlink "${CASSANDRA_INSTALL_DIR}/current")"
+fi
+
+if [[ "$(readlink "$CASSANDRA_CONF_LINK")" == "${CASSANDRA_INSTALL_DIR}/5.0/conf" ]]; then
+  pass "the conf symlink follows the selected version"
+else
+  fail "expected the conf link to point at 5.0/conf, got $(readlink "$CASSANDRA_CONF_LINK")"
+fi
+
+if grep -q "update-java-alternatives -s java-1.11.0-openjdk" "${SANDBOX}/alternatives.log"; then
+  pass "the JDK declared for the version is selected"
+else
+  fail "expected JDK 11 to be selected, got: $(cat "${SANDBOX}/alternatives.log")"
+fi
+
+# --- switching away updates 'current' ----------------------------------------
+mkdir -p "${CASSANDRA_INSTALL_DIR}/4.1/conf"
+cat >"$CASSANDRA_VERSIONS" <<'YAMLFIXTURE'
+- version: "5.0"
+  java: "11"
+  python: "3.11.9"
+- version: "4.1"
+  java: "11"
+  python: "3.11.9"
+YAMLFIXTURE
+run_script 4.1
+if [[ "$(readlink "${CASSANDRA_INSTALL_DIR}/current")" == "${CASSANDRA_INSTALL_DIR}/4.1" ]]; then
+  pass "selecting another installed version moves 'current'"
+else
+  fail "expected current -> 4.1, got $(readlink "${CASSANDRA_INSTALL_DIR}/current")"
+fi
+
+echo
+echo "${tests_run} tests, ${tests_failed} failed"
+[[ "$tests_failed" -eq 0 ]]

--- a/packer/cassandra/cassandra.in.sh
+++ b/packer/cassandra/cassandra.in.sh
@@ -4,16 +4,34 @@
 
 ### This is automatically appended to the end of every cassandra.in.sh
 
+# Agent selection helpers. Pure functions, unit tested in packer/cassandra/lib.
+ECL_AGENTS_LIB="/usr/local/lib/edl-cassandra-agents.sh"
+if [ -f "$ECL_AGENTS_LIB" ]; then
+    # shellcheck disable=SC1090
+    . "$ECL_AGENTS_LIB"
+else
+    echo "ERROR: $ECL_AGENTS_LIB is missing; Cassandra will start with NO metrics agent" >&2
+fi
+
 # Extract Cassandra version from jar filename
 ECL_CASSANDRA_JAR=$(find /usr/local/cassandra/current/ -name "apache-cassandra-[0-9]*.jar" | head -n 1)
-if [ -n "$ECL_CASSANDRA_JAR" ]; then
-    # Extract X.Y.Z from filename and then get X.Y
-    ECL_CASSANDRA_VERSION=$(basename "$ECL_CASSANDRA_JAR" | sed -E 's/apache-cassandra-([0-9]+\.[0-9]+)\.[0-9]+\.jar/\1/')
-    export ECL_CASSANDRA_VERSION
-else
+if [ -z "$ECL_CASSANDRA_JAR" ]; then
     echo "ERROR: Could not determine Cassandra version" >&2
     exit 1
 fi
+
+# An unrecognised jar name leaves ECL_CASSANDRA_VERSION empty and says so. It must never carry the
+# raw filename forward: that is what used to match no agent case and start Cassandra silently
+# without a metrics agent.
+ECL_CASSANDRA_VERSION=""
+if command -v edl_cassandra_version_from_jar >/dev/null 2>&1; then
+    ECL_CASSANDRA_VERSION=$(edl_cassandra_version_from_jar "$ECL_CASSANDRA_JAR") || ECL_CASSANDRA_VERSION=""
+fi
+if [ -z "$ECL_CASSANDRA_VERSION" ]; then
+    echo "ERROR: could not read a Cassandra X.Y release from $(basename "$ECL_CASSANDRA_JAR")." >&2
+    echo "ERROR: no agent can be selected, so this node will report NO Cassandra metrics." >&2
+fi
+export ECL_CASSANDRA_VERSION
 
 # Extract Java version
 ECL_JAVA_VERSION_OUTPUT=$(java -version 2>&1 | head -n 1)
@@ -26,48 +44,22 @@ else
     exit 1
 fi
 
-# Set AXONOPS_AGENT based on Cassandra and Java versions
+# AxonOps agent. AxonOps ships no agent for 5.1 and later, so most of the time this deliberately
+# selects nothing - but it says which release it skipped rather than going quiet.
 AXONOPS_AGENT=""
-case "$ECL_CASSANDRA_VERSION" in
-    "3.0")
-        AXONOPS_AGENT="3.0-agent"
-        ;;
-    "3.11")
-        AXONOPS_AGENT="3.11-agent"
-        ;;
-    "4.0")
-        if [ "$ECL_JAVA_VERSION" = "8" ] || [ "$ECL_JAVA_VERSION" = "1.8" ]; then
-            AXONOPS_AGENT="4.0-agent-jdk8"
-        else
-            AXONOPS_AGENT="4.0-agent"
-        fi
-        ;;
-    "4.1")
-        if [ "$ECL_JAVA_VERSION" = "8" ] || [ "$ECL_JAVA_VERSION" = "1.8" ]; then
-            AXONOPS_AGENT="4.1-agent-jdk8"
-        else
-            AXONOPS_AGENT="4.1-agent"
-        fi
-        ;;
-    "5.0")
-        if [ "$ECL_JAVA_VERSION" = "11" ]; then
-            AXONOPS_AGENT="5.0-agent-jdk11"
-        elif [ "$ECL_JAVA_VERSION" = "17" ]; then
-            AXONOPS_AGENT="5.0-agent-jdk17"
-        fi
-        ;;
-    "5.1"|"6.0")
-        # No agent for these versions
-        AXONOPS_AGENT=""
-        ;;
-esac
+if [ -n "$ECL_CASSANDRA_VERSION" ]; then
+    AXONOPS_AGENT=$(edl_axonops_agent_for "$ECL_CASSANDRA_VERSION" "$ECL_JAVA_VERSION") || AXONOPS_AGENT=""
+    if [ -z "$AXONOPS_AGENT" ]; then
+        echo "NOTE: no AxonOps agent is published for Cassandra ${ECL_CASSANDRA_VERSION} on JDK ${ECL_JAVA_VERSION}; skipping it" >&2
+    fi
+fi
 
 # Configure JVM_EXTRA_OPTS with agent if applicable.
 # The install dir is named after the full agent version (e.g. 5.0-agent-jdk11),
 # but the jar inside is always axon-cassandra<X.Y>-agent.jar (no jdk suffix),
 # so resolve it by glob rather than assuming the name matches the directory.
 if [ -n "$AXONOPS_AGENT" ]; then
-    ECL_AGENT_JAR=$(find "/usr/share/axonops/${AXONOPS_AGENT}/lib" -maxdepth 1 -name 'axon-cassandra*.jar' 2>/dev/null | head -n 1)
+    ECL_AGENT_JAR=$(find "${EDL_AXONOPS_BASE:-/usr/share/axonops}/${AXONOPS_AGENT}/lib" -maxdepth 1 -name 'axon-cassandra*.jar' 2>/dev/null | head -n 1)
     if [ -f "$ECL_AGENT_JAR" ]; then
         export JVM_EXTRA_OPTS="-javaagent:${ECL_AGENT_JAR}=/etc/axonops/axon-agent.yml"
     else
@@ -75,27 +67,43 @@ if [ -n "$AXONOPS_AGENT" ]; then
     fi
 fi
 
-# MAAC (Management API for Apache Cassandra) metrics agent
-# Exposes Cassandra metrics as Prometheus endpoint on port 9000
+# MCAC/MAAC (Management API for Apache Cassandra) metrics agent.
+# Exposes Cassandra metrics as a Prometheus endpoint on port 9000, which the node's OTel collector
+# scrapes. Every path below reports what it did: a node with no metrics agent is a node whose
+# Cassandra metrics never reach VictoriaMetrics, and that must not happen quietly.
 MAAC_AGENT_JAR=""
-case "$ECL_CASSANDRA_VERSION" in
-    "4.0")
-        MAAC_AGENT_JAR="/opt/management-api/4.0/datastax-mgmtapi-agent.jar"
-        ;;
-    "4.1")
-        MAAC_AGENT_JAR="/opt/management-api/4.1/datastax-mgmtapi-agent.jar"
-        ;;
-    "5.0")
-        MAAC_AGENT_JAR="/opt/management-api/5.0/datastax-mgmtapi-agent.jar"
-        ;;
-esac
+if [ -n "$ECL_CASSANDRA_VERSION" ]; then
+    MAAC_AGENT_JAR=$(edl_maac_agent_jar_for "$ECL_CASSANDRA_VERSION") || MAAC_AGENT_JAR=""
+    if [ -z "$MAAC_AGENT_JAR" ]; then
+        echo "WARNING: no MCAC metrics agent is installed for Cassandra ${ECL_CASSANDRA_VERSION};" >&2
+        echo "WARNING: this node will report NO Cassandra metrics. Add it in packer/cassandra/install/install_maac.sh." >&2
+    fi
+fi
 
-if [ -n "$MAAC_AGENT_JAR" ] && [ -f "$MAAC_AGENT_JAR" ]; then
-    export MAAC_PATH="/opt/management-api"
-    export POD_NAME=$(hostname)
-    export JVM_OPTS="$JVM_OPTS -javaagent:${MAAC_AGENT_JAR}"
-elif [ -n "$MAAC_AGENT_JAR" ]; then
-    echo "WARNING: MAAC agent jar not found at $MAAC_AGENT_JAR" >&2
+if [ -n "$MAAC_AGENT_JAR" ]; then
+    if [ -f "$MAAC_AGENT_JAR" ]; then
+        export MAAC_PATH="${EDL_MAAC_BASE:-/opt/management-api}"
+        POD_NAME=$(hostname)
+        export POD_NAME
+        export JVM_OPTS="$JVM_OPTS -javaagent:${MAAC_AGENT_JAR}"
+
+        # The agent's Prometheus endpoint is a Netty HTTP server, but netty-codec-http is
+        # `provided` in the agent build and is not bundled in the agent jar. Cassandra 4.x shipped
+        # a fat netty-all that happened to contain it; 5.0 and later ship granular netty modules
+        # plus an empty netty-all aggregator that does not, so the endpoint dies with
+        # NoClassDefFoundError io/netty/handler/codec/http/HttpServerCodec and the node reports
+        # nothing. install-cassandra-version puts the matching jar in the release's lib directory;
+        # check it is there rather than discovering it in a stack trace.
+        ECL_CASSANDRA_LIB="${CASSANDRA_HOME:-/usr/local/cassandra/current}/lib"
+        if ! ls "${ECL_CASSANDRA_LIB}"/netty-codec-http-*.jar >/dev/null 2>&1 \
+           && [ -z "$(find "$ECL_CASSANDRA_LIB" -maxdepth 1 -name 'netty-all-*.jar' -size +1M 2>/dev/null)" ]; then
+            echo "WARNING: no netty-codec-http jar in ${ECL_CASSANDRA_LIB};" >&2
+            echo "WARNING: the MCAC metrics endpoint cannot start, so this node will report NO Cassandra metrics." >&2
+        fi
+    else
+        echo "WARNING: MCAC metrics agent jar not found at $MAAC_AGENT_JAR;" >&2
+        echo "WARNING: this node will report NO Cassandra metrics." >&2
+    fi
 fi
 
 # Set log directory based on user

--- a/packer/cassandra/cassandra.pkr.hcl
+++ b/packer/cassandra/cassandra.pkr.hcl
@@ -197,6 +197,12 @@ build {
     destination = "/tmp/cassandra.in.sh"
   }
 
+  # Sourced by cassandra.in.sh on every Cassandra start to pick the AxonOps and MCAC agents.
+  provisioner "file" {
+    source = "lib/edl-cassandra-agents.sh"
+    destination = "/tmp/edl-cassandra-agents.sh"
+  }
+
   provisioner "shell" {
     environment_vars = [
       # we need this to be set because install_cassandra checks for it and exits if it's not there

--- a/packer/cassandra/cassandra.pkr.hcl
+++ b/packer/cassandra/cassandra.pkr.hcl
@@ -152,6 +152,7 @@ build {
   }
   provisioner "shell" {
     inline = [
+      "rm -fv bin-cassandra/*.test.sh",
       "sudo mv -v bin-cassandra/* /usr/local/bin/",
       # Test scripts live next to the script under test but have no business on a node.
       "sudo rm -f /usr/local/bin/*.test.sh",

--- a/packer/cassandra/install/install_cassandra.sh
+++ b/packer/cassandra/install/install_cassandra.sh
@@ -1,73 +1,56 @@
 #!/bin/bash
+#
+# Bake-time driver: global one-time node setup, then install every version declared in
+# /etc/cassandra_versions.yaml by calling install-cassandra-version - the same script
+# `easy-db-lab cassandra install` runs at runtime, so there is one install code path.
 
 ####################################################################
 ##### THE HEADER OF THIS FILE SHOULD BE SHELL FUNCTIONS ONLY #######
 ### THE INTENT IS TO SAFELY SOURCE THE FILE WITHOUT SIDE EFFECTS ###
 ####################################################################
 
-## Downloads the latest patch release of a cassandra version
-## This saves us from having to update cassandra_versions.yaml
-## every time a new patch release is made
-download_cassandra_version() {
-    # Check if version prefix is provided
-    if [ -z "$1" ]; then
-        echo "Usage: download_cassandra_version <version-prefix>"
-        return 1
-    fi
+# Version metadata is read from this file; overridable so the functions above can be tested.
+YAML=${YAML:-/etc/cassandra_versions.yaml}
 
-    # Assign the version prefix from the first argument
-    version_prefix="$1"
+## Reads one field of a version's entry, returning an empty string when unset.
+## Usage: version_field <version> <field>
+version_field() {
+  local version="$1" field="$2"
+  export version
+  yq ".[] | select(.version == env(version)) | .$field // \"\"" "$YAML"
+}
 
-    # Get the list of versions from the Cassandra download page
-    versions=$(curl -s https://dlcdn.apache.org/cassandra/ | grep -o 'href="[0-9]\+\.[0-9]\+\.[0-9]\+/\"' | sed 's/href="//' | sed 's/\/"//')
+## True when a version is declared but deliberately not baked into the AMI.
+version_is_lazy() {
+  local version="$1"
+  export version
+  [ "$(yq '.[] | select(.version == env(version)) | .lazy // false' "$YAML")" = "true" ]
+}
 
-    # Find the latest version that matches the given prefix
-    full_version=$(echo "$versions" | grep "^$version_prefix" | sort -V | tail -n 1)
+## Builds the install-cassandra-version argument list for a version into INSTALL_ARGS.
+## An array, not a string: ant_flags can contain spaces that must stay one argument.
+version_install_args() {
+  local version="$1"
+  INSTALL_ARGS=("$version")
 
-    # Check if a version was found
-    if [ -z "$full_version" ]; then
-        echo "ERROR: No matching version found for prefix $version_prefix"
-        return 1
-    fi
-
-    # Construct the download URL
-    archive="apache-cassandra-$full_version-bin.tar.gz"
-    download_url="https://dlcdn.apache.org/cassandra/$full_version/$archive"
-
-    # Download the file (via S3 cache, keyed by the resolved patch version)
-    echo "Downloading Cassandra version $full_version from $download_url..."
-    cached_fetch "$download_url" "cassandra-dist/$full_version/$archive" "$archive" || {
-        echo "ERROR: Failed to download Cassandra version $full_version from $download_url"
-        return 1
-    }
-
-    # Verify download was successful and file is not empty
-    if [[ ! -f "$archive" || ! -s "$archive" ]]; then
-        echo "ERROR: Downloaded file $archive is missing or empty for version $full_version"
-        return 1
-    fi
-
-    echo "Download completed successfully."
-
-    # Extract the archive (quiet: verbose file listing floods packer's SSH stream and drops it)
-    tar zxf "$archive" || {
-        echo "ERROR: Failed to extract $archive for version $full_version"
-        return 1
-    }
-
-    # Move and verify
-    mv "apache-cassandra-$full_version" "$version_prefix" || {
-        echo "ERROR: Failed to rename apache-cassandra-$full_version to $version_prefix"
-        return 1
-    }
-
-    # Verify the directory exists
-    if [[ ! -d "$version_prefix" ]]; then
-        echo "ERROR: Directory $version_prefix does not exist after extraction and rename"
-        return 1
-    fi
-
-    return 0
+  local url branch java ant_flags
+  url=$(version_field "$version" url)
+  if [ -n "$url" ]; then
+    INSTALL_ARGS+=(--url "$url")
+  fi
+  branch=$(version_field "$version" branch)
+  if [ -n "$branch" ]; then
+    INSTALL_ARGS+=(--branch "$branch")
+  fi
+  java=$(version_field "$version" java)
+  if [ -n "$java" ]; then
+    INSTALL_ARGS+=(--java "$java")
+  fi
+  ant_flags=$(version_field "$version" ant_flags)
+  if [ -n "$ant_flags" ]; then
+    INSTALL_ARGS+=(--ant-flags "$ant_flags")
+  fi
+  return 0
 }
 
 ####################################################################
@@ -77,7 +60,7 @@ download_cassandra_version() {
 ####################################################################
 
 ## exit unless INSTALL_CASSANDRA=1
-if [ -z "$INSTALL_CASSANDRA" ]; then
+if [ -z "${INSTALL_CASSANDRA:-}" ]; then
     echo "INSTALL_CASSANDRA is not set, exiting."
     return
     exit 0
@@ -87,21 +70,11 @@ fi
 set -euo pipefail
 set -x
 
-# Shared S3 download cache (provides cached_fetch, used by download_cassandra_version above).
-# Falls back to a direct download when the cache lib is absent (local script tests / no cache).
-if [ -f /usr/local/lib/edl-cache.sh ]; then
-    # shellcheck disable=SC1091
-    source /usr/local/lib/edl-cache.sh
-else
-    cached_fetch() { echo "no S3 cache; downloading $1"; curl -fsSL --retry 3 "$1" -o "$3"; }
-fi
-
 # Trap errors and report line number
 trap 'echo "ERROR: Installation failed at line $LINENO with exit code $?" >&2; exit 1' ERR
 
 # creating cassandra user with UID 999 to match the cassandra-sidecar container image
 sudo useradd -m -u 999 cassandra
-mkdir cassandra
 
 sudo mkdir -p /usr/local/cassandra
 sudo mkdir -p /mnt/db1/cassandra/logs
@@ -117,204 +90,40 @@ sudo update-java-alternatives -s "java-1.11.0-openjdk-$(dpkg --print-architectur
 
 lsblk
 
-# Change to cassandra directory with error checking
-cd cassandra || {
-    echo "ERROR: Cannot change to cassandra directory"
-    exit 1
-}
+# Every installed version gets this appended to its bin/cassandra.in.sh. Packer drops it in /tmp,
+# which does not survive a reboot - install it durably so a runtime `cassandra install` finds it.
+sudo install -D -m 0644 /tmp/cassandra.in.sh /usr/local/share/easy-db-lab/cassandra.in.sh
 
-YAML=/etc/cassandra_versions.yaml
 VERSIONS=$(yq '.[].version' "$YAML")
 echo "Installing versions: $VERSIONS"
 
-## Installs a single Cassandra version end-to-end: download (or git build), place under
-## /usr/local/cassandra/$version, and apply the per-version configuration.
-##
-## Safe to run as a background job: it operates in its own private temp working directory
-## (so concurrent versions never share extraction state, e.g. the `find . -name '*cassandra*'`
-## below only ever sees its own tarball) and otherwise writes only version-specific paths.
-## Genuinely shared/global steps (user + directory creation, update-java-alternatives, the
-## Maven cache cleanup) are kept serial outside this function.
-install_cassandra_version() {
-  local version="$1"
-  # yq's env(version) reads this from the environment; the export stays isolated to this
-  # subshell when the function is backgrounded, so parallel versions never clobber each other.
-  export version
-
-  local workdir
-  workdir=$(mktemp -d) || {
-      echo "ERROR: Failed to create temp working directory for version $version"
-      return 1
-  }
-  cd "$workdir" || {
-      echo "ERROR: Cannot change to working directory $workdir for version $version"
-      return 1
-  }
-
-  echo "Configuring version: $version"
-
-  local URL BRANCH
-  URL=$(yq '.[] | select(.version == env(version)) | .url // ""' "$YAML")
-  echo "$URL"
-  BRANCH=$(yq '.[] | select(.version == env(version)) | .branch // ""' "$YAML")
-
-  # if $version is set, $URL is blank, and $BRANCH is blank
-  if [[ $version != "" && $URL == "" && $BRANCH == "" ]]; then
-    download_cassandra_version "$version" || {
-        echo "ERROR: download_cassandra_version failed for version $version"
-        return 1
-    }
-
-    # check if $version exists in the current directory
-    if [[ ! -d $version ]]; then
-      echo "ERROR: Failed to download Cassandra version $version - directory not found"
-      return 1
-    fi
-
-    sudo mv "$version" "/usr/local/cassandra/$version" || {
-        echo "ERROR: Failed to move $version to /usr/local/cassandra/"
-        return 1
-    }
-
-  # if a URL is set and ends in .tar.gz, download it (via the S3 cache, version-keyed)
-  elif [[ $URL == *.tar.gz ]]; then
-    echo "Downloading $URL for version $version"
-
-    local archive_file
-    archive_file=$(basename "$URL")
-
-    # Route the nightly tarball through the S3 download cache (keyed by version) so it is not
-    # re-fetched cold from GitHub on every build. cached_fetch falls back to a direct download
-    # when no cache bucket is configured (local packer Docker tests).
-    cached_fetch "$URL" "cassandra-dist/$version/$archive_file" "$archive_file" || {
-        echo "ERROR: Failed to download version $version from $URL"
-        return 1
-    }
-
-    # Verify download succeeded and file is not empty
-    if [[ ! -f "$archive_file" || ! -s "$archive_file" ]]; then
-        echo "ERROR: Downloaded file $archive_file is missing or empty for version $version"
-        return 1
-    fi
-
-    echo "Extracting $archive_file"
-    tar zxf "$archive_file" || {
-        echo "ERROR: Failed to extract $archive_file for version $version"
-        return 1
-    }
-
-    rm -f "$archive_file"
-
-    # Find the extracted directory (should be the only directory created)
-    # Look for directories starting with 'apache-cassandra' or 'cassandra'
-    local f
-    f=$(find . -maxdepth 1 -type d -name '*cassandra*' ! -name '.' -printf '%f\n' | head -n 1)
-
-    # Verify extracted directory exists
-    if [[ -z "$f" || ! -d "$f" ]]; then
-        echo "ERROR: Could not find extracted Cassandra directory for version $version"
-        echo "Available directories:"
-        ls -la
-        return 1
-    fi
-
-    echo "Found extracted directory: $f"
-
-    sudo mv "$f" "/usr/local/cassandra/$version" || {
-        echo "ERROR: Failed to move $f to /usr/local/cassandra/$version"
-        return 1
-    }
-
-  else
-    # Clone the git repos specified in the yaml file (ending in .git)
-    # Use the directory name of the version field as the dir name
-    # as the directory to clone into
-    # checkout the branch specified in the yaml file
-    # do a build and create the tar.gz
-    local ANT_FLAGS
-    ANT_FLAGS=$(yq '.[] | select(.version == env(version)) | .ant_flags // ""' "$YAML")
-    # all builds work with JDK 11 for now
-
-    echo "Cloning repo for version $version from $URL branch $BRANCH"
-    git clone --depth=1 --single-branch --branch "$BRANCH" "$URL" "$version" || {
-        echo "ERROR: Git clone failed for version $version from $URL branch $BRANCH"
-        return 1
-    }
-
-    # Verify clone was successful
-    if [[ ! -d "$version/.git" ]]; then
-        echo "ERROR: Git clone incomplete for version $version - .git directory not found"
-        return 1
-    fi
-
-    echo "Building version $version with ant"
-    # Per-version build log so concurrent builds do not clobber a shared file.
-    local ant_log="/tmp/ant-build-$version.log"
-    (
-      cd "$version" || exit 1
-      # Quiet: ant output is voluminous and floods packer's SSH stream
-      # shellcheck disable=SC2086
-      ant realclean >"$ant_log" 2>&1 && ant -Dno-checkstyle=true $ANT_FLAGS >>"$ant_log" 2>&1 || exit 1
-      rm -rf .git
-    ) || {
-        echo "ERROR: Ant build failed for version $version"
-        return 1
-    }
-
-    sudo mv "$version" "/usr/local/cassandra/$version" || {
-        echo "ERROR: Failed to move built version $version to /usr/local/cassandra/"
-        return 1
-    }
-  fi
-
-  # Verify the version was successfully moved to /usr/local/cassandra/
-  if [[ ! -d "/usr/local/cassandra/$version" ]]; then
-      echo "ERROR: Version $version not found in /usr/local/cassandra/ after installation"
-      return 1
-  fi
-
-  # at this point the $version is in place, however it was installed
-  # do any general customizations in the below subshell
-  echo "Configuring version $version"
-  (
-      cd "/usr/local/cassandra/$version" || exit 1
-      rm -rf data
-      cp -R conf conf.orig
-      # create a pristine backup of the original conf
-      sudo cp conf/cassandra.yaml conf/cassandra.orig.yaml
-      cat /tmp/cassandra.in.sh >> bin/cassandra.in.sh
-  ) || {
-      echo "ERROR: Configuration failed for version $version"
-      return 1
-  }
-
-  # Remove bundled cqlsh from Cassandra 2.x and 3.x to use uv-installed version
-  if [[ "$version" == 2.* || "$version" == 3.* ]]; then
-    echo "Removing bundled cqlsh from Cassandra $version (using uv-installed version instead)"
-    rm -f "/usr/local/cassandra/$version/bin/cqlsh"
-    rm -f "/usr/local/cassandra/$version/bin/cqlsh.py"
-  fi
-
-  cd / && rm -rf "$workdir"
-
-  echo "✓ Successfully installed and configured version $version"
-}
-
-# Install every version concurrently. Each job runs in its own temp working directory and
-# writes only version-specific paths, so the fan-out is parallel-safe. The shared/global
-# setup above (user + directory creation, update-java-alternatives) already ran serially.
+# Install every version concurrently. install-cassandra-version runs in its own temp working
+# directory and writes only version-specific paths, so the fan-out is parallel-safe. The
+# shared/global setup above (user + directory creation, update-java-alternatives) already ran
+# serially.
 loop_start=$(date +%s)
 echo "Starting Cassandra version install loop at epoch $loop_start"
 
 declare -A version_pids=()
 declare -A version_logs=()
+installed_versions=()
 
 for version in $VERSIONS; do
+  # A lazy version is declared but not baked: it ships in /etc/cassandra_versions.yaml so it is
+  # discoverable and installable at runtime, costing nothing at AMI build time.
+  if version_is_lazy "$version"; then
+    echo "Skipping lazy version $version - install it at runtime with 'easy-db-lab cassandra install $version'"
+    continue
+  fi
+
+  version_install_args "$version"
+
   log="/tmp/cassandra-install-${version}.log"
   version_logs["$version"]="$log"
+  installed_versions+=("$version")
   # Capture each version's output (incl. set -x trace) to its own log so parallel jobs do
   # not interleave; the logs are replayed serially below for readable success/failure output.
-  install_cassandra_version "$version" >"$log" 2>&1 &
+  install-cassandra-version "${INSTALL_ARGS[@]}" >"$log" 2>&1 &
   version_pids["$version"]=$!
 done
 
@@ -343,10 +152,10 @@ fi
 # shared/global state (HOME), so it is kept out of the parallel fan-out.
 rm -rf ~/.m2 || true
 
-# Final verification - ensure all versions are installed
+# Final verification - ensure all non-lazy versions are installed
 echo ""
 echo "Verifying all versions were installed successfully..."
-for version in $VERSIONS; do
+for version in "${installed_versions[@]}"; do
     if [[ ! -d "/usr/local/cassandra/$version" ]]; then
         echo "ERROR: Final verification failed - version $version not found in /usr/local/cassandra/"
         exit 1
@@ -357,5 +166,4 @@ done
 echo ""
 echo "All Cassandra versions installed and verified successfully!"
 
-#rm -rf cassandra
 sudo chown -R cassandra:cassandra /usr/local/cassandra

--- a/packer/cassandra/install/install_cassandra.sh
+++ b/packer/cassandra/install/install_cassandra.sh
@@ -94,6 +94,10 @@ lsblk
 # which does not survive a reboot - install it durably so a runtime `cassandra install` finds it.
 sudo install -D -m 0644 /tmp/cassandra.in.sh /usr/local/share/easy-db-lab/cassandra.in.sh
 
+# The agent selection helpers that snippet sources on every Cassandra start. Same reason it cannot
+# live in /tmp: a runtime `cassandra install` has to find it long after the bake.
+sudo install -D -m 0644 /tmp/edl-cassandra-agents.sh /usr/local/lib/edl-cassandra-agents.sh
+
 VERSIONS=$(yq '.[].version' "$YAML")
 echo "Installing versions: $VERSIONS"
 

--- a/packer/cassandra/install/install_cassandra.test.sh
+++ b/packer/cassandra/install/install_cassandra.test.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# Unit tests for the bake-time loop's version resolution in install_cassandra.sh — which flags
+# each declared version turns into, and which versions are skipped entirely.
+#
+# install_cassandra.sh returns immediately when INSTALL_CASSANDRA is unset, so sourcing it gives
+# the functions with none of the effects. No network, no Docker, no root.
+#
+# Run directly:  ./install_cassandra.test.sh
+# Or via gradle: ./gradlew testCassandraInstallLoop
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "SKIP - yq is not installed; the bake loop's version resolution needs it"
+  exit 0
+fi
+
+FIXTURE_DIR="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+export YAML="${FIXTURE_DIR}/cassandra_versions.yaml"
+cat >"$YAML" <<'YAMLFIXTURE'
+- version: "5.0"
+  java: "11"
+  python: "3.11.9"
+
+- version: "4.0"
+  java: "11"
+  python: "3.11.9"
+  ant_flags: "-Duse.jdk11=true -Dno.tests=true"
+
+- version: "nightly"
+  url: https://example.com/apache-cassandra-nightly-bin.tar.gz
+  java: "21"
+  python: "3.11.9"
+
+- version: "cep-45"
+  url: https://github.com/apache/cassandra.git
+  branch: cep-45
+  java: "17"
+  python: "3.11.9"
+  lazy: true
+YAMLFIXTURE
+
+# shellcheck source=packer/cassandra/install/install_cassandra.sh
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/install_cassandra.sh"
+
+tests_run=0
+tests_failed=0
+
+pass() {
+  tests_run=$((tests_run + 1))
+  echo "ok   - $1"
+}
+
+fail() {
+  tests_run=$((tests_run + 1))
+  tests_failed=$((tests_failed + 1))
+  echo "FAIL - $1"
+}
+
+# Asserts the flags a version resolves to, compared as a single space-joined string.
+assert_args() {
+  local desc="$1" version="$2" expected="$3"
+  version_install_args "$version"
+  local actual="${INSTALL_ARGS[*]}"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$desc"
+  else
+    fail "$desc: expected [$expected], got [$actual]"
+  fi
+}
+
+assert_lazy() {
+  local desc="$1" version="$2"
+  if version_is_lazy "$version"; then pass "$desc"; else fail "$desc: expected lazy"; fi
+}
+
+assert_not_lazy() {
+  local desc="$1" version="$2"
+  if version_is_lazy "$version"; then fail "$desc: expected not lazy"; else pass "$desc"; fi
+}
+
+# --- an official release carries only its JDK ---------------------------------
+assert_args "official release resolves to version + java" 5.0 "5.0 --java 11"
+
+# --- ant flags with spaces stay one argument ----------------------------------
+version_install_args 4.0
+if [[ "${#INSTALL_ARGS[@]}" -eq 5 && "${INSTALL_ARGS[4]}" == "-Duse.jdk11=true -Dno.tests=true" ]]; then
+  pass "multi-word ant_flags stays a single argument"
+else
+  fail "multi-word ant_flags split into ${#INSTALL_ARGS[@]} args: ${INSTALL_ARGS[*]}"
+fi
+
+# --- tarball and git-branch entries both round-trip their fields --------------
+assert_args "tarball entry resolves its url" nightly \
+  "nightly --url https://example.com/apache-cassandra-nightly-bin.tar.gz --java 21"
+assert_args "git-branch entry resolves url and branch" cep-45 \
+  "cep-45 --url https://github.com/apache/cassandra.git --branch cep-45 --java 17"
+
+# --- lazy entries are skipped at bake time, others are not --------------------
+assert_lazy "a lazy entry is skipped at bake time" cep-45
+assert_not_lazy "an ordinary entry is not skipped" 5.0
+assert_not_lazy "a tarball entry is not skipped" nightly
+
+# --- sourcing must not have run any of the install work ----------------------
+if [[ -d /usr/local/cassandra/cep-45 ]]; then
+  fail "sourcing install_cassandra.sh installed something"
+else
+  pass "sourcing install_cassandra.sh has no side effects"
+fi
+
+echo
+echo "${tests_run} tests, ${tests_failed} failed"
+[[ "$tests_failed" -eq 0 ]]

--- a/packer/cassandra/install/install_maac.sh
+++ b/packer/cassandra/install/install_maac.sh
@@ -3,12 +3,24 @@
 # Downloads version-specific JARs that expose Cassandra metrics as Prometheus endpoint on port 9000
 set -euo pipefail
 
-MAAC_VERSION="0.1.113"
+MAAC_VERSION="0.1.125"
 MAAC_URL="https://github.com/k8ssandra/management-api-for-apache-cassandra/releases/download/v${MAAC_VERSION}/jars.zip"
 MAAC_BASE="/opt/management-api"
-TEMP_DIR=$(mktemp -d)
 
-echo "Downloading MAAC agent v${MAAC_VERSION}..."
+# The 6.0 agent is not in the release's jars.zip. Upstream builds management-api-agent-6.0.x only
+# under its `trunk` maven profile, against a cassandra-all SNAPSHOT that is published nowhere, so
+# the released zip contains 4.x, 4.1.x and 5.0.x only. The built jar does ship - in k8ssandra's
+# own nightly container images - so that is where it is taken from. The same 6.0.x jar serves
+# Cassandra 6.0 and 7.0/trunk; upstream's own 7.0 nightly image ships exactly this jar.
+#
+# Pinned to a dated tag rather than -latest so a rebake is reproducible.
+MAAC_TRUNK_IMAGE="k8ssandra/cass-management-api"
+MAAC_TRUNK_TAG="6.0-nightly-20260820"
+MAAC_TRUNK_JAR_RE='^opt/management-api/datastax-mgmtapi-agent-6\.0\.x-.*\.jar$'
+
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
 # Use the shared S3 download cache when present; otherwise download directly (local script
 # tests, or no cache configured).
 if [ -f /usr/local/lib/edl-cache.sh ]; then
@@ -17,6 +29,74 @@ if [ -f /usr/local/lib/edl-cache.sh ]; then
 else
     cached_fetch() { echo "no S3 cache; downloading $1"; curl -fsSL --retry 3 "$1" -o "$3"; }
 fi
+EDL_S3_BUCKET="${EDL_S3_BUCKET:-}"
+
+# oci_extract_file <repo> <tag> <path-regex> <dest>
+#
+# Copies one file out of a linux/amd64 container image using the registry HTTP API only - no
+# docker, no containerd, no skopeo, none of which the build instance has. Layers are listed from
+# the image manifest and searched in order; the first one holding a matching path wins.
+oci_extract_file() {
+    local repo="$1" tag="$2" path_re="$3" dest="$4"
+    local accept token index digest manifest layer match work
+
+    accept="application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json"
+
+    token=$(curl -fsSL --retry 3 "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repo}:pull" | jq -r .token)
+    index=$(curl -fsSL --retry 3 -H "Authorization: Bearer ${token}" -H "Accept: ${accept}" \
+        "https://registry-1.docker.io/v2/${repo}/manifests/${tag}")
+
+    # A multi-arch index needs one more hop to the amd64 manifest; a single-arch manifest is
+    # already the thing with .layers on it.
+    digest=$(echo "$index" | jq -r '.manifests[]? | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest' | head -n 1)
+    if [ -n "$digest" ] && [ "$digest" != "null" ]; then
+        manifest=$(curl -fsSL --retry 3 -H "Authorization: Bearer ${token}" -H "Accept: ${accept}" \
+            "https://registry-1.docker.io/v2/${repo}/manifests/${digest}")
+    else
+        manifest="$index"
+    fi
+
+    work="${TEMP_DIR}/oci"
+    mkdir -p "$work"
+
+    for layer in $(echo "$manifest" | jq -r '.layers[].digest'); do
+        curl -fsSL --retry 3 -H "Authorization: Bearer ${token}" \
+            "https://registry-1.docker.io/v2/${repo}/blobs/${layer}" -o "${work}/layer.tgz"
+        match=$(tar -tzf "${work}/layer.tgz" 2>/dev/null | grep -E "$path_re" | head -n 1 || true)
+        if [ -n "$match" ]; then
+            tar -xzf "${work}/layer.tgz" -C "$work" "$match"
+            mv "${work}/${match}" "$dest"
+            rm -f "${work}/layer.tgz"
+            echo "extracted ${match} from ${repo}:${tag}"
+            return 0
+        fi
+        rm -f "${work}/layer.tgz"
+    done
+
+    echo "ERROR: no path matching ${path_re} in ${repo}:${tag}" >&2
+    return 1
+}
+
+# Same contract as cached_fetch, but the origin is a container image rather than a URL. The
+# extraction walks up to a few hundred MB of layers, so it is worth caching the 18MB result.
+cached_oci_extract() {
+    local repo="$1" tag="$2" path_re="$3" key="$4" dest="$5"
+    local s3="s3://${EDL_S3_BUCKET}/download-cache/${key}"
+
+    if [ -n "$EDL_S3_BUCKET" ] && aws s3 cp "$s3" "$dest" --no-progress 2>/dev/null; then
+        echo "cache hit:  $key"
+        return 0
+    fi
+
+    echo "cache miss: $key (extracting from ${repo}:${tag})"
+    oci_extract_file "$repo" "$tag" "$path_re" "$dest"
+
+    if [ -n "$EDL_S3_BUCKET" ]; then
+        aws s3 cp "$dest" "$s3" --no-progress 2>/dev/null || echo "WARN: failed to populate cache for $key"
+    fi
+}
+
+echo "Downloading MAAC agent v${MAAC_VERSION}..."
 cached_fetch "${MAAC_URL}" "maac/v${MAAC_VERSION}/jars.zip" "${TEMP_DIR}/jars.zip"
 
 echo "Extracting MAAC JARs..."
@@ -24,7 +104,7 @@ cd "${TEMP_DIR}"
 unzip -q jars.zip
 
 # Install version-specific agent JARs
-sudo mkdir -p "${MAAC_BASE}/4.0" "${MAAC_BASE}/4.1" "${MAAC_BASE}/5.0" "${MAAC_BASE}/configs"
+sudo mkdir -p "${MAAC_BASE}/4.0" "${MAAC_BASE}/4.1" "${MAAC_BASE}/5.0" "${MAAC_BASE}/6.0" "${MAAC_BASE}/7.0" "${MAAC_BASE}/configs"
 
 sudo cp "management-api-agent-4.x/target/datastax-mgmtapi-agent-4.x-${MAAC_VERSION}.jar" \
     "${MAAC_BASE}/4.0/datastax-mgmtapi-agent.jar"
@@ -34,6 +114,13 @@ sudo cp "management-api-agent-4.1.x/target/datastax-mgmtapi-agent-4.1.x-${MAAC_V
 
 sudo cp "management-api-agent-5.0.x/target/datastax-mgmtapi-agent-5.0.x-${MAAC_VERSION}.jar" \
     "${MAAC_BASE}/5.0/datastax-mgmtapi-agent.jar"
+
+echo "Extracting the 6.0 agent from ${MAAC_TRUNK_IMAGE}:${MAAC_TRUNK_TAG}..."
+cached_oci_extract "$MAAC_TRUNK_IMAGE" "$MAAC_TRUNK_TAG" "$MAAC_TRUNK_JAR_RE" \
+    "maac/${MAAC_TRUNK_TAG}/datastax-mgmtapi-agent-6.0.x.jar" "${TEMP_DIR}/agent-6.0.x.jar"
+
+sudo cp "${TEMP_DIR}/agent-6.0.x.jar" "${MAAC_BASE}/6.0/datastax-mgmtapi-agent.jar"
+sudo cp "${TEMP_DIR}/agent-6.0.x.jar" "${MAAC_BASE}/7.0/datastax-mgmtapi-agent.jar"
 
 # Create metrics collector config
 sudo tee "${MAAC_BASE}/configs/metrics-collector.yaml" > /dev/null <<'EOF'
@@ -45,11 +132,10 @@ EOF
 # Set ownership
 sudo chown -R cassandra: "${MAAC_BASE}"
 
-# Clean up
-rm -rf "${TEMP_DIR}"
-
 echo "MAAC agent v${MAAC_VERSION} installed successfully"
 echo "  4.0 JAR: ${MAAC_BASE}/4.0/datastax-mgmtapi-agent.jar"
 echo "  4.1 JAR: ${MAAC_BASE}/4.1/datastax-mgmtapi-agent.jar"
 echo "  5.0 JAR: ${MAAC_BASE}/5.0/datastax-mgmtapi-agent.jar"
+echo "  6.0 JAR: ${MAAC_BASE}/6.0/datastax-mgmtapi-agent.jar (from ${MAAC_TRUNK_IMAGE}:${MAAC_TRUNK_TAG})"
+echo "  7.0 JAR: ${MAAC_BASE}/7.0/datastax-mgmtapi-agent.jar (same 6.0.x agent, as upstream ships it)"
 echo "  Config:  ${MAAC_BASE}/configs/metrics-collector.yaml"

--- a/packer/cassandra/lib/edl-cassandra-agents.sh
+++ b/packer/cassandra/lib/edl-cassandra-agents.sh
@@ -1,0 +1,130 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Agent selection for Cassandra nodes, sourced by cassandra.in.sh at every Cassandra startup.
+#
+# It answers three questions, and nothing else:
+#   - which Cassandra release (X.Y) is this node about to start?
+#   - which AxonOps agent, if any, belongs to that release?
+#   - which MCAC/MAAC metrics agent, if any, belongs to that release?
+#
+# It lives in its own file, holding pure functions with no side effects, because the version
+# derivation used to be an inline sed in cassandra.in.sh that only matched `X.Y.Z` jar names.
+# Anything else - `6.0-alpha3-SNAPSHOT`, `5.1-rc1`, `7.0-SNAPSHOT`, every branch build that
+# `cassandra install --branch` produces - fell through the sed unchanged, matched no agent case,
+# and started Cassandra with no metrics agent and not one line of output saying so. Both the
+# parsing and the version -> agent mapping are unit tested (edl-cassandra-agents.test.sh).
+#
+# POSIX sh only: Cassandra's bin/cassandra is a /bin/sh script, so on the nodes this is sourced by
+# dash. No [[ ]], no =~, no BASH_REMATCH, no local. Variables are _edl_-prefixed instead of local
+# so a caller's names are never clobbered.
+#
+# Installed to /usr/local/lib/edl-cassandra-agents.sh by install_cassandra.sh.
+
+# Where install_maac.sh puts the per-release MCAC/MAAC agent jars. Overridable for tests.
+EDL_MAAC_BASE="${EDL_MAAC_BASE:-/opt/management-api}"
+
+# Cassandra releases we install an MCAC/MAAC agent for. A release outside this list gets a warning
+# naming it, never silence - see edl_maac_agent_jar_for.
+EDL_MAAC_VERSIONS="${EDL_MAAC_VERSIONS:-4.0 4.1 5.0 6.0 7.0}"
+
+# Where install_axon.sh puts the per-release AxonOps agents. Overridable for tests.
+EDL_AXONOPS_BASE="${EDL_AXONOPS_BASE:-/usr/share/axonops}"
+
+# edl_is_digits <string> - true when the string is one or more digits and nothing else.
+edl_is_digits() {
+    case "$1" in
+        ''|*[!0-9]*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# edl_cassandra_version_from_jar <path-or-name-of-apache-cassandra-jar>
+#
+# Prints the release as X.Y. Returns 1 without printing anything when the name is not an
+# apache-cassandra jar with a major and a minor - the caller must treat that as an error rather
+# than carry the unparsed text forward.
+#
+# Handles every shape the node actually holds:
+#   apache-cassandra-3.11.19.jar             -> 3.11
+#   apache-cassandra-5.0.4.jar               -> 5.0
+#   apache-cassandra-6.0.jar                 -> 6.0
+#   apache-cassandra-5.1-rc1.jar             -> 5.1
+#   apache-cassandra-6.0-beta1.jar           -> 6.0
+#   apache-cassandra-6.0-alpha3-SNAPSHOT.jar -> 6.0
+#   apache-cassandra-7.0-SNAPSHOT.jar        -> 7.0
+edl_cassandra_version_from_jar() {
+    _edl_jar="${1##*/}"
+
+    # Reject the sibling jars in the same lib directory (apache-cassandra-thrift-*,
+    # apache-cassandra-clientutil-*) and anything not named for a release at all.
+    case "$_edl_jar" in
+        apache-cassandra-[0-9]*.jar) ;;
+        *) return 1 ;;
+    esac
+
+    _edl_rest="${_edl_jar#apache-cassandra-}"
+    _edl_rest="${_edl_rest%.jar}"
+
+    _edl_major="${_edl_rest%%.*}"
+    edl_is_digits "$_edl_major" || return 1
+
+    # A major with no minor (apache-cassandra-6.jar) is not a release this can map to an agent.
+    case "$_edl_rest" in
+        *.*) ;;
+        *) return 1 ;;
+    esac
+
+    # The minor runs to the next '.' (5.0.4), the next '-' (6.0-alpha3-SNAPSHOT), or the end (6.0).
+    _edl_rest="${_edl_rest#*.}"
+    _edl_minor="${_edl_rest%%.*}"
+    _edl_minor="${_edl_minor%%-*}"
+    edl_is_digits "$_edl_minor" || return 1
+
+    printf '%s.%s\n' "$_edl_major" "$_edl_minor"
+}
+
+# edl_maac_agent_jar_for <X.Y>
+#
+# Prints the MCAC/MAAC agent jar path for that release. Returns 1 without printing when no agent
+# is installed for it, so the caller can say which release it is skipping.
+edl_maac_agent_jar_for() {
+    for _edl_supported in $EDL_MAAC_VERSIONS; do
+        if [ "$1" = "$_edl_supported" ]; then
+            printf '%s/%s/datastax-mgmtapi-agent.jar\n' "$EDL_MAAC_BASE" "$1"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# edl_axonops_agent_for <X.Y> <java-major-version>
+#
+# Prints the AxonOps agent install directory name for that release and JDK. Returns 1 without
+# printing when AxonOps ships no agent for the combination.
+edl_axonops_agent_for() {
+    case "$1" in
+        "3.0"|"3.11")
+            printf '%s-agent\n' "$1"
+            ;;
+        "4.0"|"4.1")
+            if [ "$2" = "8" ] || [ "$2" = "1.8" ]; then
+                printf '%s-agent-jdk8\n' "$1"
+            else
+                printf '%s-agent\n' "$1"
+            fi
+            ;;
+        "5.0")
+            case "$2" in
+                11|17) printf '5.0-agent-jdk%s\n' "$2" ;;
+                *) return 1 ;;
+            esac
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+
+    return 0
+}

--- a/packer/cassandra/lib/edl-cassandra-agents.test.sh
+++ b/packer/cassandra/lib/edl-cassandra-agents.test.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#
+# Unit tests for edl-cassandra-agents.sh — the version derivation and agent selection that
+# cassandra.in.sh runs on every Cassandra startup.
+#
+# The bug these exist for: the old inline sed only matched `apache-cassandra-X.Y.Z.jar`. A
+# pre-release jar name such as `apache-cassandra-6.0-alpha3-SNAPSHOT.jar` did not match, so sed
+# echoed the whole filename back, that matched no agent case, and the node started with no metrics
+# agent and no message. Every jar shape the node holds is asserted here, including the one that
+# cannot be parsed at all.
+#
+# The library is pure — no filesystem, no network, no root — so this just sources it.
+#
+# Run directly:  ./edl-cassandra-agents.test.sh
+# Or via gradle: ./gradlew testCassandraAgentSelection
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/edl-cassandra-agents.sh"
+
+tests_run=0
+tests_failed=0
+
+pass() {
+  tests_run=$((tests_run + 1))
+  echo "ok   - $1"
+}
+
+fail() {
+  tests_run=$((tests_run + 1))
+  tests_failed=$((tests_failed + 1))
+  echo "FAIL - $1"
+}
+
+assert_version() {
+  local jar="$1" expected="$2" actual
+  actual="$(edl_cassandra_version_from_jar "$jar")"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "${jar} -> ${expected}"
+  else
+    fail "${jar} should give ${expected}, got '${actual}'"
+  fi
+}
+
+assert_unparseable() {
+  local jar="$1" actual status
+  actual="$(edl_cassandra_version_from_jar "$jar")"
+  status=$?
+  if [[ "$status" -eq 0 ]]; then
+    fail "${jar} should be rejected, but parsed as '${actual}'"
+  elif [[ -n "$actual" ]]; then
+    fail "${jar} was rejected but still printed '${actual}' — callers must get nothing to carry forward"
+  else
+    pass "${jar} is rejected, printing nothing"
+  fi
+}
+
+# --- version derivation: every jar shape the node actually holds --------------
+assert_version "apache-cassandra-3.0.32.jar" "3.0"
+assert_version "apache-cassandra-3.11.19.jar" "3.11"
+assert_version "apache-cassandra-4.0.21.jar" "4.0"
+assert_version "apache-cassandra-4.1.3.jar" "4.1"
+assert_version "apache-cassandra-5.0.4.jar" "5.0"
+assert_version "apache-cassandra-5.0.10-SNAPSHOT.jar" "5.0"
+assert_version "apache-cassandra-6.0-alpha3-SNAPSHOT.jar" "6.0"
+assert_version "apache-cassandra-7.0-SNAPSHOT.jar" "7.0"
+
+# --- version derivation: shapes a release or branch build can produce ---------
+assert_version "apache-cassandra-6.0.jar" "6.0"
+assert_version "apache-cassandra-6.0-beta1.jar" "6.0"
+assert_version "apache-cassandra-5.1-rc1.jar" "5.1"
+assert_version "apache-cassandra-4.1.9-SNAPSHOT.jar" "4.1"
+
+# The find in cassandra.in.sh passes a full path, not a basename.
+assert_version "/usr/local/cassandra/current/lib/apache-cassandra-6.0-alpha3-SNAPSHOT.jar" "6.0"
+
+# --- version derivation: what must NOT be accepted ---------------------------
+# The whole point of the fix: an unrecognised name fails instead of being passed through.
+assert_unparseable "cassandra-5.0.4.jar"
+assert_unparseable "apache-cassandra-thrift-3.11.19.jar"
+assert_unparseable "apache-cassandra-clientutil-3.0.32.jar"
+assert_unparseable "apache-cassandra-.jar"
+assert_unparseable "apache-cassandra-6.jar"
+assert_unparseable "apache-cassandra-trunk.jar"
+assert_unparseable ""
+
+# --- MCAC/MAAC agent selection -----------------------------------------------
+EDL_MAAC_BASE="/opt/management-api"
+EDL_MAAC_VERSIONS="4.0 4.1 5.0 6.0 7.0"
+
+for version in 4.0 4.1 5.0 6.0 7.0; do
+  expected="/opt/management-api/${version}/datastax-mgmtapi-agent.jar"
+  actual="$(edl_maac_agent_jar_for "$version")"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "MAAC ${version} -> ${expected}"
+  else
+    fail "MAAC ${version} should give ${expected}, got '${actual}'"
+  fi
+done
+
+# 6.0 is the release that had no agent at all and is the reason for this change; assert it is
+# no longer an empty result.
+if [[ -n "$(edl_maac_agent_jar_for 6.0)" ]]; then
+  pass "MAAC 6.0 resolves to an agent (the regression this change fixes)"
+else
+  fail "MAAC 6.0 must resolve to an agent"
+fi
+
+for version in 3.0 3.11 5.1 8.0; do
+  if edl_maac_agent_jar_for "$version" >/dev/null; then
+    fail "MAAC ${version} should report no agent"
+  else
+    pass "MAAC ${version} reports no agent so the caller can say so"
+  fi
+done
+
+# --- AxonOps agent selection --------------------------------------------------
+assert_axonops() {
+  local version="$1" java="$2" expected="$3" actual
+  actual="$(edl_axonops_agent_for "$version" "$java")"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "AxonOps ${version}/jdk${java} -> ${expected}"
+  else
+    fail "AxonOps ${version}/jdk${java} should give ${expected}, got '${actual}'"
+  fi
+}
+
+assert_axonops 3.0 8 "3.0-agent"
+assert_axonops 3.11 8 "3.11-agent"
+assert_axonops 4.0 8 "4.0-agent-jdk8"
+assert_axonops 4.0 11 "4.0-agent"
+assert_axonops 4.1 1.8 "4.1-agent-jdk8"
+assert_axonops 4.1 17 "4.1-agent"
+assert_axonops 5.0 11 "5.0-agent-jdk11"
+assert_axonops 5.0 17 "5.0-agent-jdk17"
+
+for combo in "5.0 21" "5.1 17" "6.0 21" "7.0 21"; do
+  # shellcheck disable=SC2086
+  set -- $combo
+  if edl_axonops_agent_for "$1" "$2" >/dev/null; then
+    fail "AxonOps $1/jdk$2 should report no agent"
+  else
+    pass "AxonOps $1/jdk$2 reports no agent so the caller can say so"
+  fi
+done
+
+# --- the library has to run under /bin/sh, not just bash ---------------------
+# Cassandra's bin/cassandra is a /bin/sh script, so on a node this is sourced by dash. A bash-only
+# construct here does not degrade: dash fails to parse the file and Cassandra will not start at
+# all. Exercise the functions through a real /bin/sh so that can never ship again.
+POSIX_SH="$(command -v dash || command -v sh)"
+
+if sh_out="$("$POSIX_SH" -c '. "$1"; edl_cassandra_version_from_jar apache-cassandra-6.0-alpha3-SNAPSHOT.jar' _ "${SCRIPT_DIR}/edl-cassandra-agents.sh" 2>&1)" \
+   && [[ "$sh_out" == "6.0" ]]; then
+  pass "version derivation works under ${POSIX_SH}"
+else
+  fail "version derivation must work under ${POSIX_SH}, got: ${sh_out}"
+fi
+
+if sh_out="$("$POSIX_SH" -c '. "$1"; edl_cassandra_version_from_jar apache-cassandra-trunk.jar' _ "${SCRIPT_DIR}/edl-cassandra-agents.sh" 2>&1)" \
+   || [[ -z "$sh_out" ]]; then
+  if [[ -z "$sh_out" ]]; then
+    pass "an unparseable name is rejected under ${POSIX_SH} too"
+  else
+    fail "an unparseable name printed '${sh_out}' under ${POSIX_SH}"
+  fi
+else
+  fail "an unparseable name printed '${sh_out}' under ${POSIX_SH}"
+fi
+
+if sh_out="$("$POSIX_SH" -c '. "$1"; edl_maac_agent_jar_for 6.0; edl_axonops_agent_for 4.0 8' _ "${SCRIPT_DIR}/edl-cassandra-agents.sh" 2>&1)" \
+   && [[ "$sh_out" == *"/opt/management-api/6.0/datastax-mgmtapi-agent.jar"* && "$sh_out" == *"4.0-agent-jdk8"* ]]; then
+  pass "agent selection works under ${POSIX_SH}"
+else
+  fail "agent selection must work under ${POSIX_SH}, got: ${sh_out}"
+fi
+
+echo
+echo "${tests_run} assertions, ${tests_failed} failed"
+[[ "$tests_failed" -eq 0 ]]

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
@@ -439,6 +439,9 @@ object Constants {
     object Cassandra {
         /** UID of the cassandra OS user — must match the cassandra-sidecar container image */
         const val USER_ID = 999L
+
+        /** Python version cqlsh runs under when a version declares none — matches every shipped entry */
+        const val DEFAULT_PYTHON_VERSION = "3.11.9"
     }
 
     // Cassandra stress testing configuration

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/CLAUDE.md
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/CLAUDE.md
@@ -211,7 +211,7 @@ Commands should delegate to these services:
 | `K8sService` | Kubernetes operations |
 | `K3sService` | K3s cluster management |
 | `StressJobService` | Stress testing jobs on K8s |
-| `HostOperationsService` | Parallel operations across hosts |
+| `HostOperationsService` | Parallel operations across hosts (see below) |
 | `ClusterProvisioningService` | EC2 instance provisioning |
 | `ClusterConfigurationService` | Cluster configuration management |
 | `AWSResourceSetupService` | IAM roles, security groups, VPC setup (`services.aws`) |
@@ -229,6 +229,38 @@ Commands should delegate to these services:
 | `InstallTemplateResolver` | Resolves install templates from profile dir, classpath, or `--from` path |
 | `ObjectStore` | S3 file operations |
 | `RemoteOperationsService` | SSH execution (use sparingly, prefer domain services) |
+
+## Running Something On Every Host
+
+`HostOperationsService` offers two ways to fan out across a cluster. Pick by what the command needs
+to report, not by convenience:
+
+- **`withHosts`** — the first failure aborts the command. Every host still runs; the remaining
+  failures are attached as suppressed exceptions, so an operator fixing a multi-node problem sees
+  all of them in one run. Use this when a partial result is not a meaningful outcome.
+- **`collectFromHosts`** — returns a `HostResult` per host (`host` + `Result`) and throws nothing.
+  Use this when the command reports per-host outcomes, or when hosts can legitimately end in
+  *different* states — installed here, already present there. `CassandraInstall` is the reference
+  implementation: it emits one event per host, then throws once at the end if anything went wrong.
+
+Results are keyed by position, never by alias — two hosts sharing an alias would otherwise
+misattribute each other's failure.
+
+## Invoking AMI-Baked Scripts At Runtime
+
+Some scripts under `packer/` are not bake-time-only. `packer/cassandra/bin/install-cassandra-version`
+and `use-cassandra` are installed onto the node's `PATH` by the AMI build and then invoked at
+runtime over SSH by `CassandraInstall` and `UseCassandra`. This is deliberate: one install code path
+serves both the bake and a running cluster, instead of two that have to be kept in sync by hand.
+
+Consequences when editing those scripts:
+
+- They are a **contract with Kotlin callers**, not just with the packer provisioner. Changing their
+  flags or output breaks a command.
+- Build the remote command with `String.shellQuote()` (`ShellQuoting.kt`, root package) — arguments can
+  carry URLs, branch names, and ant flags.
+- They have shell unit tests (`*.test.sh` next to each script) run by `./gradlew testCassandraScripts`
+  and in CI. Update them with the script.
 
 ## Output
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Cassandra.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Cassandra.kt
@@ -23,6 +23,7 @@ import picocli.CommandLine.Spec
     description = ["Cassandra cluster management and tooling operations"],
     mixinStandardHelpOptions = true,
     subcommands = [
+        CassandraInstall::class,
         Cql::class,
         DownloadConfig::class,
         ListVersions::class,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/CassandraInstall.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/CassandraInstall.kt
@@ -1,0 +1,346 @@
+package com.rustyrazorblade.easydblab.commands.cassandra
+
+import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
+import com.rustyrazorblade.easydblab.commands.mixins.HostsMixin
+import com.rustyrazorblade.easydblab.configuration.CassandraVersion
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.Host
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.events.Event
+import com.rustyrazorblade.easydblab.exceptions.CommandExecutionException
+import com.rustyrazorblade.easydblab.services.HostOperationsService
+import com.rustyrazorblade.easydblab.shellQuote
+import com.rustyrazorblade.easydblab.ssh.redactUrlCredentials
+import org.koin.core.component.inject
+import picocli.CommandLine.Command
+import picocli.CommandLine.Mixin
+import picocli.CommandLine.Option
+import picocli.CommandLine.Parameters
+import java.io.File
+
+/**
+ * Installs one additional Cassandra version onto an already-running cluster, without an AMI rebuild.
+ *
+ * The version's install parameters come from a declared `cassandra_versions.yaml` entry (the same
+ * merged candidate set an AMI bake resolves), or entirely from CLI flags for a one-off test. The
+ * resolved entry is pushed into each targeted node's `/etc/cassandra_versions.yaml` — so a later
+ * `cassandra use` finds the java/python it needs — and then `install-cassandra-version` runs
+ * remotely, the same script the AMI bake uses.
+ */
+@RequireProfileSetup
+@Command(
+    name = "install",
+    description = ["Install a Cassandra version onto a running cluster"],
+)
+class CassandraInstall : PicoBaseCommand() {
+    private val hostOperationsService: HostOperationsService by inject()
+
+    @Parameters(description = ["Cassandra version to install"], index = "0")
+    lateinit var version: String
+
+    @Mixin
+    var hosts = HostsMixin()
+
+    @Option(
+        names = ["--url"],
+        description = ["Tarball URL (.tar.gz) or git repository URL (with --branch)"],
+    )
+    var url: String = ""
+
+    @Option(
+        names = ["--branch"],
+        description = ["Git branch to clone and build, requires --url"],
+    )
+    var branch: String = ""
+
+    @Option(
+        names = ["--java", "-j"],
+        description = ["Java version to build and run this version with, e.g. 8, 11, 17, 21"],
+    )
+    var javaVersion: String = ""
+
+    @Option(
+        names = ["--python"],
+        description = ["Python version cqlsh runs under (default: ${Constants.Cassandra.DEFAULT_PYTHON_VERSION})"],
+    )
+    var pythonVersion: String = ""
+
+    @Option(
+        names = ["--ant-flags"],
+        description = ["Extra flags passed to ant when building from a branch"],
+    )
+    var antFlags: String = ""
+
+    /** Per-host outcome, reported after every host has been attempted. */
+    private sealed interface Outcome {
+        data object Installed : Outcome
+
+        data object AlreadyPresent : Outcome
+
+        /**
+         * The version is on disk, but with parameters other than the ones just resolved.
+         *
+         * @param differences one entry per field, e.g. "java: declared 11, requested 17"
+         */
+        data class DeclarationMismatch(
+            val differences: List<String>,
+        ) : Outcome
+    }
+
+    override fun execute() {
+        check(version.isNotBlank()) { "A version to install is required, e.g. 'cassandra install 5.0'" }
+
+        val resolved = resolveVersion(declaredCassandraVersions(context))
+        val state = clusterState
+        val available = state.getHosts(ServerType.Cassandra)
+        val targeted = hostOperationsService.filteredHosts(state.hosts, ServerType.Cassandra, hosts.hostList)
+        // Installing on nothing is never what was meant; without this the command reports success
+        // for an install that never ran.
+        require(targeted.isNotEmpty()) {
+            if (available.isEmpty()) {
+                "This cluster has no Cassandra nodes. Check you are in the right cluster workspace directory."
+            } else {
+                "--hosts ${hosts.hostList} matched no Cassandra nodes; available: " +
+                    available.joinToString(", ") { it.alias }
+            }
+        }
+
+        eventBus.emit(Event.Cassandra.InstallingVersion(resolved.version, targeted.size, hosts.hostList))
+
+        val results =
+            hostOperationsService.collectFromHosts(
+                state.hosts,
+                ServerType.Cassandra,
+                hosts.hostList,
+                parallel = true,
+            ) { host -> installOnHost(host, resolved) }
+
+        results.forEach { (host, result) ->
+            result.fold(
+                onSuccess = { outcome ->
+                    when (outcome) {
+                        is Outcome.Installed -> eventBus.emit(Event.Cassandra.VersionInstalled(host.alias, resolved.version))
+                        is Outcome.AlreadyPresent ->
+                            eventBus.emit(Event.Cassandra.VersionAlreadyInstalled(host.alias, resolved.version))
+                        is Outcome.DeclarationMismatch ->
+                            eventBus.emit(
+                                Event.Cassandra.VersionDeclarationMismatch(
+                                    host.alias,
+                                    resolved.version,
+                                    outcome.differences,
+                                ),
+                            )
+                    }
+                },
+                onFailure = { failure ->
+                    eventBus.emit(
+                        Event.Cassandra.VersionInstallFailed(
+                            host.alias,
+                            resolved.version,
+                            // a resolved git url can carry a token, and this event reaches
+                            // MCP and Redis subscribers
+                            redactUrlCredentials(failure.message ?: failure::class.simpleName ?: "unknown error"),
+                        ),
+                    )
+                },
+            )
+        }
+
+        val failed = results.filter { it.result.isFailure }.map { it.host.alias }
+        val mismatched = results.filter { it.result.getOrNull() is Outcome.DeclarationMismatch }.map { it.host.alias }
+        val problems =
+            buildList {
+                if (failed.isNotEmpty()) {
+                    add("Failed to install Cassandra ${resolved.version} on: ${failed.joinToString(", ")}")
+                }
+                if (mismatched.isNotEmpty()) {
+                    add(
+                        "Cassandra ${resolved.version} is already installed with different parameters on: " +
+                            "${mismatched.joinToString(", ")} — nothing was changed there",
+                    )
+                }
+            }
+        if (problems.isNotEmpty()) {
+            throw CommandExecutionException(problems.joinToString("\n"))
+        }
+    }
+
+    /**
+     * Resolves the version's install parameters, CLI flags taking precedence over the declared
+     * entry field by field.
+     *
+     * @param declared The merged candidate set from cassandra_versions.yaml plus profile extras
+     */
+    internal fun resolveVersion(declared: List<CassandraVersion>): CassandraVersion {
+        val entry = declared.firstOrNull { it.version == version }
+
+        val resolvedJava = javaVersion.ifBlank { entry?.java.orEmpty() }
+        require(resolvedJava.isNotBlank()) {
+            "No java version for $version: it is not declared in cassandra_versions.yaml, so --java is required."
+        }
+
+        val resolvedUrl = url.ifBlank { entry?.url.orEmpty() }
+        val resolvedBranch = branch.ifBlank { entry?.branch.orEmpty() }
+        require(resolvedBranch.isBlank() || resolvedUrl.isNotBlank()) {
+            "Building $version from a branch requires a git repository: pass --url."
+        }
+
+        return CassandraVersion(
+            version = version,
+            java = resolvedJava,
+            python =
+                pythonVersion.ifBlank {
+                    entry?.python.orEmpty().ifBlank { Constants.Cassandra.DEFAULT_PYTHON_VERSION }
+                },
+            jvmOptions = entry?.jvmOptions,
+            antFlags = antFlags.ifBlank { entry?.antFlags.orEmpty() }.ifBlank { null },
+            url = resolvedUrl.ifBlank { null },
+            branch = resolvedBranch.ifBlank { null },
+        )
+    }
+
+    /**
+     * Declares the version on the node, then runs the install script.
+     *
+     * Whether the version is installed is decided by what is on disk, never by the node's version
+     * list: every AMI ships the whole cassandra_versions.yaml, `lazy: true` entries included, so a
+     * lazy version is always already declared on a node that has never installed it.
+     *
+     * The declaration is refreshed whenever it differs from what was resolved — a baked entry
+     * saying `java: 11` must not survive an install run with `--java 21`, or a later
+     * `cassandra use` picks the wrong JDK. It is never rolled back on failure: declared but not
+     * installed is the harmless state (it is exactly what a lazy entry looks like), whereas
+     * installed but not declared cannot be repaired, because every retry short-circuits on the
+     * disk check before it can re-declare.
+     */
+    private fun installOnHost(
+        clusterHost: ClusterHost,
+        resolved: CassandraVersion,
+    ): Outcome {
+        val host = clusterHost.toHost()
+        val alreadyInstalled = isInstalled(host, resolved.version)
+
+        val localFile = File.createTempFile("cassandra_versions-${clusterHost.alias}", ".yaml")
+        try {
+            remoteOps.download(host, REMOTE_VERSIONS_FILE, localFile.toPath())
+            val existing = CassandraVersion.loadFromFile(localFile.toPath())
+            val declaration = nodeDeclaration(resolved)
+
+            if (alreadyInstalled) {
+                val declared = existing.firstOrNull { it.version == declaration.version }
+                val differences = declarationDifferences(declared, declaration)
+                return when {
+                    // On disk but undeclared — `cassandra use` hard-exits without java/python, and
+                    // there is no existing declaration for these flags to contradict. Repair it.
+                    declared == null -> {
+                        pushVersions(clusterHost, existing + declaration, localFile)
+                        Outcome.AlreadyPresent
+                    }
+                    // What is on disk was built with the parameters the node declares, so rewriting
+                    // the declaration to today's flags would make it describe something that was
+                    // never installed. Say so instead of quietly dropping the flags. Compared only
+                    // on java/python/antFlags — url/branch are always null in a declaration (see
+                    // nodeDeclaration), so a baked HEAD entry's real url/branch must not trip this.
+                    differences.isNotEmpty() -> Outcome.DeclarationMismatch(differences)
+                    else -> Outcome.AlreadyPresent
+                }
+            }
+
+            val matchesExisting =
+                existing.any {
+                    it.version == declaration.version && declarationDifferences(it, declaration).isEmpty()
+                }
+            if (!matchesExisting) {
+                pushVersions(clusterHost, existing.replacingOrAdding(declaration), localFile)
+            }
+
+            remoteOps.executeRemotely(host, installCommand(resolved)).text
+            return Outcome.Installed
+        } finally {
+            localFile.delete()
+        }
+    }
+
+    /**
+     * How the node's own declaration of a version differs from what was just resolved, one entry
+     * per field, empty when they agree.
+     */
+    private fun declarationDifferences(
+        declared: CassandraVersion?,
+        requested: CassandraVersion,
+    ): List<String> {
+        if (declared == null) {
+            return listOf("this node does not declare ${requested.version} at all")
+        }
+        return listOfNotNull(
+            difference("java", declared.java, requested.java),
+            difference("python", declared.python, requested.python),
+            difference("ant flags", declared.antFlags.orEmpty(), requested.antFlags.orEmpty()),
+        )
+    }
+
+    private fun difference(
+        field: String,
+        declared: String,
+        requested: String,
+    ): String? = "$field: declared $declared, requested $requested".takeIf { declared != requested }
+
+    /**
+     * What the node's version list should say about this version.
+     *
+     * `use-cassandra` reads only `java`/`python` from that file — `url`/`branch` have no remote
+     * consumer, and a git URL can carry a token, so persisting them would leave a credential
+     * sitting in `/etc/cassandra_versions.yaml` indefinitely.
+     */
+    private fun nodeDeclaration(resolved: CassandraVersion): CassandraVersion = resolved.copy(url = null, branch = null)
+
+    private fun List<CassandraVersion>.replacingOrAdding(entry: CassandraVersion): List<CassandraVersion> =
+        if (any { it.version == entry.version }) {
+            map { if (it.version == entry.version) entry else it }
+        } else {
+            this + entry
+        }
+
+    /**
+     * Whether the version is on disk. `install-cassandra-version` makes the same check itself, but
+     * asking first is what lets the command report an untouched host rather than shelling out.
+     */
+    private fun isInstalled(
+        host: Host,
+        version: String,
+    ): Boolean {
+        val path = "$CASSANDRA_INSTALL_DIR/$version".shellQuote()
+        val check = "test -d $path && echo $INSTALLED_MARKER || true"
+        return remoteOps.executeRemotely(host, check, output = false).text.trim() == INSTALLED_MARKER
+    }
+
+    private fun pushVersions(
+        clusterHost: ClusterHost,
+        versions: List<CassandraVersion>,
+        localFile: File,
+    ) {
+        val host = clusterHost.toHost()
+        CassandraVersion.write(versions, localFile)
+        remoteOps.upload(host, localFile.toPath(), STAGED_VERSIONS_FILE)
+        remoteOps.executeRemotely(host, "sudo mv $STAGED_VERSIONS_FILE $REMOTE_VERSIONS_FILE").text
+    }
+
+    private fun installCommand(resolved: CassandraVersion): String =
+        buildString {
+            append("install-cassandra-version ")
+            append(resolved.version.shellQuote())
+            resolved.url?.let { append(" --url ${it.shellQuote()}") }
+            resolved.branch?.let { append(" --branch ${it.shellQuote()}") }
+            append(" --java ${resolved.java.shellQuote()}")
+            resolved.antFlags?.let { append(" --ant-flags ${it.shellQuote()}") }
+        }
+
+    companion object {
+        private const val REMOTE_VERSIONS_FILE = "/etc/cassandra_versions.yaml"
+        private const val STAGED_VERSIONS_FILE = "cassandra_versions.yaml"
+        private const val CASSANDRA_INSTALL_DIR = "/usr/local/cassandra"
+        private const val INSTALLED_MARKER = "installed"
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/DeclaredVersions.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/DeclaredVersions.kt
@@ -1,0 +1,25 @@
+package com.rustyrazorblade.easydblab.commands.cassandra
+
+import com.rustyrazorblade.easydblab.Context
+import com.rustyrazorblade.easydblab.configuration.CassandraVersion
+import java.io.File
+
+private const val DECLARED_VERSIONS_PATH = "cassandra/cassandra_versions.yaml"
+
+/**
+ * The Cassandra versions an AMI bake would resolve: the packaged cassandra_versions.yaml merged
+ * with any yaml files in the user's profile `cassandra_versions` extras directory.
+ *
+ * Empty when the packaged file is not on disk — without it there is no declared set, only whatever
+ * a caller names explicitly.
+ */
+internal fun declaredCassandraVersions(context: Context): List<CassandraVersion> {
+    val mainFile = File(context.packerHome, DECLARED_VERSIONS_PATH)
+    if (!mainFile.exists()) {
+        return emptyList()
+    }
+    return CassandraVersion.loadFromMainAndExtras(
+        mainFile.toPath(),
+        context.cassandraVersionsExtra.toPath(),
+    )
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/ListVersions.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/ListVersions.kt
@@ -3,12 +3,14 @@ package com.rustyrazorblade.easydblab.commands.cassandra
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
+import com.rustyrazorblade.easydblab.configuration.CassandraVersion
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.events.Event
 import picocli.CommandLine.Command
 
 /**
- * Lists available Cassandra versions installed on the cluster.
+ * Lists the Cassandra versions installed on the cluster, plus any lazily-declared version that is
+ * declared but not yet installed anywhere.
  */
 @McpCommand
 @RequireProfileSetup
@@ -21,8 +23,25 @@ class ListVersions : PicoBaseCommand() {
     override fun execute() {
         clusterState.getHosts(ServerType.Cassandra).first().let {
             val response = remoteOps.executeRemotely(it, "ls /usr/local/cassandra", output = false)
-            val versions = response.text.split("\n").filter { line -> line != "current" }
-            eventBus.emit(Event.Cassandra.VersionList(versions))
+            val installed =
+                response.text
+                    .split("\n")
+                    .map { line -> line.trim() }
+                    .filter { line -> line.isNotEmpty() && line != "current" }
+            eventBus.emit(buildVersionList(installed, declaredCassandraVersions(context)))
         }
     }
+
+    /**
+     * A lazily-declared version is not baked into the AMI, so it only shows up here — as
+     * installable — until someone actually installs it.
+     */
+    internal fun buildVersionList(
+        installed: List<String>,
+        declared: List<CassandraVersion>,
+    ): Event.Cassandra.VersionList =
+        Event.Cassandra.VersionList(
+            installed,
+            declared.filter { it.lazy && it.version !in installed }.map { it.version },
+        )
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/CLAUDE.md
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/CLAUDE.md
@@ -153,7 +153,7 @@ val result = template.substitute(mapOf("EXTRA" to "value"))  // extra vars overr
 
 ## Other Configuration Classes
 
-- **`CassandraVersion`** — version definition (Cassandra, Java, Python versions)
+- **`CassandraVersion`** — version definition (Cassandra, Java, Python versions). `lazy: true` declares a version without baking it: the entry still ships in every node's `/etc/cassandra_versions.yaml`, so it is discoverable and installable at runtime via `cassandra install`, but the AMI bake skips it. Loaded from `packer/cassandra/cassandra_versions.yaml` merged with the profile's `cassandra_versions/` extras.
 - **`CassandraYaml`** — cassandra.yaml manipulation (Jackson-based)
 - **`Seeds`** — seed list management
 - **`Host`** — legacy host data class (use `ClusterHost` for new code)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/CassandraVersion.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/CassandraVersion.kt
@@ -39,6 +39,13 @@ data class CassandraVersion(
     @JsonIgnoreProperties(ignoreUnknown = true)
     @param:JsonProperty("jvm_config")
     val jvmConfig: String? = null,
+    /**
+     * Declared but not baked: the entry ships in every node's /etc/cassandra_versions.yaml so it is
+     * discoverable and installable at runtime, but the AMI bake skips installing it.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @get:JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    val lazy: Boolean = false,
 ) {
     companion object {
         private val objectMapper = ObjectMapper(YAMLFactory()).registerKotlinModule()

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
@@ -337,8 +337,68 @@ sealed interface Event {
         @SerialName("Cassandra.VersionList")
         data class VersionList(
             val versions: List<String>,
+            val declaredNotInstalled: List<String> = emptyList(),
         ) : Cassandra {
-            override fun toDisplayString(): String = versions.joinToString("\n")
+            override fun toDisplayString(): String =
+                (
+                    versions +
+                        declaredNotInstalled.map { "$it (declared, not installed - run: cassandra install $it)" }
+                ).joinToString("\n")
+        }
+
+        @Serializable
+        @SerialName("Cassandra.InstallingVersion")
+        data class InstallingVersion(
+            val version: String,
+            val hostCount: Int,
+            val hostsFilter: String,
+        ) : Cassandra {
+            override fun toDisplayString(): String = "Installing version $version on $hostCount hosts, filter: $hostsFilter"
+        }
+
+        @Serializable
+        @SerialName("Cassandra.VersionInstalled")
+        data class VersionInstalled(
+            val host: String,
+            val version: String,
+        ) : Cassandra {
+            override fun toDisplayString(): String = "$host: installed $version"
+        }
+
+        @Serializable
+        @SerialName("Cassandra.VersionAlreadyInstalled")
+        data class VersionAlreadyInstalled(
+            val host: String,
+            val version: String,
+        ) : Cassandra {
+            override fun toDisplayString(): String = "$host: $version is already installed, nothing to do"
+        }
+
+        @Serializable
+        @SerialName("Cassandra.VersionDeclarationMismatch")
+        data class VersionDeclarationMismatch(
+            val host: String,
+            val version: String,
+            val differences: List<String>,
+        ) : Cassandra {
+            override fun toDisplayString(): String =
+                "$host: $version is already installed, built with the parameters this node declares — " +
+                    "${differences.joinToString("; ")}. Nothing was changed. " +
+                    "To change the java version in use, run: cassandra use $version --java <version>"
+
+            override fun isError(): Boolean = true
+        }
+
+        @Serializable
+        @SerialName("Cassandra.VersionInstallFailed")
+        data class VersionInstallFailed(
+            val host: String,
+            val version: String,
+            val reason: String,
+        ) : Cassandra {
+            override fun toDisplayString(): String = "$host: failed to install $version: $reason"
+
+            override fun isError(): Boolean = true
         }
 
         @Serializable

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/exceptions/EasyCassLabExceptions.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/exceptions/EasyCassLabExceptions.kt
@@ -51,6 +51,34 @@ class SSHException(
 ) : EasyDBLabException(message, cause)
 
 /**
+ * Thrown when a remote command runs to completion but exits non-zero.
+ *
+ * Carries what the remote side actually said, because the command's own error message is the only
+ * thing that explains the failure — the transport-level "Remote command failed (1)" never does.
+ *
+ * Deliberately not an [IOException] or [RuntimeException]: a non-zero exit is a deterministic
+ * failure of the command itself, so the SSH retry policy must not re-run it. Deliberately carries
+ * no cause either — the underlying exception's message repeats the unredacted command, which a
+ * printed stack trace would then leak.
+ */
+class RemoteCommandFailedException(
+    val command: String,
+    val stdout: String,
+    val stderr: String,
+    summary: String,
+) : EasyDBLabException(
+        buildString {
+            append(summary)
+            if (stderr.isNotBlank()) {
+                append("\nstderr:\n").append(stderr.trimEnd())
+            }
+            if (stdout.isNotBlank()) {
+                append("\nstdout:\n").append(stdout.trimEnd())
+            }
+        },
+    )
+
+/**
  * Thrown when an AWS operation times out waiting for resources
  */
 class AwsTimeoutException(

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/CLAUDE.md
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/CLAUDE.md
@@ -79,6 +79,25 @@ RetryUtil.withVpcTeardownRetry("delete-sg") { ec2Client.deleteSecurityGroup(requ
 - `RemoteOperationsService` — high-level SSH ops (execute, upload, download)
 - Registered in `SSHModule.kt`: provider as **singleton**, remote ops as **factory**
 
+### Credential Redaction Is A Boundary, Not A Call-Site Convention
+
+Remote commands legitimately carry a URL with an embedded credential — a git clone of a private
+fork is the common case — and the remote side echoes the command straight back on failure.
+`ssh/SSHClient` therefore redacts at the single point every remote command passes through, covering
+all four sinks at once: the debug log, the emitted `Event.Ssh.CommandOutput`, the returned
+`Response`, and the thrown `RemoteCommandFailedException`. The helper is
+`ssh/Redaction.kt`'s `redactUrlCredentials`.
+
+Rules that follow from this:
+
+- **Do not redact per call site.** A convention only has to be forgotten once to leak. If a new
+  sink appears (a new exception type, a new event), redact it inside `SSHClient` too.
+- **Do not lower `org.apache.sshd` below `INFO`** in `easydblab-logback.xml`. MINA logs every
+  remote command verbatim at DEBUG, one layer *below* this boundary, straight into `debug.log` and
+  its 30 days of archives. `LogbackConfigurationTest` locks this in.
+- `executeRemotely(secret = true)` is stronger still: neither the command nor any of its output is
+  repeated anywhere, because a failing secret command routinely echoes its own argument back.
+
 ## Docker Provider
 
 - `DockerClientProvider` — lazy-initialized Docker client (expensive to create)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/ssh/DefaultRemoteOperationsService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/ssh/DefaultRemoteOperationsService.kt
@@ -4,7 +4,9 @@ import com.rustyrazorblade.easydblab.Version
 import com.rustyrazorblade.easydblab.configuration.Host
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.events.EventBus
+import com.rustyrazorblade.easydblab.exceptions.RemoteCommandFailedException
 import com.rustyrazorblade.easydblab.ssh.Response
+import com.rustyrazorblade.easydblab.ssh.redactUrlCredentials
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.resilience4j.retry.Retry
 import io.github.resilience4j.retry.RetryConfig
@@ -38,7 +40,13 @@ class DefaultRemoteOperationsService(
          * - Max 3 attempts
          * - 2 second initial wait
          * - Exponential backoff (1.5x multiplier)
-         * - Retries on IOException and RuntimeException
+         * - Retries on IOException and RuntimeException — transient transport faults. Note that
+         *   resilience4j's `decorateSupplier`/`decorateRunnable` only ever catch RuntimeException,
+         *   so in practice a checked IOException propagates on the first attempt
+         *   (see DefaultRemoteOperationsServiceTest)
+         * - Never retries a command that ran and exited non-zero: that is a deterministic failure
+         *   of the command itself, and re-running it would just repeat the work (a failed Cassandra
+         *   build three times over) while hiding the real error behind the delay
          */
         val defaultRetryConfig: RetryConfig =
             RetryConfig
@@ -46,6 +54,7 @@ class DefaultRemoteOperationsService(
                 .maxAttempts(3)
                 .waitDuration(Duration.ofMillis(2000))
                 .retryExceptions(IOException::class.java, RuntimeException::class.java)
+                .ignoreExceptions(RemoteCommandFailedException::class.java)
                 .build()
     }
 
@@ -57,7 +66,9 @@ class DefaultRemoteOperationsService(
         output: Boolean,
         secret: Boolean,
     ): Response {
-        log.debug { "Executing command on ${host.alias}: ${if (secret) "[REDACTED]" else command}" }
+        log.debug {
+            "Executing command on ${host.alias}: ${if (secret) "[REDACTED]" else redactUrlCredentials(command)}"
+        }
         return Retry
             .decorateSupplier(retry) {
                 connectionProvider.getConnection(host).executeRemoteCommand(command, output, secret)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/HostOperationsService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/HostOperationsService.kt
@@ -4,6 +4,18 @@ import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import org.koin.core.component.KoinComponent
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Outcome of running a per-host action against a single host.
+ *
+ * Pairs the host with its [Result] so a caller can report success and failure per host rather than
+ * only learning that "something, somewhere" failed.
+ */
+data class HostResult<T>(
+    val host: ClusterHost,
+    val result: Result<T>,
+)
 
 /**
  * Service for iterating over cluster hosts and executing operations.
@@ -61,15 +73,65 @@ class HostOperationsService(
         val filteredHosts = filteredHosts(hosts, serverType, hostFilter)
 
         if (parallel && filteredHosts.size > 1) {
-            val threads =
-                filteredHosts.map { host ->
-                    kotlin.concurrent.thread(start = true, isDaemon = false) {
-                        action(host)
-                    }
-                }
-            threads.forEach { it.join() }
+            val failures =
+                collectFromHosts(hosts, serverType, hostFilter, parallel = true, action = action)
+                    .mapNotNull { it.result.exceptionOrNull() }
+
+            // Every host ran. Rethrow the first failure with the rest attached, so an operator
+            // fixing a multi-node problem sees all of it at once instead of one host per run.
+            failures.firstOrNull()?.let { first ->
+                failures.drop(1).filter { it !== first }.forEach { first.addSuppressed(it) }
+                throw first
+            }
         } else {
             filteredHosts.forEach(action)
+        }
+    }
+
+    /**
+     * Executes an action on filtered hosts and returns each host's outcome instead of throwing.
+     *
+     * Every host runs regardless of what happens on any other host; a failing action is captured
+     * as a failed [Result] on that host's [HostResult]. Use this when the caller needs to report
+     * per-host success and failure (e.g. installing a version across a cluster); use [withHosts]
+     * when the first failure should simply abort the command.
+     *
+     * @param hosts Map of server types to their hosts
+     * @param serverType The type of server to filter
+     * @param hostFilter Comma-separated list of host aliases to include (empty means all)
+     * @param parallel If true, execute operations in parallel
+     * @param action The action to perform on each host
+     * @return One [HostResult] per targeted host, in declaration order
+     */
+    fun <T> collectFromHosts(
+        hosts: Map<ServerType, List<ClusterHost>>,
+        serverType: ServerType,
+        hostFilter: String = "",
+        parallel: Boolean = false,
+        action: (ClusterHost) -> T,
+    ): List<HostResult<T>> {
+        val filteredHosts = filteredHosts(hosts, serverType, hostFilter)
+
+        if (!parallel || filteredHosts.size <= 1) {
+            return filteredHosts.map { HostResult(it, runCatching { action(it) }) }
+        }
+
+        // Keyed by position, not alias: two hosts sharing an alias would silently overwrite
+        // each other's outcome and misattribute a failure.
+        val results = ConcurrentHashMap<Int, Result<T>>()
+        filteredHosts
+            .mapIndexed { index, host ->
+                kotlin.concurrent.thread(start = true, isDaemon = false) {
+                    results[index] = runCatching { action(host) }
+                }
+            }.forEach { it.join() }
+
+        return filteredHosts.mapIndexed { index, host ->
+            HostResult(
+                host,
+                results[index]
+                    ?: Result.failure(IllegalStateException("No result recorded for host ${host.alias}")),
+            )
         }
     }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/ssh/Redaction.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/ssh/Redaction.kt
@@ -1,0 +1,18 @@
+package com.rustyrazorblade.easydblab.ssh
+
+/**
+ * Matches the userinfo of a URL, with or without a password half: `https://user:token@host` and
+ * the single-field `https://token@host` GitHub documents for personal access tokens are both
+ * credentials. The mandatory `://` leaves an scp-style git remote (`git@github.com:acme/repo.git`)
+ * alone — there the `git@` is a username with no secret attached.
+ */
+private val URL_CREDENTIALS = Regex("([a-zA-Z][a-zA-Z0-9+.-]*://)[^/@\\s]+(:[^/@\\s]*)?@")
+
+/**
+ * Strips credentials out of any URL in [text].
+ *
+ * Remote commands can legitimately carry a git URL with an embedded token (the usual way to reach a
+ * private fork), and that command — along with whatever the remote side echoes back — ends up in log
+ * lines, exception messages, and serialized events that reach MCP and Redis subscribers.
+ */
+fun redactUrlCredentials(text: String): String = URL_CREDENTIALS.replace(text, "$1***@")

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/ssh/SSHClient.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/ssh/SSHClient.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.ssh
 
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.events.EventBus
+import com.rustyrazorblade.easydblab.exceptions.RemoteCommandFailedException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.apache.sshd.client.session.ClientSession
 import org.apache.sshd.scp.client.CloseableScpClient
@@ -12,6 +13,7 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.charset.Charset
 import java.nio.file.Path
+import java.rmi.RemoteException
 import java.util.ArrayDeque
 
 /**
@@ -44,6 +46,14 @@ class SSHClient(
     private val eventBus: EventBus by inject()
     private val log = KotlinLogging.logger {}
 
+    companion object {
+        /** How much of a failed command's output to keep in the exception message. */
+        private const val MAX_FAILURE_OUTPUT_LINES = 50
+
+        /** Stands in for anything belonging to a command marked secret. */
+        private const val HIDDEN = "[hidden]"
+    }
+
     // Synchronization lock to ensure thread-safe access to the session
     // This allows multiple SSHClient instances (different hosts) to operate in parallel
     // while serializing operations on the same session (same host)
@@ -69,22 +79,66 @@ class SSHClient(
         synchronized(operationLock) {
             require(command.isNotBlank()) { "Command cannot be blank" }
 
-            // Create connection for this host
+            // Every sink below — the debug log, the emitted event, the returned Response and the
+            // thrown exception — is redacted here rather than at each call site. A remote command
+            // legitimately carries a git URL with an embedded token, and the remote side echoes it
+            // straight back; a per-call-site convention only has to be forgotten once to leak it.
             if (!secret) {
-                log.debug { "Executing remote command: $command" }
+                log.debug { "Executing remote command: ${redactUrlCredentials(command)}" }
             } else {
                 log.debug { "Executing remote command: [hidden]" }
             }
 
+            // Own both streams so a non-zero exit still yields whatever the command said before it
+            // failed — MINA's RemoteException carries only "Remote command failed (N): <command>",
+            // and the command's own error message is the only thing that explains the failure.
+            val stdoutStream = ByteArrayOutputStream()
             val stderrStream = ByteArrayOutputStream()
-            val result = session.executeRemoteCommand(command, stderrStream, Charset.defaultCharset())
+            try {
+                session.executeRemoteCommand(command, stdoutStream, stderrStream, Charset.defaultCharset())
+            } catch (e: RemoteException) {
+                throw remoteCommandFailure(command, secret, stdoutStream, stderrStream, e)
+            }
+
+            val result = redactUrlCredentials(stdoutStream.toString(Charset.defaultCharset()))
 
             if (output) {
                 eventBus.emit(Event.Ssh.CommandOutput(result))
             }
 
-            return@synchronized Response(result, stderrStream.toString())
+            return@synchronized Response(result, redactUrlCredentials(stderrStream.toString(Charset.defaultCharset())))
         }
+
+    private fun remoteCommandFailure(
+        command: String,
+        secret: Boolean,
+        stdoutStream: ByteArrayOutputStream,
+        stderrStream: ByteArrayOutputStream,
+        failure: RemoteException,
+    ): RemoteCommandFailedException {
+        if (secret) {
+            // A secret command routinely echoes its own argument back on failure — a usage line,
+            // an error naming the key — so none of its output can be repeated.
+            return RemoteCommandFailedException(
+                command = HIDDEN,
+                stdout = HIDDEN,
+                stderr = HIDDEN,
+                summary = "Remote command failed on $remoteAddress: $HIDDEN",
+            )
+        }
+        return RemoteCommandFailedException(
+            command = redactUrlCredentials(command),
+            stdout = tail(stdoutStream.toString(Charset.defaultCharset())),
+            stderr = tail(stderrStream.toString(Charset.defaultCharset())),
+            summary = "$remoteAddress: ${redactUrlCredentials(failure.message ?: "Remote command failed: $command")}",
+        )
+    }
+
+    /** Keeps a failure message readable when the command spewed (e.g. a replayed ant build log). */
+    private fun tail(text: String): String =
+        redactUrlCredentials(
+            text.lines().takeLast(MAX_FAILURE_OUTPUT_LINES).joinToString("\n"),
+        )
 
     /**
      * Upload a file to a remote host

--- a/src/main/resources/easydblab-logback.xml
+++ b/src/main/resources/easydblab-logback.xml
@@ -36,6 +36,15 @@
 
     <!-- Note: Log instrumentation is handled automatically by the OpenTelemetry Java agent -->
 
+    <!--
+      Apache MINA logs every remote command verbatim at DEBUG ("send SSH_MSG_CHANNEL_REQUEST exec
+      command={}"), one layer below where this codebase redacts. A remote command legitimately
+      carries a git URL with an embedded token, so at DEBUG that credential would land unredacted
+      in debug.log and its 30 days of gzipped archives. Narrowed to INFO: this silences only the
+      SSH transport's own chatter, not application debug logging.
+    -->
+    <logger name="org.apache.sshd" level="INFO" />
+
     <root level="DEBUG">
         <appender-ref ref="INFO_FILE" />
         <appender-ref ref="DEBUG_FILE" />

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/LogbackConfigurationTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/LogbackConfigurationTest.kt
@@ -1,0 +1,39 @@
+package com.rustyrazorblade.easydblab
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.joran.JoranConfigurator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Guards the shipped logging configuration against re-opening a credential leak.
+ *
+ * Apache MINA logs every remote command verbatim at DEBUG, one layer below where this codebase
+ * redacts, and a remote command legitimately carries a git URL with an embedded token. The root
+ * logger runs at DEBUG into a file kept for 30 days, so the SSH transport's own logging has to be
+ * held above DEBUG.
+ */
+class LogbackConfigurationTest {
+    private fun shippedConfiguration(): LoggerContext {
+        val context = LoggerContext()
+        val configuration = requireNotNull(javaClass.classLoader.getResourceAsStream("easydblab-logback.xml"))
+        JoranConfigurator().apply { setContext(context) }.doConfigure(configuration)
+        return context
+    }
+
+    @Test
+    fun `the ssh transport never logs at debug, where it would echo the raw remote command`() {
+        val context = shippedConfiguration()
+
+        assertThat(context.getLogger("org.apache.sshd").effectiveLevel).isEqualTo(Level.INFO)
+        assertThat(context.getLogger("org.apache.sshd.client.channel.ChannelExec").isDebugEnabled).isFalse()
+    }
+
+    @Test
+    fun `application logging still runs at debug`() {
+        val context = shippedConfiguration()
+
+        assertThat(context.getLogger("com.rustyrazorblade.easydblab").isDebugEnabled).isTrue()
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/CassandraInstallTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/CassandraInstallTest.kt
@@ -1,0 +1,561 @@
+package com.rustyrazorblade.easydblab.commands.cassandra
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.configuration.CassandraVersion
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.configuration.Host
+import com.rustyrazorblade.easydblab.configuration.InitConfig
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.exceptions.CommandExecutionException
+import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
+import com.rustyrazorblade.easydblab.output.OutputHandler
+import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
+import com.rustyrazorblade.easydblab.services.HostOperationsService
+import com.rustyrazorblade.easydblab.ssh.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.atLeast
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Collections
+
+/**
+ * Covers version resolution precedence and the per-host push-up/install/report flow of
+ * `cassandra install`.
+ */
+class CassandraInstallTest : BaseKoinTest() {
+    private lateinit var mockClusterStateManager: ClusterStateManager
+    private lateinit var mockRemoteOps: RemoteOperationsService
+    private lateinit var hostOperationsService: HostOperationsService
+    private lateinit var outputHandler: BufferedOutputHandler
+
+    /** Contents of each host's /etc/cassandra_versions.yaml, keyed by alias. */
+    private val nodeVersionsFile = mutableMapOf<String, String>()
+
+    private fun clusterHost(alias: String) =
+        ClusterHost(
+            publicIp = "54.1.2.3",
+            privateIp = "10.0.1.1",
+            alias = alias,
+            availabilityZone = "us-west-2a",
+            instanceId = "i-$alias",
+        )
+
+    private val testClusterState =
+        ClusterState(
+            name = "test-cluster",
+            versions = mutableMapOf(),
+            initConfig = InitConfig(region = "us-west-2"),
+            hosts =
+                mapOf(
+                    ServerType.Cassandra to listOf(clusterHost("db0"), clusterHost("db1")),
+                ),
+        )
+
+    private val declaredVersions =
+        listOf(
+            CassandraVersion(
+                version = "5.1-test",
+                java = "11",
+                python = "3.12.0",
+                jvmOptions = null,
+                url = "https://example.com/apache-cassandra-5.1-test-bin.tar.gz",
+                antFlags = "-Duse.jdk11=true",
+            ),
+        )
+
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                single<ClusterStateManager> { mockClusterStateManager }
+                single<RemoteOperationsService> { mockRemoteOps }
+                single { hostOperationsService }
+            },
+        )
+
+    /** Versions actually present under /usr/local/cassandra on each host, keyed by alias. */
+    private val installedOnNode = mutableMapOf<String, MutableSet<String>>()
+
+    /** Aliases whose install invocation should fail, and with what. */
+    private val installFailures = mutableMapOf<String, RuntimeException>()
+
+    @BeforeEach
+    fun setupMocks() {
+        mockClusterStateManager = mock()
+        mockRemoteOps = mock()
+        hostOperationsService = HostOperationsService(mockClusterStateManager)
+        outputHandler = getKoin().get<OutputHandler>() as BufferedOutputHandler
+
+        whenever(mockClusterStateManager.load()).thenReturn(testClusterState)
+        whenever(mockClusterStateManager.exists()).thenReturn(true)
+
+        nodeVersionsFile["db0"] = INSTALLED_VERSIONS_YAML
+        nodeVersionsFile["db1"] = INSTALLED_VERSIONS_YAML
+        installedOnNode["db0"] = mutableSetOf("5.0")
+        installedOnNode["db1"] = mutableSetOf("5.0")
+
+        doAnswer { invocation ->
+            val host = invocation.getArgument<Host>(0)
+            val command = invocation.getArgument<String>(1)
+            when {
+                command.startsWith("test -d ") -> {
+                    val version = command.substringAfter("/usr/local/cassandra/").substringBefore(" ")
+                    val present = version in installedOnNode.getValue(host.alias)
+                    Response(if (present) "installed" else "")
+                }
+
+                command.startsWith("install-cassandra-version") -> {
+                    installFailures[host.alias]?.let { throw it }
+                    Response("")
+                }
+
+                else -> Response("")
+            }
+        }.whenever(mockRemoteOps).executeRemotely(any(), any(), any(), any())
+
+        doAnswer { invocation ->
+            val host = invocation.getArgument<Host>(0)
+            val local = invocation.getArgument<Path>(2)
+            Files.writeString(local, nodeVersionsFile.getValue(host.alias))
+        }.whenever(mockRemoteOps).download(any(), any(), any())
+    }
+
+    /** A command configured for the zero-yaml-edit path: every field supplied as a CLI flag. */
+    private fun flagDrivenInstall(version: String = "5.1-test") =
+        CassandraInstall().apply {
+            this.version = version
+            javaVersion = "11"
+            url = "https://example.com/apache-cassandra-5.1-test-bin.tar.gz"
+            antFlags = "-Duse.jdk11=true"
+        }
+
+    @Test
+    fun `resolveVersion prefers CLI flags over the declared entry`() {
+        val command =
+            CassandraInstall().apply {
+                version = "5.1-test"
+                javaVersion = "17"
+                url = "https://example.com/override.tar.gz"
+                antFlags = "-Dno.tests=true"
+            }
+
+        val resolved = command.resolveVersion(declaredVersions)
+
+        assertThat(resolved.java).isEqualTo("17")
+        assertThat(resolved.url).isEqualTo("https://example.com/override.tar.gz")
+        assertThat(resolved.antFlags).isEqualTo("-Dno.tests=true")
+        // no flag touched python, so it still comes from the declared entry
+        assertThat(resolved.python).isEqualTo("3.12.0")
+    }
+
+    @Test
+    fun `resolveVersion falls back to the declared entry when no flags are given`() {
+        val resolved = CassandraInstall().apply { version = "5.1-test" }.resolveVersion(declaredVersions)
+
+        assertThat(resolved.version).isEqualTo("5.1-test")
+        assertThat(resolved.java).isEqualTo("11")
+        assertThat(resolved.python).isEqualTo("3.12.0")
+        assertThat(resolved.url).isEqualTo("https://example.com/apache-cassandra-5.1-test-bin.tar.gz")
+        assertThat(resolved.antFlags).isEqualTo("-Duse.jdk11=true")
+    }
+
+    @Test
+    fun `resolveVersion defaults python when neither source supplies it`() {
+        val command =
+            CassandraInstall().apply {
+                version = "6.0-experiment"
+                javaVersion = "21"
+            }
+
+        val resolved = command.resolveVersion(declaredVersions)
+
+        assertThat(resolved.python).isEqualTo("3.11.9")
+        assertThat(resolved.java).isEqualTo("21")
+        assertThat(resolved.url).isNull()
+    }
+
+    @Test
+    fun `resolveVersion fails when neither source supplies java`() {
+        val command = CassandraInstall().apply { version = "6.0-experiment" }
+
+        assertThatThrownBy { command.resolveVersion(declaredVersions) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("6.0-experiment")
+            .hasMessageContaining("--java")
+    }
+
+    @Test
+    fun `resolveVersion rejects a branch without a url`() {
+        val command =
+            CassandraInstall().apply {
+                version = "6.0-experiment"
+                javaVersion = "21"
+                branch = "trunk"
+            }
+
+        assertThatThrownBy { command.resolveVersion(declaredVersions) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("--url")
+    }
+
+    @Test
+    fun `execute repairs a missing declaration for a version already on disk`() {
+        // On disk but undeclared: use-cassandra hard-exits without java/python, and there is no
+        // existing declaration for these flags to contradict, so this one is safe to write.
+        installedOnNode["db0"] = mutableSetOf("5.0", "5.1-test")
+        installedOnNode["db1"] = mutableSetOf("5.0", "5.1-test")
+        val pushedByHost = capturePushes()
+
+        flagDrivenInstall().execute()
+
+        assertThat(executedCommands()).noneMatch { it.contains("install-cassandra-version") }
+        assertThat(outputHandler.messages.joinToString("\n")).contains("already installed")
+        val written = CassandraVersion.loadFromFile(writeToTemp(pushedByHost.first().second))
+        assertThat(written.single { it.version == "5.1-test" }.java).isEqualTo("11")
+    }
+
+    @Test
+    fun `execute tells the operator when flags are ignored on an already-installed version`() {
+        // Installed with --java 11 yesterday, re-run with --java 17 today. The bits on disk were
+        // built with the old parameters, so nothing is changed — but staying silent would leave the
+        // operator to discover it later through a wrong-JDK `cassandra use`.
+        installedOnNode["db0"] = mutableSetOf("5.0", "5.1-test")
+        installedOnNode["db1"] = mutableSetOf("5.0", "5.1-test")
+        nodeVersionsFile["db0"] = INSTALLED_VERSIONS_YAML + MATCHING_ENTRY_YAML
+        nodeVersionsFile["db1"] = INSTALLED_VERSIONS_YAML + MATCHING_ENTRY_YAML
+
+        assertThatThrownBy { flagDrivenInstall().apply { javaVersion = "17" }.execute() }
+            .isInstanceOf(CommandExecutionException::class.java)
+            .hasMessageContaining("5.1-test")
+
+        val reported = outputHandler.errors.map { it.first }
+        assertThat(reported).anyMatch { it.contains("db0") && it.contains("java") }
+        assertThat(reported).anyMatch { it.contains("declared 11") && it.contains("requested 17") }
+        // nothing was touched: not reinstalled, and the declaration still describes what is on disk
+        assertThat(executedCommands()).noneMatch { it.contains("install-cassandra-version") }
+        verify(mockRemoteOps, never()).upload(any(), any(), any())
+    }
+
+    @Test
+    fun `execute stays quiet when an already-installed version matches what was asked for`() {
+        installedOnNode["db0"] = mutableSetOf("5.0", "5.1-test")
+        installedOnNode["db1"] = mutableSetOf("5.0", "5.1-test")
+        nodeVersionsFile["db0"] = INSTALLED_VERSIONS_YAML + MATCHING_ENTRY_YAML
+        nodeVersionsFile["db1"] = INSTALLED_VERSIONS_YAML + MATCHING_ENTRY_YAML
+
+        flagDrivenInstall().execute()
+
+        assertThat(outputHandler.messages.joinToString("\n")).contains("already installed")
+        assertThat(outputHandler.errors).isEmpty()
+    }
+
+    @Test
+    fun `execute stays quiet when an already-installed HEAD version has a baked url on disk`() {
+        // Baked HEAD-tracking entries (5.0-HEAD, trunk, ...) legitimately carry a url/branch on
+        // disk from the AMI bake. nodeDeclaration always strips url/branch to null before
+        // comparing, so a non-null url on the declared entry must not read as a mismatch — only
+        // java/python/antFlags matter here.
+        installedOnNode["db0"] = mutableSetOf("5.0", "5.1-test")
+        installedOnNode["db1"] = mutableSetOf("5.0", "5.1-test")
+        nodeVersionsFile["db0"] = INSTALLED_VERSIONS_YAML + MATCHING_ENTRY_WITH_URL_YAML
+        nodeVersionsFile["db1"] = INSTALLED_VERSIONS_YAML + MATCHING_ENTRY_WITH_URL_YAML
+
+        flagDrivenInstall().execute()
+
+        assertThat(outputHandler.errors).isEmpty()
+        assertThat(outputHandler.messages.joinToString("\n")).contains("already installed")
+        assertThat(executedCommands()).noneMatch { it.contains("install-cassandra-version") }
+    }
+
+    @Test
+    fun `execute installs a lazy version the node declares but has never installed`() {
+        // Every AMI ships the whole cassandra_versions.yaml, lazy entries included, so a lazy
+        // version is always already declared on the node — that must not read as "installed".
+        nodeVersionsFile["db0"] = INSTALLED_VERSIONS_YAML + DECLARED_ENTRY_YAML
+        nodeVersionsFile["db1"] = INSTALLED_VERSIONS_YAML + DECLARED_ENTRY_YAML
+
+        flagDrivenInstall().execute()
+
+        val installs = executedCommands().filter { it.contains("install-cassandra-version") }
+        assertThat(installs).hasSize(2)
+        assertThat(outputHandler.messages.joinToString("\n")).contains("installed 5.1-test")
+    }
+
+    @Test
+    fun `execute pushes the resolved entry and runs the install script on every host`() {
+        flagDrivenInstall().execute()
+
+        verify(mockRemoteOps, times(2)).upload(any(), any(), any())
+
+        val installs = executedCommands().filter { it.contains("install-cassandra-version") }
+        assertThat(installs).hasSize(2)
+        assertThat(installs.first())
+            .contains("install-cassandra-version 5.1-test")
+            .contains("--java 11")
+            .contains("--url https://example.com/apache-cassandra-5.1-test-bin.tar.gz")
+            .contains("--ant-flags -Duse.jdk11=true")
+    }
+
+    @Test
+    fun `execute appends the new version to the file it pushes back`() {
+        val pushed = mutableListOf<String>()
+        doAnswer { invocation ->
+            pushed.add(Files.readString(invocation.getArgument<Path>(1)))
+        }.whenever(mockRemoteOps).upload(any(), any(), any())
+
+        flagDrivenInstall().execute()
+
+        val written = CassandraVersion.loadFromFile(writeToTemp(pushed.first()))
+        assertThat(written.map { it.version }).containsExactly("5.0", "5.1-test")
+        assertThat(written.single { it.version == "5.1-test" }.java).isEqualTo("11")
+        assertThat(written.single { it.version == "5.1-test" }.python).isEqualTo("3.11.9")
+    }
+
+    @Test
+    fun `execute only touches the hosts named by --hosts`() {
+        flagDrivenInstall().apply { hosts.hostList = "db1" }.execute()
+
+        val installedHosts = executedHosts().filterIndexed { index, _ -> executedCommands()[index].contains("install-") }
+        assertThat(installedHosts).containsExactly("db1")
+        verify(mockRemoteOps, times(1)).upload(any(), any(), any())
+        verify(mockRemoteOps, never()).download(argThat { alias == "db0" }, any(), any())
+    }
+
+    @Test
+    fun `execute refuses to report success when the cluster has no Cassandra nodes`() {
+        whenever(mockClusterStateManager.load()).thenReturn(
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                initConfig = InitConfig(region = "us-west-2"),
+                hosts = mapOf(ServerType.Control to listOf(clusterHost("control0"))),
+            ),
+        )
+
+        assertThatThrownBy { flagDrivenInstall().execute() }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("no Cassandra nodes")
+    }
+
+    @Test
+    fun `execute refuses an unmatched --hosts filter`() {
+        assertThatThrownBy { flagDrivenInstall().apply { hosts.hostList = "db7" }.execute() }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("db7")
+            .hasMessageContaining("db0, db1")
+    }
+
+    @Test
+    fun `execute installs a declared git-branch version with its build flags`() {
+        val branchEntry =
+            CassandraVersion(
+                version = "cep-45",
+                java = "17",
+                python = "3.11.9",
+                jvmOptions = null,
+                url = "https://github.com/apache/cassandra.git",
+                branch = "cep-45",
+                antFlags = "-Duse.jdk17=true",
+            )
+
+        val resolved = CassandraInstall().apply { version = "cep-45" }.resolveVersion(listOf(branchEntry))
+
+        assertThat(resolved.url).isEqualTo("https://github.com/apache/cassandra.git")
+        assertThat(resolved.branch).isEqualTo("cep-45")
+
+        CassandraInstall()
+            .apply {
+                version = "cep-45"
+                url = branchEntry.url.orEmpty()
+                branch = branchEntry.branch.orEmpty()
+                javaVersion = branchEntry.java
+                antFlags = branchEntry.antFlags.orEmpty()
+            }.execute()
+
+        val install = executedCommands().first { it.contains("install-cassandra-version") }
+        assertThat(install)
+            .contains("install-cassandra-version cep-45")
+            .contains("--url https://github.com/apache/cassandra.git")
+            .contains("--branch cep-45")
+            .contains("--java 17")
+            .contains("--ant-flags -Duse.jdk17=true")
+    }
+
+    @Test
+    fun `execute fails loudly when one host fails but still runs every host`() {
+        installFailures["db1"] = RuntimeException("ant build failed")
+
+        assertThatThrownBy { flagDrivenInstall().execute() }
+            .isInstanceOf(CommandExecutionException::class.java)
+            .hasMessageContaining("db1")
+            // only the failure applies here; the mismatch half must not appear, empty or otherwise
+            .hasMessageNotContaining("null")
+            .hasMessageNotContaining("different parameters")
+
+        val installs = executedCommands().filter { it.contains("install-cassandra-version") }
+        assertThat(installs).hasSize(2)
+        assertThat(outputHandler.errors.map { it.first })
+            .anyMatch { it.contains("db1") && it.contains("ant build failed") }
+    }
+
+    @Test
+    fun `a failed install leaves the declaration in place so a retry can proceed`() {
+        installFailures["db1"] = RuntimeException("404 fetching tarball")
+        val pushedByHost = capturePushes()
+
+        assertThatThrownBy { flagDrivenInstall().execute() }
+            .isInstanceOf(CommandExecutionException::class.java)
+
+        // Declared-but-uninstalled is the harmless state — it is exactly what a lazy entry looks
+        // like. Installed-but-undeclared is the unrecoverable one, so nothing is rolled back.
+        val db1Pushes = pushedByHost.filter { it.first == "db1" }.map { it.second }
+        assertThat(db1Pushes).hasSize(1)
+        assertThat(CassandraVersion.loadFromFile(writeToTemp(db1Pushes.single())).map { it.version })
+            .contains("5.1-test")
+    }
+
+    @Test
+    fun `the pushed entry carries no credential`() {
+        val pushedByHost = capturePushes()
+
+        CassandraInstall()
+            .apply {
+                version = "fork"
+                javaVersion = "17"
+                url = "https://x-access-token:ghp_secrettoken@github.com/acme/cassandra.git"
+                branch = "my-feature"
+            }.execute()
+
+        val pushed = pushedByHost.map { it.second }
+        assertThat(pushed).isNotEmpty
+        // the node only ever reads java/python from this file, so url/branch have no business
+        // being persisted there — least of all one carrying a token
+        assertThat(pushed).allSatisfy { yaml ->
+            assertThat(yaml).doesNotContain("ghp_secrettoken")
+            assertThat(yaml).doesNotContain("url:")
+            assertThat(yaml).doesNotContain("branch:")
+        }
+        val entry = CassandraVersion.loadFromFile(writeToTemp(pushed.first())).single { it.version == "fork" }
+        assertThat(entry.java).isEqualTo("17")
+        assertThat(entry.url).isNull()
+        assertThat(entry.branch).isNull()
+    }
+
+    @Test
+    fun `execute refreshes a declaration whose parameters no longer match`() {
+        // The baked entry says java 11; the operator is installing with --java 21. Leaving the
+        // node's declaration stale would make a later `cassandra use` pick the wrong JDK.
+        nodeVersionsFile["db0"] = INSTALLED_VERSIONS_YAML + DECLARED_ENTRY_YAML
+        nodeVersionsFile["db1"] = INSTALLED_VERSIONS_YAML + DECLARED_ENTRY_YAML
+        val pushedByHost = capturePushes()
+
+        flagDrivenInstall().apply { javaVersion = "21" }.execute()
+
+        val written = CassandraVersion.loadFromFile(writeToTemp(pushedByHost.first().second))
+        assertThat(written.single { it.version == "5.1-test" }.java).isEqualTo("21")
+        // replaced in place, not appended a second time
+        assertThat(written.map { it.version }).containsExactly("5.0", "5.1-test")
+    }
+
+    @Test
+    fun `execute pushes nothing when the node's declaration already matches`() {
+        nodeVersionsFile["db0"] = INSTALLED_VERSIONS_YAML + MATCHING_ENTRY_YAML
+        nodeVersionsFile["db1"] = INSTALLED_VERSIONS_YAML + MATCHING_ENTRY_YAML
+
+        flagDrivenInstall().execute()
+
+        verify(mockRemoteOps, never()).upload(any(), any(), any())
+        assertThat(executedCommands().filter { it.contains("install-cassandra-version") }).hasSize(2)
+    }
+
+    /** Records every uploaded yaml as (host alias, file contents). */
+    private fun capturePushes(): List<Pair<String, String>> {
+        // CassandraInstall visits hosts in parallel, so this collects from several threads.
+        val pushed = Collections.synchronizedList(mutableListOf<Pair<String, String>>())
+        doAnswer { invocation ->
+            val host = invocation.getArgument<Host>(0)
+            pushed.add(host.alias to Files.readString(invocation.getArgument<Path>(1)))
+        }.whenever(mockRemoteOps).upload(any(), any(), any())
+        return pushed
+    }
+
+    private fun executedCommands(): List<String> {
+        val captor = argumentCaptor<String>()
+        verify(mockRemoteOps, atLeast(0)).executeRemotely(any(), captor.capture(), any(), any())
+        return captor.allValues
+    }
+
+    /** Host aliases, positionally aligned with [executedCommands]. */
+    private fun executedHosts(): List<String> {
+        val captor = argumentCaptor<Host>()
+        verify(mockRemoteOps, atLeast(0)).executeRemotely(captor.capture(), any(), any(), any())
+        return captor.allValues.map { it.alias }
+    }
+
+    private fun writeToTemp(content: String): Path {
+        val path = Files.createTempFile("pushed", ".yaml")
+        Files.writeString(path, content)
+        path.toFile().deleteOnExit()
+        return path
+    }
+
+    companion object {
+        private val INSTALLED_VERSIONS_YAML =
+            """
+            - version: "5.0"
+              java: "11"
+              python: "3.11.9"
+
+            """.trimIndent()
+
+        private val DECLARED_ENTRY_YAML =
+            """
+            - version: "5.1-test"
+              java: "11"
+              python: "3.12.0"
+              lazy: true
+
+            """.trimIndent()
+
+        /** Exactly what a flag-driven install of 5.1-test resolves to, so nothing needs pushing. */
+        private val MATCHING_ENTRY_YAML =
+            """
+            - version: "5.1-test"
+              java: "11"
+              python: "3.11.9"
+              ant_flags: "-Duse.jdk11=true"
+
+            """.trimIndent()
+
+        /**
+         * Same as [MATCHING_ENTRY_YAML] on every field `declarationDifferences` compares
+         * (java/python/antFlags), but with a real `url:` on disk — exactly what a baked HEAD-tracking
+         * entry (5.0-HEAD, trunk, ...) looks like after the AMI bake. `nodeDeclaration` always strips
+         * url/branch to null before comparing, so this must not be reported as a mismatch.
+         */
+        private val MATCHING_ENTRY_WITH_URL_YAML =
+            """
+            - version: "5.1-test"
+              java: "11"
+              python: "3.11.9"
+              ant_flags: "-Duse.jdk11=true"
+              url: "https://example.com/apache-cassandra-5.1-test-bin.tar.gz"
+
+            """.trimIndent()
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/ListVersionsTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/ListVersionsTest.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.commands.cassandra
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.configuration.CassandraVersion
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
@@ -8,6 +9,7 @@ import com.rustyrazorblade.easydblab.configuration.InitConfig
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
 import com.rustyrazorblade.easydblab.output.OutputHandler
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.koin.core.module.Module
@@ -53,6 +55,35 @@ class ListVersionsTest : BaseKoinTest() {
 
         whenever(mockClusterStateManager.load()).thenReturn(testClusterState)
     }
+
+    @Test
+    fun `buildVersionList marks a lazy version that is not installed`() {
+        val event =
+            ListVersions().buildVersionList(
+                installed = listOf("5.0", "trunk"),
+                declared = listOf(lazyVersion("cep-45"), lazyVersion("trunk"), eagerVersion("6.0")),
+            )
+
+        assertThat(event.versions).containsExactly("5.0", "trunk")
+        // trunk is declared lazy but already installed; 6.0 is declared but not lazy
+        assertThat(event.declaredNotInstalled).containsExactly("cep-45")
+        assertThat(event.toDisplayString())
+            .contains("cep-45 (declared, not installed")
+            .doesNotContain("trunk (declared")
+    }
+
+    @Test
+    fun `buildVersionList reports only installed versions when nothing is declared lazily`() {
+        val event = ListVersions().buildVersionList(installed = listOf("5.0"), declared = emptyList())
+
+        assertThat(event.declaredNotInstalled).isEmpty()
+        assertThat(event.toDisplayString()).isEqualTo("5.0")
+    }
+
+    private fun lazyVersion(version: String) =
+        CassandraVersion(version = version, java = "11", python = "3.11.9", jvmOptions = null, lazy = true)
+
+    private fun eagerVersion(version: String) = CassandraVersion(version = version, java = "11", python = "3.11.9", jvmOptions = null)
 
     @Test
     fun `execute lists versions excluding current`() {

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/CassandraVersionTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/CassandraVersionTest.kt
@@ -2,7 +2,9 @@ package com.rustyrazorblade.easydblab.configuration
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import java.io.ByteArrayOutputStream
+import java.nio.file.Path
 import java.nio.file.Paths
 
 class CassandraVersionTest {
@@ -20,6 +22,42 @@ class CassandraVersionTest {
         assertThat(cassandraVersions).anyMatch { it.version == "3.11" }
         assertThat(cassandraVersions).anyMatch { it.version == "4.0" }
         assertThat(cassandraVersions).anyMatch { it.version == "1.2" }
+    }
+
+    @Test
+    fun `lazy round-trips through write and loadFromFile`(
+        @TempDir tempDir: Path,
+    ) {
+        val versions =
+            listOf(
+                CassandraVersion(version = "5.1-lazy", java = "17", python = "3.11.9", jvmOptions = null, lazy = true),
+                CassandraVersion(version = "5.0", java = "11", python = "3.11.9", jvmOptions = null),
+            )
+        val file = tempDir.resolve("cassandra_versions.yaml").toFile()
+
+        CassandraVersion.write(versions, file)
+        val loaded = CassandraVersion.loadFromFile(file.toPath())
+
+        assertThat(loaded.single { it.version == "5.1-lazy" }.lazy).isTrue()
+        assertThat(loaded.single { it.version == "5.0" }.lazy).isFalse()
+        // A non-lazy entry must not gain a `lazy: false` line when a node's file is rewritten.
+        assertThat(file.readText()).doesNotContain("lazy: false")
+    }
+
+    @Test
+    fun `lazy defaults to false when the field is absent`(
+        @TempDir tempDir: Path,
+    ) {
+        val file = tempDir.resolve("cassandra_versions.yaml").toFile()
+        file.writeText(
+            """
+            - version: "5.0"
+              java: "11"
+              python: "3.11.9"
+            """.trimIndent(),
+        )
+
+        assertThat(CassandraVersion.loadFromFile(file.toPath()).single().lazy).isFalse()
     }
 
     @Test

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/providers/ssh/DefaultRemoteOperationsServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/providers/ssh/DefaultRemoteOperationsServiceTest.kt
@@ -2,17 +2,22 @@ package com.rustyrazorblade.easydblab.providers.ssh
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
 import com.rustyrazorblade.easydblab.configuration.Host
+import com.rustyrazorblade.easydblab.exceptions.RemoteCommandFailedException
 import com.rustyrazorblade.easydblab.ssh.ISSHClient
 import com.rustyrazorblade.easydblab.ssh.Response
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.core.module.Module
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class DefaultRemoteOperationsServiceTest :
@@ -167,5 +172,40 @@ class DefaultRemoteOperationsServiceTest :
         // Then verify the result
         assertThat(result).isNotNull()
         assertThat(result.text).isEqualTo(expectedOutput)
+    }
+
+    @Test
+    fun `a command that exits non-zero is not retried`() {
+        val command = "install-cassandra-version trunk"
+        val failure =
+            RemoteCommandFailedException(
+                command = command,
+                stdout = "",
+                stderr = "ERROR: Ant build failed",
+                summary = "Remote command failed (1): $command",
+            )
+        // doAnswer, not thenThrow: Kotlin emits no `throws` clause, so Mockito rejects stubbing a
+        // checked exception on this method even though it propagates fine at runtime.
+        doAnswer { throw failure }.whenever(mockSSHClient).executeRemoteCommand(eq(command), any(), any())
+
+        assertThatThrownBy { service.executeRemotely(host, command) }
+            .isInstanceOf(RemoteCommandFailedException::class.java)
+            .hasMessageContaining("ERROR: Ant build failed")
+
+        // A deterministic command failure must run once — re-running a failed build wastes minutes
+        verify(mockSSHClient, times(1)).executeRemoteCommand(eq(command), any(), any())
+    }
+
+    @Test
+    fun `a transient transport failure is still retried`() {
+        val command = "echo 1"
+        var attempts = 0
+        doAnswer {
+            attempts++
+            if (attempts < 3) error("connection reset") else Response("1")
+        }.whenever(mockSSHClient).executeRemoteCommand(eq(command), any(), any())
+
+        assertThat(service.executeRemotely(host, command).text).isEqualTo("1")
+        verify(mockSSHClient, times(3)).executeRemoteCommand(eq(command), any(), any())
     }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/HostOperationsServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/HostOperationsServiceTest.kt
@@ -1,0 +1,111 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import java.util.concurrent.ConcurrentLinkedQueue
+
+/**
+ * Verifies host fan-out semantics, in particular that a failure inside a parallel per-host action
+ * reaches the caller instead of dying silently inside its worker thread.
+ */
+class HostOperationsServiceTest {
+    private val service = HostOperationsService(mock<ClusterStateManager>())
+
+    private fun host(alias: String) =
+        ClusterHost(
+            publicIp = "54.0.0.1",
+            privateIp = "10.0.0.1",
+            alias = alias,
+            availabilityZone = "us-west-2a",
+            instanceId = "i-$alias",
+        )
+
+    private val hosts =
+        mapOf(
+            ServerType.Cassandra to listOf(host("db0"), host("db1"), host("db2")),
+        )
+
+    @Test
+    fun `parallel withHosts surfaces a per-host failure to the caller`() {
+        assertThatThrownBy {
+            service.withHosts(hosts, ServerType.Cassandra, parallel = true) { clusterHost ->
+                if (clusterHost.alias == "db1") {
+                    error("install failed on ${clusterHost.alias}")
+                }
+            }
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("install failed on db1")
+    }
+
+    @Test
+    fun `parallel withHosts still runs every host when one fails`() {
+        val visited = ConcurrentLinkedQueue<String>()
+
+        assertThatThrownBy {
+            service.withHosts(hosts, ServerType.Cassandra, parallel = true) { clusterHost ->
+                visited.add(clusterHost.alias)
+                if (clusterHost.alias == "db0") {
+                    error("boom")
+                }
+            }
+        }.isInstanceOf(IllegalStateException::class.java)
+
+        assertThat(visited).containsExactlyInAnyOrder("db0", "db1", "db2")
+    }
+
+    @Test
+    fun `parallel withHosts surfaces every failure, not just the first`() {
+        // Otherwise an operator fixes one host, reruns, and only then learns about the next.
+        assertThatThrownBy {
+            service.withHosts(hosts, ServerType.Cassandra, parallel = true) { clusterHost ->
+                if (clusterHost.alias != "db2") {
+                    error("broken on ${clusterHost.alias}")
+                }
+            }
+        }.satisfies({ thrown ->
+            val reported = (listOf(thrown) + thrown.suppressed).mapNotNull { it.message }
+            assertThat(reported).containsExactlyInAnyOrder("broken on db0", "broken on db1")
+        })
+    }
+
+    @Test
+    fun `collectFromHosts returns per-host outcomes in host order`() {
+        val results =
+            service.collectFromHosts(hosts, ServerType.Cassandra, parallel = true) { clusterHost ->
+                if (clusterHost.alias == "db1") {
+                    error("no route to host")
+                }
+                "installed on ${clusterHost.alias}"
+            }
+
+        assertThat(results.map { it.host.alias }).containsExactly("db0", "db1", "db2")
+        assertThat(results[0].result.getOrNull()).isEqualTo("installed on db0")
+        assertThat(results[1].result.exceptionOrNull()).hasMessageContaining("no route to host")
+        assertThat(results[2].result.getOrNull()).isEqualTo("installed on db2")
+    }
+
+    @Test
+    fun `collectFromHosts honors the host filter`() {
+        val results =
+            service.collectFromHosts(hosts, ServerType.Cassandra, hostFilter = "db2") { it.alias }
+
+        assertThat(results.map { it.host.alias }).containsExactly("db2")
+    }
+
+    @Test
+    fun `serial withHosts propagates a failure`() {
+        assertThatThrownBy {
+            service.withHosts(hosts, ServerType.Cassandra) { clusterHost ->
+                if (clusterHost.alias == "db0") {
+                    error("serial boom")
+                }
+            }
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("serial boom")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/ssh/RedactionTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/ssh/RedactionTest.kt
@@ -1,0 +1,66 @@
+package com.rustyrazorblade.easydblab.ssh
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * A git URL is a normal way to reach a private fork, and it can carry credentials in its userinfo.
+ * Those must never survive into a log line, an exception message, or a serialized event.
+ */
+class RedactionTest {
+    @Test
+    fun `redacts userinfo credentials from a url`() {
+        val redacted = redactUrlCredentials("git clone https://alice:ghp_secrettoken@github.com/acme/cassandra.git")
+
+        assertThat(redacted).doesNotContain("ghp_secrettoken").doesNotContain("alice")
+        assertThat(redacted).isEqualTo("git clone https://***@github.com/acme/cassandra.git")
+    }
+
+    @Test
+    fun `redacts a single-field token, the documented GitHub PAT form`() {
+        val redacted = redactUrlCredentials("git clone https://ghp_secrettoken@github.com/acme/cassandra.git")
+
+        assertThat(redacted).doesNotContain("ghp_secrettoken")
+        assertThat(redacted).isEqualTo("git clone https://***@github.com/acme/cassandra.git")
+    }
+
+    @Test
+    fun `redacts the x-access-token form`() {
+        val redacted = redactUrlCredentials("https://x-access-token:ghp_secrettoken@github.com/acme/cassandra.git")
+
+        assertThat(redacted).doesNotContain("ghp_secrettoken").doesNotContain("x-access-token")
+        assertThat(redacted).isEqualTo("https://***@github.com/acme/cassandra.git")
+    }
+
+    @Test
+    fun `redacts every url in a multi-line string`() {
+        val text =
+            """
+            ERROR: clone failed for https://bob:hunter2@git.example.com/x.git
+            retrying https://bob:hunter2@git.example.com/x.git
+            """.trimIndent()
+
+        assertThat(redactUrlCredentials(text)).doesNotContain("hunter2")
+        assertThat(redactUrlCredentials(text).lines()).allMatch { it.contains("***@") }
+    }
+
+    @Test
+    fun `leaves a scp-style git url alone`() {
+        // git@github.com is a username, not a credential — redacting it would be noise
+        val url = "git@github.com:acme/cassandra.git"
+
+        assertThat(redactUrlCredentials(url)).isEqualTo(url)
+    }
+
+    @Test
+    fun `leaves urls without credentials alone`() {
+        val command = "install-cassandra-version 5.0 --url https://example.com/apache-cassandra-5.0-bin.tar.gz"
+
+        assertThat(redactUrlCredentials(command)).isEqualTo(command)
+    }
+
+    @Test
+    fun `leaves text with no url alone`() {
+        assertThat(redactUrlCredentials("sudo use-cassandra 5.0")).isEqualTo("sudo use-cassandra 5.0")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/ssh/SSHClientTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/ssh/SSHClientTest.kt
@@ -1,6 +1,9 @@
 package com.rustyrazorblade.easydblab.ssh
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.exceptions.RemoteCommandFailedException
+import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
+import com.rustyrazorblade.easydblab.output.OutputHandler
 import org.apache.sshd.client.session.ClientSession
 import org.apache.sshd.common.io.IoSession
 import org.assertj.core.api.Assertions.assertThat
@@ -14,8 +17,10 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.io.File
+import java.io.OutputStream
 import java.net.InetSocketAddress
 import java.nio.charset.Charset
+import java.rmi.RemoteException
 
 /**
  * Unit tests for SSHClient
@@ -33,9 +38,11 @@ class SSHClientTest :
     private lateinit var mockSession: ClientSession
     private lateinit var mockIoSession: IoSession
     private lateinit var sshClient: SSHClient
+    private lateinit var outputHandler: BufferedOutputHandler
 
     @BeforeEach
     fun setup() {
+        outputHandler = getKoin().get<OutputHandler>() as BufferedOutputHandler
         mockSession = mock()
         mockIoSession = mock()
 
@@ -48,19 +55,119 @@ class SSHClientTest :
 
     // ========== Command Execution Tests ==========
 
+    /** Stubs the session to write [stdout]/[stderr], then fail the way MINA does on a non-zero exit. */
+    private fun stubRemoteCommand(
+        stdout: String = "",
+        stderr: String = "",
+        failWith: RemoteException? = null,
+    ) {
+        whenever(mockSession.executeRemoteCommand(any(), any(), any(), any<Charset>())).thenAnswer { invocation ->
+            invocation.getArgument<OutputStream>(1).write(stdout.toByteArray())
+            invocation.getArgument<OutputStream>(2).write(stderr.toByteArray())
+            failWith?.let { throw it }
+            null
+        }
+    }
+
     @Test
     fun `executeRemoteCommand should execute command and return response`() {
         // Given
         val command = "ls -la"
         val expectedOutput = "total 0\ndrwxr-xr-x 1 root root 0 Jan 1 00:00 ."
-        whenever(mockSession.executeRemoteCommand(eq(command), any(), any())).thenReturn(expectedOutput)
+        stubRemoteCommand(stdout = expectedOutput, stderr = "a warning")
 
         // When
         val response = sshClient.executeRemoteCommand(command, output = false, secret = false)
 
         // Then
         assertThat(response.text).isEqualTo(expectedOutput)
-        verify(mockSession).executeRemoteCommand(eq(command), any(), eq(Charset.defaultCharset()))
+        assertThat(response.stderr).isEqualTo("a warning")
+        verify(mockSession).executeRemoteCommand(eq(command), any(), any(), eq(Charset.defaultCharset()))
+    }
+
+    @Test
+    fun `a non-zero exit surfaces what the remote command actually said`() {
+        val command = "sudo use-cassandra 5.1"
+        stubRemoteCommand(
+            stdout = "Cassandra version 5.1 is not installed on this node.\nRun 'cassandra install 5.1' first.",
+            stderr = "",
+            failWith = RemoteException("Remote command failed (1): $command"),
+        )
+
+        assertThatThrownBy { sshClient.executeRemoteCommand(command, output = false, secret = false) }
+            .isInstanceOf(RemoteCommandFailedException::class.java)
+            .hasMessageContaining("Cassandra version 5.1 is not installed on this node.")
+            .hasMessageContaining("cassandra install 5.1")
+    }
+
+    @Test
+    fun `a non-zero exit surfaces stderr as well as stdout`() {
+        stubRemoteCommand(
+            stdout = "Building version trunk with ant",
+            stderr = "ERROR: Ant build failed for version trunk\ncompile: BUILD FAILED",
+            failWith = RemoteException("Remote command failed (1): install-cassandra-version trunk"),
+        )
+
+        assertThatThrownBy {
+            sshClient.executeRemoteCommand("install-cassandra-version trunk", output = false, secret = false)
+        }.isInstanceOf(RemoteCommandFailedException::class.java)
+            .hasMessageContaining("ERROR: Ant build failed for version trunk")
+            .hasMessageContaining("Building version trunk with ant")
+    }
+
+    @Test
+    fun `a failure never leaks credentials embedded in the command`() {
+        val command = "install-cassandra-version fork --url https://alice:ghp_secrettoken@github.com/acme/cassandra.git"
+        stubRemoteCommand(
+            stderr = "ERROR: Git clone failed for https://alice:ghp_secrettoken@github.com/acme/cassandra.git",
+            failWith = RemoteException("Remote command failed (1): $command"),
+        )
+
+        assertThatThrownBy { sshClient.executeRemoteCommand(command, output = false, secret = false) }
+            .isInstanceOf(RemoteCommandFailedException::class.java)
+            .hasMessageNotContaining("ghp_secrettoken")
+            .hasMessageContaining("***@github.com")
+    }
+
+    @Test
+    fun `a failure on a secret command repeats neither the command nor its output`() {
+        // A secret command routinely echoes its own argument back: a usage line, an error naming
+        // the key it just rejected.
+        stubRemoteCommand(
+            stdout = "usage: tailscale up --authkey=tskey-auth-hunter2",
+            stderr = "invalid key: tskey-auth-hunter2",
+            failWith = RemoteException("Remote command failed (1): tailscale up --authkey=tskey-auth-hunter2"),
+        )
+
+        assertThatThrownBy {
+            sshClient.executeRemoteCommand("tailscale up --authkey=tskey-auth-hunter2", output = false, secret = true)
+        }.isInstanceOf(RemoteCommandFailedException::class.java)
+            .hasMessageNotContaining("hunter2")
+    }
+
+    @Test
+    fun `a successful command's output is redacted before it reaches the event bus`() {
+        // install-cassandra-version echoes the clone URL it was given; that output is emitted as a
+        // @Serializable event reaching every MCP and Redis subscriber.
+        stubRemoteCommand(
+            stdout = "Cloning repo for version fork from https://ghp_secrettoken@github.com/acme/cassandra.git",
+        )
+
+        val response = sshClient.executeRemoteCommand("install-cassandra-version fork", output = true, secret = false)
+
+        assertThat(response.text).doesNotContain("ghp_secrettoken")
+        assertThat(response.text).contains("***@github.com")
+        val emitted = outputHandler.messages.joinToString("\n")
+        assertThat(emitted).doesNotContain("ghp_secrettoken")
+    }
+
+    @Test
+    fun `a successful command's stderr is redacted too`() {
+        stubRemoteCommand(stderr = "warning: fetching https://ghp_secrettoken@github.com/acme/cassandra.git")
+
+        val response = sshClient.executeRemoteCommand("git fetch", output = false, secret = false)
+
+        assertThat(response.stderr).doesNotContain("ghp_secrettoken")
     }
 
     @Test
@@ -75,7 +182,7 @@ class SSHClientTest :
     fun `executeRemoteCommand with secret flag should hide command in output`() {
         // Given
         val command = "echo secret"
-        whenever(mockSession.executeRemoteCommand(eq(command), any(), any())).thenReturn("secret")
+        stubRemoteCommand(stdout = "secret")
 
         // When
         sshClient.executeRemoteCommand(command, output = true, secret = true)

--- a/test-plans/cassandra-6.0-rustyrazorblade-install-and-stress.md
+++ b/test-plans/cassandra-6.0-rustyrazorblade-install-and-stress.md
@@ -1,0 +1,304 @@
+# Cassandra 6.0-rustyrazorblade — runtime install + 4h stress
+
+## Cluster Name
+
+cassandra-876-cursor
+
+## Datacenters
+
+single
+
+## Steps
+
+1. Provision — 3 db + 1 stress, `i4i.xlarge`
+2. `use` before `install` fails helpfully
+3. Install on a single host (`--hosts`)
+4. `cassandra list` distinguishes installed from declared
+5. Install across the whole cluster
+6. Re-run is a safe no-op
+7. Failure is loud and per-host
+8. Activate, set up the cursor-compaction A/B, verify Java 21
+9. 4h `RandomPartitionAccess` stress run at `--rate 100k`
+
+
+Validates issue #876 / PR #878 (`cassandra install <version>`) against a real AWS cluster,
+then reuses the same cluster to stress the custom perf patches in the 6.0-rustyrazorblade
+build.
+
+This plan does double duty:
+
+1. **Steps 2–8** — walk every acceptance criterion on #876 that needs real hardware. Cheap,
+   runs in minutes.
+2. **Step 9** — a 4h `RandomPartitionAccess` run at `--rate 100k` against the freshly
+   installed build.
+
+## Artifact under test
+
+| | |
+|---|---|
+| Source repo | `rustyrazorblade/cassandra-builds` |
+| Build run | https://github.com/rustyrazorblade/cassandra-builds/actions/runs/33138617467 |
+| Release tag | `cassandra-6.0-rustyrazorblade` |
+| Version | 6.0-alpha3 (SHA `273046beeb32`) |
+| Build JDK | Temurin 21.0.12 |
+| Tarball | `apache-cassandra-6.0-alpha3-273046beeb32-bin.tar.gz` (74 MB) |
+
+Tarball URL (public, unauthenticated — verified HTTP 200):
+
+```
+https://github.com/rustyrazorblade/cassandra-builds/releases/download/cassandra-6.0-rustyrazorblade/apache-cassandra-6.0-alpha3-273046beeb32-bin.tar.gz
+```
+
+Installed as version name **`6.0-rustyrazorblade`** → `/usr/local/cassandra/6.0-rustyrazorblade`.
+
+No `cassandra_versions.yaml` edit and no AMI rebake: install parameters come entirely from
+CLI flags, which is the one-off path `CassandraInstall` documents.
+
+---
+
+## Step 1 — Provision
+
+3 Cassandra nodes (the minimum that exercises `--hosts` targeting and the parallel per-host
+error reporting this branch rewrote) + 1 stress node.
+
+```bash
+$EDB init -c 3 -s 1 -i i4i.xlarge --up
+```
+
+**Expect:** 3 db nodes + 1 stress node up, K3s healthy.
+
+**Pre-flight — verify the AMI carries the node-side half of #878.** `cassandra install` does
+*not* upload its worker script; it invokes `install-cassandra-version` by bare name on the
+node's `PATH`, so an AMI baked before this branch fails every step from 2 on. `use-cassandra`
+must also carry the guard that refuses a missing version rather than dangling the symlink.
+
+```bash
+CLUSTER_DIR=$(dirname "$EDB")
+for h in db0 db1 db2; do
+  echo "== $h"
+  ssh -F "$CLUSTER_DIR/sshConfig" $h \
+    "ls -l /usr/local/bin/install-cassandra-version /usr/local/bin/use-cassandra"
+done
+```
+
+**Fail if:** `install-cassandra-version` is absent on any node — stop and rebake
+(`easy-db-lab build-image`, which builds *both* the base and cassandra AMIs), then re-provision
+with `--ami <new cassandra ami>`. Do not hand-copy the scripts onto the nodes; that bypasses the
+delivery path this plan exists to validate.
+
+---
+
+## Step 2 — `use` before `install` fails helpfully
+
+AC: *`cassandra use <version>` for a version that isn't installed fails with a clear message
+directing the operator to run `cassandra install` first — never a generic error.*
+
+```bash
+$EDB cassandra use 6.0-rustyrazorblade
+```
+
+**Expect:** non-zero exit. Message names the version and points at `cassandra install`.
+**Fail if:** a generic stack trace, a silent success, or a symlink swap to a missing directory.
+
+---
+
+## Step 3 — Install on a single host
+
+AC: *`--hosts` installs only on the targeted subset; untargeted nodes are unaffected.*
+
+```bash
+$EDB cassandra install 6.0-rustyrazorblade \
+  --url https://github.com/rustyrazorblade/cassandra-builds/releases/download/cassandra-6.0-rustyrazorblade/apache-cassandra-6.0-alpha3-273046beeb32-bin.tar.gz \
+  --java 21 \
+  --hosts db0
+```
+
+**Expect:** success reported for `db0` only. `/usr/local/cassandra/6.0-rustyrazorblade`
+exists on `db0` and **not** on `db1`/`db2`. `/etc/cassandra_versions.yaml`
+on `db0` gained the entry with `java: 21`; the other two are unchanged.
+
+**Also check:** no credential material written into `/etc/cassandra_versions.yaml` (this branch
+explicitly stopped persisting credentials there).
+
+---
+
+## Step 4 — `cassandra list` distinguishes installed from declared
+
+AC: *`cassandra list` shows lazily-declared-but-not-yet-installed versions, distinguishable
+from versions actually installed on the node.*
+
+```bash
+$EDB cassandra list
+```
+
+**Expect:** `6.0-rustyrazorblade` shown as installed on `db0`, and visibly *not*
+installed on the other two.
+
+---
+
+## Step 5 — Install across the whole cluster
+
+AC: *tarball `url:` install lands at `/usr/local/cassandra/<version>` on targeted nodes.*
+
+```bash
+$EDB cassandra install 6.0-rustyrazorblade \
+  --url https://github.com/rustyrazorblade/cassandra-builds/releases/download/cassandra-6.0-rustyrazorblade/apache-cassandra-6.0-alpha3-273046beeb32-bin.tar.gz \
+  --java 21
+```
+
+**Expect:** `db1`/`db2` install; `db0` reports **already present** rather
+than re-downloading 74 MB. All 3 nodes now have the version on disk.
+
+---
+
+## Step 6 — Re-run is a safe no-op
+
+AC: *re-running for an already-installed version does not error and does not re-download or
+re-build — logs "already present."*
+
+Re-run the exact command from step 5.
+
+**Expect:** all 3 hosts report already-present. No network transfer, no extraction.
+**Fail if:** any node re-downloads, or a false `DeclarationMismatch` fires (the last commit on
+this branch specifically fixed that for HEAD-tracking re-installs).
+
+---
+
+## Step 7 — Failure is loud and per-host
+
+AC: *install failure (unreachable/404 tarball) fails loudly with a clear per-host error
+identifying the version and the reason — no silent partial state, no fallback.*
+
+```bash
+$EDB cassandra install 6.0-bogus-does-not-exist \
+  --url https://github.com/rustyrazorblade/cassandra-builds/releases/download/cassandra-6.0-rustyrazorblade/no-such-file-bin.tar.gz \
+  --java 21
+```
+
+**Expect:** non-zero exit. **Every** failing host reported, not just the first — this branch
+rewrote `withHosts` specifically so parallel failures all surface. Error names the version and
+the reason (404). No partial directory left behind at `/usr/local/cassandra/6.0-bogus-*` —
+the install script now cleans its working directory on every exit path.
+
+---
+
+## Step 8 — Activate, set up the cursor-compaction A/B, and verify Java 21
+
+`cursor_compaction_enabled` defaults to **`true`** — it is not in the shipped
+`conf/cassandra.yaml`, and `Config.java:720` initialises it from
+`CassandraRelevantProperties.CURSOR_COMPACTION_ENABLED`, whose default is `"true"`. So the
+A/B is created by turning it **off** on the control nodes, not on by explicitly setting it.
+
+| Node | `cursor_compaction_enabled` | Role |
+|---|---|---|
+| `db0` | default (`true`) | treatment — cursor compaction ON |
+| `db1` | `false` | control |
+| `db2` | `false` | control |
+
+`use` first (so `update-config` resolves `current` to the new version), then patch, then start.
+
+```bash
+$EDB cassandra use 6.0-rustyrazorblade
+```
+
+> **A patch file is a complete config, not a delta.** `update-config` rebuilds
+> `conf/cassandra.yaml` from pristine `conf.orig` on every apply, so a file containing only
+> `cursor_compaction_enabled` strips seeds, cluster name and data directories, and the node dies
+> at startup with `Found no candidates during initialization ... [/127.0.0.1:7000]`.
+> `cassandra use` above already applied `cassandra.patch.yaml` to all three nodes, so `db0` is
+> done — only the control arm needs a second, complete file.
+
+```bash
+CLUSTER_DIR=$(dirname "$EDB")
+derive-host-patch.sh "$CLUSTER_DIR/cassandra.patch.yaml" \
+                     "$CLUSTER_DIR/cursor-off.patch.yaml" \
+                     cursor_compaction_enabled=false
+
+$EDB cassandra update-config cursor-off.patch.yaml --hosts db1,db2
+```
+
+**Verify the written config on all 3 nodes BEFORE starting.** A node that starts with a
+stripped config takes the whole cluster down with it, so check first rather than debugging after:
+
+```bash
+CLUSTER_DIR=$(dirname "$EDB")
+for h in db0 db1 db2; do
+  echo "== $h"
+  ssh -F "$CLUSTER_DIR/sshConfig" $h \
+    "grep -E 'seeds:|cluster_name:|cursor_compaction' \
+     /usr/local/cassandra/current/conf/cassandra.yaml"
+done
+```
+
+**Expect:** all 3 show `seeds:` and `cluster_name:`; `db1`/`db2` additionally show
+`cursor_compaction_enabled: false`; `db0` shows no `cursor_compaction` key at all.
+**Fail if:** any node is missing `seeds:` — do not start, re-apply the correct superset patch.
+
+```bash
+$EDB cassandra start
+```
+
+**Expect:** all 3 nodes start on the custom build. A startup failure here means the config is
+wrong, not the key — stop rather than continue with a broken arm.
+
+Verify, on each node:
+
+- `nodetool version` reports 6.0-alpha3
+- the running Cassandra process is under **Java 21** (not the AMI default)
+- `nodetool status` shows 3 nodes `UN`
+
+> `$EDB cassandra nodetool status` rejects passthrough args ("Unmatched arguments from index 1").
+> Go through ssh instead:
+> `ssh -F "$(dirname "$EDB")/sshConfig" db0 "/usr/local/cassandra/current/bin/nodetool status"`
+
+**Fail if:** the JVM is any version other than 21 — the tarball was built on Temurin 21.0.12,
+so a runtime mismatch is a real defect in how `--java` is recorded and consumed.
+
+---
+
+## Step 9 — 4h stress run
+
+The perf half of this plan. Custom perf patches are in this build; this is the load that
+exercises them.
+
+```bash
+$EDB cassandra stress start RandomPartitionAccess -d 4h --rate 100k --maxrlat 10 --maxwlat 10
+```
+
+Args after the subcommand pass through verbatim to cassandra-easy-stress.
+
+**Monitor:** Grafana on the control node (`cassandra-overview`, `system-overview`), plus
+`$EDB cassandra stress status` / `stress logs`.
+
+**Record for the report:**
+
+- achieved throughput vs the requested 100k
+- read/write latency distributions against the `--maxrlat 10` / `--maxwlat 10` ceilings
+- GC behaviour and CPU saturation across the 4h window
+- any compaction backlog build-up
+
+**The cursor-compaction A/B — break every compaction metric out per node**, `db0`
+(ON) against `db1`/`db2` (OFF), since all three take the same load:
+
+- compaction throughput and pending-task depth
+- time spent in compaction, and compaction-related CPU
+- read latency as a function of SSTable count per node
+- any divergence in disk I/O between the arms
+
+Caveat to state in the report rather than correct for: the arms are not evenly sized (1 vs 2),
+and per-node load is only as even as the token distribution makes it.
+
+**Known failure mode to report, not work around:** if `--rate 100k` exceeds what the cluster
+can absorb, cassandra-easy-stress aborts queue-full (same mode #875 documented for the sysbench
+kit). Report it as a result — do not silently lower the rate.
+
+---
+
+## Teardown
+
+**Do not tear down automatically.** The 4h run is the point of the cluster; leave it up for
+inspection afterwards and tear down only on explicit instruction:
+
+```bash
+$EDB down --auto-approve
+```


### PR DESCRIPTION
Closes #876

## Summary

Adds `cassandra install <version>` to install a Cassandra version onto an already-provisioned, running cluster without an AMI rebuild — extracting the existing install logic (both the tarball and git-branch modes, unchanged in capability) into a standalone, flag-driven script used identically at AMI bake time and at runtime. Also adds `lazy: true` version declarations (discoverable via `cassandra list` before install), fixes `cassandra use` to fail clearly instead of leaving a dangling symlink when a version isn't installed, and fixes a latent bug where `HostOperationsService.withHosts(parallel = true)` silently swallowed per-host exceptions.

## Review process

Went through 3 rounds of a 5-lens review panel (spec conformance, code correctness, security, test rigor, observability), plus one owner-directed fix pass for the round-3 residuals, all independently verified:

- **Round 1** found and fixed two blockers: a lazy-version idempotency bug that made the headline feature never actually install, and an SSH client that discarded all remote command output on failure (breaking both `use-cassandra`'s new error message and every install-failure reason).
- **Round 2** found the round-1 fixes were incomplete in two areas and fixed both: credential handling across 5 distinct leak/persistence paths (a URL passed to `--url` could reach logs, a serialized event, and — most seriously — get persisted indefinitely in every targeted node's `/etc/cassandra_versions.yaml`, even though nothing there reads it), and the push-up/rollback logic making presence-based decisions where value-based ones were needed (a resolved override could silently never reach the node; a post-completion failure could leave a version installed-but-undeclared with no recovery path). Rollback-on-failure was dropped entirely in favor of treating declared-but-uninstalled as the intentional, harmless steady state.
- **Round 3**: 3 of 5 lenses approved outright, confirming the round-2 fixes hold up under independent re-scrutiny. 3 residual findings remained: the underlying SSH library's own DEBUG-level logging sat one layer below the chosen redaction boundary; re-running install with different flags on an already-installed node was a silent no-op; and the failure-path workdir cleanup had no test coverage (verified correct, just untested).
- **Owner-directed final pass** closed all three: narrowed SSH transport logging to INFO (with a behavioral test locking in both directions), added a distinct "declaration mismatch" outcome/event so changed flags are surfaced instead of silently dropped (and — this being the state that's actually unrecoverable — an installed-but-undeclared version is now automatically repaired rather than left broken), and added the missing cleanup test (which itself caught a macOS/BSD `mktemp` quirk that would have made a naive version of the test pass vacuously).
- **Build pass** additionally caught and fixed two CI-only failures (a mistagged GitHub Action, a snap-confined `yq` that couldn't see test fixtures) and a genuine intermittent race in the new test suite's parallel-host assertions.

## Testing

The unit tier runs locally (`./gradlew test`, plus three new bash test suites totaling 37 assertions for the extracted `install-cassandra-version` script, the rewritten bake-time loop, and `use-cassandra`'s existence guard); the full/integration suite runs in CI, where all 13 checks are green. `ktlintCheck`/`detekt`/shellcheck all clean. Container-based verification was re-run repeatedly against the actual shell scripts throughout (both install modes, no-op idempotency, failure cleanup, `use-cassandra`'s guard).

Not exercised anywhere: the git-branch install path against a real remote (pre-existing dead code before this change — zero `cassandra_versions.yaml` entries use it today; both install modes are code-identical between bake time and runtime, and the tarball mode is exercised extensively).

## Follow-ups surfaced, not filed (owner triage)

- `HostOperationsService`'s shared SSH retry config has a largely-inert `IOException` entry (resilience4j's decorator only catches `RuntimeException`) — pre-existing, repo-wide, unrelated to this change.
- `Event.Ssh.CommandOutput` has no host field, so parallel command output is unattributable in the console/MCP/Redis stream.
- `cassandra list` only queries the first Cassandra node, so it can under-report cluster state after a `--hosts`-filtered install (pre-existing).
- `secret = true` commands still leak their success-path output verbatim (only the failure path was hardened); reachable via `TailscaleService`'s auth key.
- A handful of pre-existing shellcheck style/info findings (~150) below CI's enforced `severity: error` threshold on the touched scripts.
- Local `integrationTest` is flaky under rapid back-to-back Gradle runs in the same worktree (a result-aggregation collision, not a test defect) — unrelated to this PR.
