### PR TITLE
spec-flow: adopt pipeline settings and correct the merge gate policy

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,15 @@
 {
-  "agent": "project-manager",
   "enabledPlugins": {
     "cassandra-expert@rustyrazorblade-plugins": true,
     "easy-db-lab@rustyrazorblade-plugins": true,
-    "spec-flow@rustyrazorblade-plugins": true
+    "spec-flow@rustyrazorblade-plugins": true,
+    "dev-skills@rustyrazorblade-plugins": true
+  },
+  "agent": "spec-flow:project-manager",
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "SPEC_FLOW_SEAM_VIEW": "explain",
+    "SPEC_FLOW_DEVELOPER_AGENT": "kotlin-dev",
+    "SPEC_FLOW_REFACTOR_BREAKER": "ask"
   }
 }

--- a/spec-flow/TESTING.md
+++ b/spec-flow/TESTING.md
@@ -60,14 +60,21 @@ set. This contract is already wired. Do not break it when editing the workflow.
 
 ## Merge gate
 
-Green CI is necessary and not sufficient. **GitHub does not enforce it.** `main` has
-branch protection, but its required-status-check list is empty, so nothing blocks a merge
-mechanically. The gate is ours to hold:
+**GitHub enforces the CI gate.** An active repository ruleset on `main` requires three
+status checks — `test`, `quality`, `claude-review` — and adds `deletion` and
+`non_fast_forward` rules. A direct push to `main` is rejected. Read it with
+`gh api repos/OWNER/REPO/rulesets`; the classic
+`gh api repos/OWNER/REPO/branches/main/protection` endpoint reports an empty
+required-check list and is misleading here.
 
-1. Both CI jobs are green.
+Green CI is necessary and not sufficient. The rest of the gate is ours to hold:
+
+1. All three required checks are green.
 2. The owner has tested the change, on a real cluster where the change touches cluster
    behavior.
 3. The owner squash-merges.
+
+Every change reaches `main` through a pull request. There is no direct-push path.
 
 **Never use `gh pr merge --auto`.** It has merged a PR here before CI finished. Poll the
 checks and merge only on green.


### PR DESCRIPTION
Two commits, no code.

**`chore(spec-flow)`** — `.claude/settings.json`. Pins the default agent to
`spec-flow:project-manager` so a plugin name collision cannot redirect the entry point.
Enables agent teams for team-led `implement`, routes seam rendering through the
`dev-skills` `ide-explain` skill, selects `kotlin-dev` as the developer agent, and sets
the refactor circuit breaker to `ask`.

**`docs(spec-flow)`** — `spec-flow/TESTING.md`. The merge gate section landed in #885
claiming GitHub enforced nothing. That was wrong. It was written from
`gh api repos/OWNER/REPO/branches/main/protection`, which reports an empty
required-check list here.

The real gate is a repository ruleset on `main`, enforcement `active`:

- required status checks: `test`, `quality`, `claude-review`
- `deletion`
- `non_fast_forward`

A direct push to `main` is rejected. This PR exists because that push was rejected.

The section now states the enforcement accurately and names
`gh api repos/OWNER/REPO/rulesets` as the endpoint to read, so the misleading one is not
consulted again.