### PR TITLE
spec-flow: this repo states its own policy

### DIFF
--- a/spec-flow/TESTING.md
+++ b/spec-flow/TESTING.md
@@ -1,0 +1,81 @@
+# Test and CI policy — easy-db-lab
+
+This repo owns this file. spec-flow reads it and ships no default; if it goes away, the
+pipeline stops rather than falling back to anything. Every line here is ours to change,
+including the local/CI split itself. Keep it short — every implementation and review
+agent reads it on every run.
+
+## The suite is two tiers
+
+- **Unit tier** — `src/test/kotlin`, run by `./gradlew test`. No Docker, no sockets, no
+  real I/O.
+- **Integration tier** — `src/integrationTest/kotlin`, run by `./gradlew integrationTest`.
+  TestContainers, the Fabric8 kubernetes-server-mock, okhttp MockWebServer, fixed-port
+  sockets.
+
+The split is enforced by the compiler, not by convention. `testcontainers`,
+`fabric8 kubernetes-server-mock` and `okhttp-mockwebserver` are scoped to
+`integrationTestImplementation` only. A test that needs one of them does not compile
+under `src/test/`. Put it in the integration tier.
+
+## Local gate — runs on every TDD cycle
+
+```bash
+./gradlew test
+```
+
+The fast tier only. This runs on every red-green-refactor cycle, so it must stay fast.
+Do not put the integration tier here.
+
+## Local gate — before pushing a branch
+
+```bash
+./gradlew ktlintFormat
+./gradlew check
+```
+
+`check` runs both test tiers plus `detekt` and `ktlintCheck`. **Run it on JDK 21.**
+detekt 1.23.8 cannot run under a JDK 25 runtime. Compiling, running and testing the app
+work on 25; `check` and `detekt` do not.
+
+The integration tier needs a running Docker daemon. If TestContainers fails to start,
+that is a broken local Docker, not a broken test. Say so and stop. Never record a
+TestContainers failure as pre-existing or environment-specific.
+
+## CI — `.github/workflows/pr-checks.yml`
+
+CI is a real test gate. Two jobs run in parallel on every pull request and every push to
+`main`:
+
+- `test` — `./gradlew test integrationTest koverXmlReport` on JDK 21. GitHub's ubuntu
+  runners ship a running Docker daemon, so the integration tier runs for real.
+- `quality` — `./gradlew ktlintCheck` then `./gradlew detekt` on JDK 21.
+
+Kover reports coverage to the PR with an 80% floor, overall and on changed files.
+
+On any test failure the `test` job writes every failing test id, one
+`com.example.FooTest.method` per line across both tiers, and uploads it as the
+`spec-flow-failures` artifact. `/spec-flow:sync-ci` pulls that into the branch's flagged
+set. This contract is already wired. Do not break it when editing the workflow.
+
+## Merge gate
+
+Green CI is necessary and not sufficient. **GitHub does not enforce it.** `main` has
+branch protection, but its required-status-check list is empty, so nothing blocks a merge
+mechanically. The gate is ours to hold:
+
+1. Both CI jobs are green.
+2. The owner has tested the change, on a real cluster where the change touches cluster
+   behavior.
+3. The owner squash-merges.
+
+**Never use `gh pr merge --auto`.** It has merged a PR here before CI finished. Poll the
+checks and merge only on green.
+
+An agent never merges a feature PR on its own unless the issue carries the
+`merge-on-green` label, and even then only after every required check reports green.
+
+## Push cadence
+
+Push the issue branch and open a PR. Never push to `main`. CI runs both tiers on the PR,
+so results are ready by the time a human looks.

--- a/spec-flow/WORKFLOWS.md
+++ b/spec-flow/WORKFLOWS.md
@@ -1,0 +1,64 @@
+# Review panel policy — easy-db-lab
+
+This repo owns this file. spec-flow reads it and ships no default; if it goes away, the
+pipeline stops rather than falling back to anything. Every line here is ours to change,
+including whether a panel runs at all. Keep it short — every implementation and review
+agent reads it on every run.
+
+## The panel
+
+Five lenses run concurrently on the branch diff after the developer agent's first green
+commit. Each earns its slot for a reason specific to this repo:
+
+- **`reviewer`** — spec conformance plus this repo's own conventions. The conventions are
+  unusually load-bearing here: typed `Event.Domain.*` versus `println()`, no
+  `Event.Message`/`Event.Error`, fabric8 builders over YAML strings, kotlinx.serialization
+  over Jackson, resilience4j over hand-rolled retry loops, constants in `Constants`. All
+  are written in `CLAUDE.md`, and none are caught by a compiler.
+
+- **`code-reviewer`** — correctness only. Logic errors, boundary mistakes, unhandled error
+  paths, `!!` on nullable values, concurrency faults, resource leaks.
+
+- **`security-reviewer`** — self-gating; returns empty on a diff with no security surface.
+  It earns its slot because this repo holds AWS credentials, opens SSH sessions, and runs
+  a SOCKS proxy whose global-property misuse caused a real incident. Never set the
+  `socksProxyHost` / `socksProxyPort` JVM properties; see `Socks5ProxySelector` and
+  REQ-NET-005.
+
+- **`test-rigor-reviewer`** — this repo bans mock-echo tests outright: a test that only
+  verifies a mock was called with the values it was handed proves nothing. It also bans
+  mocking `TemplateService`, and bans mocking `K8sService` or `RemoteOperationsService`
+  to test manifest application. This lens is what catches those.
+
+- **`observability-reviewer`** — the product is an observability lab. New code paths and
+  failure modes must be diagnosable, and events must carry structured fields rather than
+  prose.
+
+## What must be fixed
+
+Blocking. The fix loop runs until these are gone:
+
+- Any correctness finding.
+- Any security finding the security lens did not self-gate away.
+- Any convention finding that contradicts `CLAUDE.md` or a package-level `CLAUDE.md`.
+- Any missing test on a code path that makes a decision, transforms data, or can fail.
+
+Advisory. Recorded in the PR, not blocking:
+
+- Style preferences with no rule behind them.
+- Over-built test findings, unless the test churn is large enough to slow the suite.
+
+## Never fixed by weakening the check
+
+A finding is never resolved by disabling functionality, making a dependency optional,
+skipping a test, adding a memory limiter to an OTel collector, or lowering a threshold.
+If a check cannot pass, that is a real problem. Surface it to the owner and stop.
+
+Backwards compatibility is never a finding. Clusters here are ephemeral; there is no
+migration path to preserve. Large `storageSize` defaults are never a finding either; the
+local-storage provisioner ignores PVC capacity.
+
+## Round cap
+
+Three fix rounds. If blocking findings remain after the third, stop and hand the issue to
+the owner with what is left. Do not loop further.


### PR DESCRIPTION
Adds spec-flow/TESTING.md, spec-flow/WORKFLOWS.md, this repo's own spec-flow policy.

spec-flow reads this file at the start of every run. It ships no default and falls back to nothing,
so this file is the only thing the pipeline obeys — and every line of it is yours to change,
including the local/CI split itself.

Seeded by `/spec-flow:setup` from a proposal you confirmed. Nothing here was written without your
say-so. Review it as you would any other PR; nothing merges it for you.