### PR TITLE
Kit detection registers any directory with a bin/ as a kit

### DIFF
--- a/docs/user-guide/platform-substrate.md
+++ b/docs/user-guide/platform-substrate.md
@@ -84,6 +84,9 @@ The `install` command can render templates from a custom directory:
 easy-db-lab kit install --from ./my-kit/ --kit my-kit --size 50Gi
 ```
 
+The directory must contain a `kit.yaml`. Without it the install is rejected before anything is
+written to the workspace, because `kit.yaml` is what marks an installed directory as a kit.
+
 ### Template Variable Contract
 
 All templates receive these standard variables from cluster state:

--- a/openspec/changes/issue-888/.openspec.yaml
+++ b/openspec/changes/issue-888/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/issue-888/ac-coverage.md
+++ b/openspec/changes/issue-888/ac-coverage.md
@@ -1,0 +1,16 @@
+# Acceptance criteria coverage
+
+| Source | Requirement | Covering scenario(s) | Status |
+|--------|-------------|----------------------|--------|
+| AC | `bin/start.sh` but no `kit.yaml` → not registered, absent from `-h` | `workload-runner: Dir without kit.yaml is not registered`; `workload-runner: Help omits a bin/-only directory` | ✅ Covered |
+| AC | Holds `kit.yaml` → registered under the directory name | `workload-runner: Kit dir with kit.yaml discovered`; `workload-runner: Multiple workloads discovered`; `install-command: An installed kit directory carries its descriptor` | ✅ Covered |
+| AC | Holds both `kit.yaml` and `bin/start.sh` → `<kit> start` stays valid | `workload-runner: Kit dir with kit.yaml discovered` | ✅ Covered |
+| AC | Holds neither marker → not registered | `workload-runner: Dir with neither marker is not registered` | ✅ Covered |
+| AC | `status` lists only the `kit.yaml` directory | `workload-runner: status lists only directories holding kit.yaml` | ✅ Covered |
+| AC | Only `bin/`-only dirs → no `=== KITS ===` section | `workload-runner: status omits the KITS section when nothing qualifies` | ✅ Covered |
+| AC | Predicate changes → both call sites change; no inline copy remains | `workload-runner: Both listings agree` (requirement: Filesystem kit discovery has a single source of truth) | ✅ Covered |
+| Owner | `kit.yaml` invariant: every non-Kotlin kit directory has one, no exceptions | `install-command: Kit descriptor filename` (requirement text) + `An installed kit directory carries its descriptor` | ✅ Covered |
+| Risk | `kit install --from <dir>` with no `kit.yaml` installs a kit that no longer registers, silently | `install-command: --from rejects a template without kit.yaml`; `install-command: --from accepts a template with kit.yaml` | ✅ Covered |
+| Risk | Kits installed via `kit install <name>` could lose registration | `install-command: An installed kit directory carries its descriptor` | ✅ Covered |
+| Risk | `CommandLineParser` registration path is not directly tested end to end | `CommandLineParserTest` — renders `--help` over a workspace holding `clickhouse/kit.yaml` and an executable `trunk/bin/cassandra`, asserting `clickhouse` is listed and `trunk` is not | ✅ Covered — `design.md` records this as excluded on the premise that a test needed three mocked Koin dependencies. That premise was wrong: the test needs five real Koin definitions and no mocks, and costs 3.891s in the parallel run. Added in the review fix round, and mutation-tested — re-inlining a `bin/` predicate turns it red. |
+| Risk | `CommandLineParser` loses its last `java.io.File` use; stale import fails ktlint | — | ⚠️ Excluded — build-mechanical, not a behavior contract. Caught by task 5.1 (`ktlintCheck`), and called out explicitly in task 2.3. |

--- a/openspec/changes/issue-888/design.md
+++ b/openspec/changes/issue-888/design.md
@@ -1,0 +1,139 @@
+# Design
+
+## Context
+
+Two call sites carry a copied-inline predicate deciding whether a workspace subdirectory is an
+installed kit:
+
+- `CommandLineParser.registerDynamicKitSubcommands()` (around lines 251-295)
+- `Status.displayKitsSection()` (around lines 419-435)
+
+Both compute `hasBinScripts || hasConfigYaml`. The `hasBinScripts` leg is the defect. They share no
+class today: `Status` does not use `KitRunnerCommandFactory`, and the two want different return
+shapes — the parser needs `File` objects to build kit groups from, `Status` needs sorted names for
+display. Where the shared rule lives was the open design question.
+
+## Goals / Non-Goals
+
+**Goals.** One implementation of the rule, consumed by both call sites. `kit.yaml` as the sole
+marker. The rule written down in the specs rather than implied.
+
+**Non-Goals.** Name-collision handling where a kit directory shadows a core command. Any new
+warning or diagnostic for a rejected directory. The `kit uninstall` phase rule. The behavior of
+`KitRunnerCommandFactory.collectScriptPhases()` — this changes which directories qualify, not what a
+qualified kit exposes. The unparseable-`kit.yaml` case, which keeps its warn-and-fall-back behavior:
+there the file exists, so the directory still registers.
+
+## Decisions
+
+### `WorkspaceKitScanner`, a Koin service in `services/`
+
+```kotlin
+class WorkspaceKitScanner(private val context: Context) {
+    fun isInstalledKit(dir: File): Boolean =
+        dir.isDirectory && File(dir, Constants.Kit.CONFIG_FILE).isFile
+
+    fun discover(): List<File> =
+        context.workingDirectory.listFiles().orEmpty().filter { isInstalledKit(it) }
+}
+```
+
+Registered with one line in `services/ServicesModule.kt` beside the other kit registrations:
+`singleOf(::WorkspaceKitScanner)`.
+
+`KitSourcesProvider` is the same shape already — a small class over `Context`, `singleOf`-registered,
+filesystem-only, no external side effects. `Status` injects services with `by inject()`;
+`CommandLineParser` resolves them with `get<T>()` in the same init path. The layering holds: commands
+read from a service, the service reads the filesystem.
+
+### The seam is `discover(): List<File>`, not the bare predicate
+
+Both call sites share the whole head of the pipeline —
+`listFiles().orEmpty().filter { isDirectory }.filter { predicate }` — and differ only in the tail.
+Sharing just the boolean would leave the `listFiles()` null handling duplicated, which is the part
+with a real failure mode.
+
+`Status` appends `.map { it.name }.sorted()` itself, because sort order is a display concern. No
+`discoverNames()` method: it would add public surface for one `map`.
+
+`isInstalledKit(dir)` stays public. It states the rule in one place and reads better than an inlined
+`File(dir, CONFIG_FILE).isFile` at any future call site.
+
+### `kit install --from` enforces the invariant
+
+`resolveAdHoc` currently requires only that the path is an existing directory:
+
+```kotlin
+require(dir.isDirectory) { "Template path does not exist or is not a directory: $path" }
+```
+
+A second `require` beside it rejects a template with no `kit.yaml`. This is where the check belongs:
+it is the single entry point for the ad-hoc path, it fails before anything is written to disk, and it
+matches the guard already there.
+
+`kit install <name>` needs no equivalent check. That path only registers an install subcommand when
+`loadInstallConfig(source)` returns non-null, so a template with no parseable descriptor never gets a
+subcommand to invoke.
+
+Rejected: writing a minimal `kit.yaml` when the template has none. It would paper over a malformed
+template rather than enforce the rule, and the invariant is meant to hold because installation
+enforces it, not because the tool patches around violations.
+
+### Naming
+
+`WorkspaceKitScanner`, not `InstalledKitScanner`. Kits registered in the tool in code are not
+discovered from the filesystem, so a name promising "every installed kit" would overclaim once both
+registration paths exist. `WorkspaceKitScanner` names what is actually scanned.
+
+## Alternatives Considered
+
+**A top-level function `discoverInstalledKits(workingDirectory: File)` in `services/`.** The close
+runner-up, and a legitimate choice. Zero DI wiring, and the repo does have top-level functions
+(`kubernetes/getLocalKubeconfigPath`). Rejected only because a class matches the existing
+`KitSourcesProvider` precedent and satisfies the project's class-KDoc convention naturally. Nothing
+else in the design changes if this is preferred.
+
+**A companion function on `KitRunnerCommandFactory`.** Rejected. It would make `Status` depend on the
+PicoCLI group builder. The factory builds command specs; it does not own a filesystem query. It is
+also not Koin-registered.
+
+**An extension on `Context`.** Rejected. `Context` is a broad config holder in the root package.
+Kit-domain knowledge does not belong there.
+
+**The `core` module.** Rejected. `Constants` lives in the root module, so `core` cannot reference
+`Constants.Kit.CONFIG_FILE` without moving `Constants` too — an unrelated migration.
+
+**An extension point for future marker types.** Explicitly rejected by the owner. The rule is a hard
+invariant, not a pluggable strategy. Kotlin-native kits (issue 879) are registered in code and never
+reach this predicate, so there is no second marker to accommodate.
+
+**Writing a minimal `kit.yaml` when an ad-hoc `--from` template has none.** Rejected by the owner. It
+would paper over a malformed template rather than enforce the rule. The invariant is stated in the
+spec instead; see "Risks" below for the residual exposure.
+
+## Risks / Trade-offs
+
+**`kit install --from <dir>` on a template with no `kit.yaml` now fails where it used to succeed.**
+That is the intent: such an install would otherwise produce a kit directory that registers nothing,
+with no error — a silent failure, which is the mode this repo's fail-fast convention exists to
+avoid. The template was always malformed; the old `bin/` predicate merely hid it.
+
+Whether any real `--from` template lacks a descriptor is unknown. The repo contains no such fixture
+and every built-in kit ships one, so the expected blast radius is zero.
+
+**Kits installed by name are unaffected.** `registerDynamicInstallSubcommands()` only registers a
+`kit install <name>` subcommand when `loadInstallConfig(source)` returns non-null, and
+`BaseInstallCommand` then writes that descriptor into the installed directory. A template with no
+parseable `kit.yaml` never gets an install subcommand in the first place.
+
+**Small blast radius.** One new file, one Koin registration, two call sites each reduced to a single
+line, two test files, and the documentation. `CommandLineParser` loses its last use of
+`java.io.File`, so that import must go or ktlint fails. `Constants` stays — line 135 still uses it.
+The existing `@Suppress("TooGenericExceptionCaught")` is still needed for the surviving try/catch
+around `buildKitGroup`.
+
+**No `CommandLineParser` registration test.** There is none today, and building one pulls three Koin
+dependencies plus a ClassGraph scan in `init`. Once the predicate moves out, the registration loop
+has no branching the scanner test does not already cover, so the direct proof of "not registered"
+rests on the scanner test rather than an end-to-end registration test. Recorded as a deliberate
+trade-off, not an oversight.

--- a/openspec/changes/issue-888/overrides.md
+++ b/openspec/changes/issue-888/overrides.md
@@ -1,0 +1,62 @@
+# Overrides and conflicts
+
+## Overrides existing behavior
+
+### workload-runner: Installed workload dirs are discovered as top-level subcommands
+
+**Currently:** "At startup, the CLI SHALL scan `context.workingDirectory` for subdirectories that
+contain a `bin/` directory. Each such directory SHALL be registered as a top-level PicoCLI
+subcommand whose sub-subcommands are the executable files found in `bin/`."
+
+Its scenario "Dir without bin/ is not registered" asserts: WHEN `./clickhouse/` exists but has no
+`bin/` subdirectory, THEN `easy-db-lab clickhouse` is not registered.
+
+**This change:** the scan is for subdirectories containing a `kit.yaml` descriptor, and a `bin/`
+directory explicitly does not qualify a directory. The scenario is replaced by its inverse —
+a directory with an executable `bin/` script and no `kit.yaml` is not registered.
+
+This is the substance of the change, and it is a **correction of an error, not a reversal of
+intent**. The owner confirms the `bin/` rule was a careless mistake when the spec was written. Two
+scenarios that asserted the defect are rewritten, and one new scenario covers a directory holding
+neither marker.
+
+### workload-runner: Discovered workloads appear in --help output
+
+**Currently:** the scenario keys on `./clickhouse/bin/` existing.
+
+**This change:** it keys on `./clickhouse/kit.yaml` existing, and a second scenario asserts a
+`bin/`-only directory is absent from the listing. The requirement sentence itself is unchanged.
+
+### install-command: Kit descriptor filename
+
+**Currently:** `kit.yaml` is named as the descriptor the loader looks for, across classpath,
+profile directory, and ad-hoc `--from` sources. Nothing states that an installed kit directory must
+carry one.
+
+**This change:** adds the invariant — every kit directory installed in the workspace contains a
+`kit.yaml`, no exceptions; the descriptor is the sole marker of an installed kit, and its presence
+is a property of installation rather than of any particular template. Kits registered in code are
+excluded, because they are never discovered from the filesystem.
+
+It also adds enforcement: `kit install --from <dir>` rejects a template directory with no
+`kit.yaml`. **This changes behavior that works today** — such an install currently succeeds, and the
+resulting kit registers because its `bin/` satisfies the old predicate. After this change the
+install fails with a message naming the missing file. That is deliberate: without it the invariant
+would be stated and unenforced, and the install would silently produce a kit that registers nothing.
+
+The three existing scenarios are unchanged; three are added.
+
+## Conflicts with other in-flight changes
+
+- `kit-node-type-requirement` also touches `install-command` — **no conflict.** It adds a new
+  requirement, "Kit node-type requirement field", about a `type:` field inside `kit.yaml`. This
+  change modifies "Kit descriptor filename". Different requirements, and the two are complementary:
+  one says the descriptor must exist, the other describes a field within it.
+
+- `kit-subcommand-restructure` also touches `install-command` — **no conflict.** It modifies
+  "Dynamic install subcommands registered under `kit install`" and removes the `install --list` flag
+  and `install` as a top-level command. That is about where the *install* subcommands live in the
+  command tree. This change is about which *workspace directories* register as kit subcommands.
+  Neither touches a requirement the other touches.
+
+- No other open change touches `workload-runner`.

--- a/openspec/changes/issue-888/proposal.md
+++ b/openspec/changes/issue-888/proposal.md
@@ -1,0 +1,72 @@
+# Require kit.yaml as the sole marker of an installed kit
+
+## Why
+
+The CLI registers any working-directory subdirectory as a top-level kit command when that
+directory holds a `bin/` directory containing an executable file or a `*.sh` file. A `bin/`
+directory does not prove a kit is installed. Running `easy-db-lab -h` in a directory of Cassandra
+checkouts prints 24 false top-level commands, including `trunk`, `5.0`, `4.0`,
+`21554-cursor-flush`, and `.venv` — none of which holds a `kit.yaml`. Help output is unusable, and
+a directory name can shadow a core command.
+
+The rule is copied inline at two call sites, so `easy-db-lab status` reports the same false kits
+under `=== KITS ===`.
+
+`kit.yaml` is the correct marker and the rule is an invariant, not a heuristic: **every non-Kotlin
+kit directory has a `kit.yaml`, with no exceptions.** `kit install` writes it
+(`BaseInstallCommand.kt:58`), and `KitInstallCommand.kt:124` already treats its absence as "not
+installed". The specs currently mandate the `bin/` rule instead; that text was a careless mistake
+when written, not a design decision, so this change corrects an error rather than reversing intent.
+
+## What Changes
+
+- **BREAKING** (intentionally): a workspace subdirectory holding only a `bin/` directory is no
+  longer registered as a kit subcommand and no longer appears under `=== KITS ===` in
+  `easy-db-lab status`. Only a directory holding `kit.yaml` qualifies. This is the defect being
+  fixed; every kit installed through `kit install` carries the descriptor and is unaffected.
+- A new `WorkspaceKitScanner` service becomes the single source of truth for filesystem kit
+  discovery, exposing `isInstalledKit(dir)` and `discover(): List<File>`.
+- `CommandLineParser.registerDynamicKitSubcommands()` and `Status.displayKitsSection()` both
+  consume that service. Neither retains an inline copy of the rule, so the two listings cannot
+  disagree.
+- The `kit.yaml` invariant is stated explicitly in the specs, so the rule is written down rather
+  than implied by an implementation detail.
+- `kit install --from <dir>` rejects a template directory with no `kit.yaml`, with a clear message.
+  That path is the one way to produce a descriptor-less kit directory today; without the check the
+  invariant would be stated but not enforced, and such an install would silently register nothing.
+- Which phases a qualified kit exposes is unchanged. This alters which directories qualify, not
+  what a qualified kit does.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `workload-runner` — the discovery requirement and its scenarios currently specify `bin/` as the
+  marker. The requirement sentence, three scenarios under it, and one scenario under the `--help`
+  requirement all change to `kit.yaml`. A new requirement states the invariant.
+- `install-command` — the narrative describing how an installed kit is detected currently states
+  the `bin/` rule, and its example directory tree depicts a kit directory with no `kit.yaml`, which
+  would not register under the corrected rule.
+
+## Impact
+
+- `src/main/kotlin/com/rustyrazorblade/easydblab/services/WorkspaceKitScanner.kt` — new.
+- `src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt` — one Koin
+  registration.
+- `src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt` — predicate removed, KDoc
+  corrected, now-unused `java.io.File` import removed.
+- `src/main/kotlin/com/rustyrazorblade/easydblab/commands/Status.kt` — inline predicate removed,
+  scanner injected.
+- `src/main/kotlin/com/rustyrazorblade/easydblab/services/InstallTemplateResolver.kt` — one added
+  `require` in `resolveAdHoc`, beside the existing directory check.
+- `src/main/kotlin/com/rustyrazorblade/easydblab/commands/CLAUDE.md` — the
+  `<kit> start/stop subcommands` section states the old rule.
+- Tests: one new `WorkspaceKitScannerTest`, two added cases in `StatusTest`. All fast tier
+  (`src/test/`) — no Docker, TestContainers, mock server, or socket.
+- No behavior change for any kit installed via `kit install <name>`: that path only registers an
+  install subcommand when the template's `kit.yaml` parses, and then writes that descriptor into
+  the installed directory.

--- a/openspec/changes/issue-888/specs/install-command/spec.md
+++ b/openspec/changes/issue-888/specs/install-command/spec.md
@@ -1,0 +1,37 @@
+# Install Command Spec
+
+## MODIFIED Requirements
+
+### Requirement: Kit descriptor filename
+The kit descriptor file SHALL be named `kit.yaml`.
+The CLI loader SHALL look for `kit.yaml` when resolving a kit's configuration from any template source (classpath, profile directory, or ad-hoc `--from` path).
+
+Every kit directory installed in the cluster workspace SHALL contain a `kit.yaml`, with no exceptions. That descriptor is the sole marker that a directory is an installed kit, and its presence is an invariant of installation rather than a property of any particular template. This does not apply to kits registered in the tool in code, which are not discovered from the filesystem at all.
+
+The CLI SHALL enforce that invariant at install time. `kit install --from <dir>` SHALL reject a template directory that does not contain a `kit.yaml`, failing with a message naming the missing file, before writing anything to the workspace.
+
+#### Scenario: Loader finds kit.yaml in classpath
+- **WHEN** the CLI resolves a built-in kit template
+- **THEN** it reads `kit.yaml` from the template directory
+
+#### Scenario: Loader finds kit.yaml in profile directory
+- **WHEN** a user has a custom template at `~/.easy-db-lab/profiles/<profile>/install/<name>/kit.yaml`
+- **THEN** the CLI reads that file and it overrides the built-in
+
+#### Scenario: Loader ignores config.yaml
+- **WHEN** a template directory contains `config.yaml` but no `kit.yaml`
+- **THEN** the CLI does not load it (no silent fallback)
+
+#### Scenario: An installed kit directory carries its descriptor
+- **WHEN** `kit install <name>` completes successfully
+- **THEN** the installed kit directory in the workspace contains a `kit.yaml`
+- **AND** the directory is registered as a top-level subcommand
+
+#### Scenario: --from rejects a template without kit.yaml
+- **WHEN** `kit install --from <dir>` runs against a directory holding `bin/start.sh` but no `kit.yaml`
+- **THEN** the command fails with a message naming the missing `kit.yaml`
+- **AND** nothing is written to the workspace
+
+#### Scenario: --from accepts a template with kit.yaml
+- **WHEN** `kit install --from <dir>` runs against a directory holding `kit.yaml`
+- **THEN** the install proceeds

--- a/openspec/changes/issue-888/specs/workload-runner/spec.md
+++ b/openspec/changes/issue-888/specs/workload-runner/spec.md
@@ -1,0 +1,58 @@
+# Workload Runner
+
+## MODIFIED Requirements
+
+### Requirement: Installed workload dirs are discovered as top-level subcommands
+At startup, the CLI SHALL scan `context.workingDirectory` for subdirectories that contain a `kit.yaml` descriptor. Each such directory SHALL be registered as a top-level PicoCLI subcommand whose sub-subcommands are the executable files found in `bin/`.
+
+A `bin/` directory SHALL NOT qualify a directory as an installed kit. Source checkouts, virtualenvs, and unrelated project trees contain one, and treating them as kits registered them as CLI commands.
+
+#### Scenario: Kit dir with kit.yaml discovered
+- **WHEN** `./clickhouse/kit.yaml` exists
+- **AND** `./clickhouse/bin/start` exists and is executable
+- **THEN** `easy-db-lab clickhouse start` is a valid command
+
+#### Scenario: Dir without kit.yaml is not registered
+- **WHEN** `./trunk/bin/cassandra` exists and is executable
+- **AND** `./trunk/kit.yaml` does not exist
+- **THEN** `easy-db-lab trunk` is not registered as a subcommand
+
+#### Scenario: Dir with neither marker is not registered
+- **WHEN** `./notes/` exists and contains neither `kit.yaml` nor a `bin/` subdirectory
+- **THEN** `easy-db-lab notes` is not registered as a subcommand
+
+#### Scenario: Multiple workloads discovered
+- **WHEN** both `./clickhouse/kit.yaml` and `./presto/kit.yaml` exist
+- **THEN** both `easy-db-lab clickhouse` and `easy-db-lab presto` are valid subcommands
+
+### Requirement: Discovered workloads appear in --help output
+Workload subcommands registered from the working directory SHALL appear in the top-level `easy-db-lab --help` output alongside static commands.
+
+#### Scenario: Help lists discovered workload
+- **WHEN** `./clickhouse/kit.yaml` exists and `easy-db-lab --help` is run
+- **THEN** `clickhouse` appears in the command listing
+
+#### Scenario: Help omits a bin/-only directory
+- **WHEN** `./trunk/bin/cassandra` exists and is executable, `./trunk/kit.yaml` does not exist, and `easy-db-lab --help` is run
+- **THEN** `trunk` does not appear in the command listing
+
+## ADDED Requirements
+
+### Requirement: Filesystem kit discovery has a single source of truth
+Every part of the CLI that reports which kits are installed on disk SHALL determine that from one shared implementation. No call site SHALL carry its own copy of the rule.
+
+This covers at least dynamic subcommand registration and the `=== KITS ===` section of `easy-db-lab status`, so the two read one discovery rule. Registration MAY still drop a discovered kit afterwards — on a name collision with a core command, or when building its command group fails — so the two listings are not guaranteed identical.
+
+#### Scenario: status lists only directories holding kit.yaml
+- **WHEN** the working directory holds `./clickhouse/kit.yaml` and an executable `./trunk/bin/cassandra` with no `./trunk/kit.yaml`
+- **AND** `easy-db-lab status` runs
+- **THEN** the `=== KITS ===` section lists `clickhouse` and does not list `trunk`
+
+#### Scenario: status omits the KITS section when nothing qualifies
+- **WHEN** the working directory holds only directories with a `bin/` and no `kit.yaml`
+- **AND** `easy-db-lab status` runs
+- **THEN** no `=== KITS ===` section is printed
+
+#### Scenario: Both listings agree
+- **WHEN** the discovery rule changes
+- **THEN** subcommand registration and the `status` listing change together, because both read the same implementation

--- a/openspec/changes/issue-888/tasks.md
+++ b/openspec/changes/issue-888/tasks.md
@@ -1,0 +1,83 @@
+# Tasks
+
+## 1. The shared scanner
+
+- [x] 1.1 Create `src/main/kotlin/com/rustyrazorblade/easydblab/services/WorkspaceKitScanner.kt`
+      with `isInstalledKit(dir: File): Boolean` and `discover(): List<File>`. `kit.yaml`
+      (`Constants.Kit.CONFIG_FILE`) is the sole marker. Class KDoc states the rule and why a `bin/`
+      directory does not qualify.
+- [x] 1.2 Register it in `services/ServicesModule.kt` beside the other kit registrations:
+      `singleOf(::WorkspaceKitScanner)`.
+
+## 2. Both call sites
+
+- [x] 2.1 `CommandLineParser.registerDynamicKitSubcommands()`: replace the `listFiles`/`filter`/
+      `hasBinScripts`/`hasConfigYaml` block with `get<WorkspaceKitScanner>().discover()`. Leave the
+      subcommand-name guard and the try/catch around `buildKitGroup` untouched.
+- [x] 2.2 Rewrite that method's KDoc (lines 251-259) to state the `kit.yaml`-only rule. It currently
+      documents the defect.
+- [x] 2.3 Remove the now-unused `java.io.File` import from `CommandLineParser.kt`. Keep `Constants`;
+      line 135 still uses it. ktlint fails otherwise.
+- [x] 2.4 `Status`: inject `WorkspaceKitScanner`, and reduce `displayKitsSection()`'s first statement
+      to `workspaceKitScanner.discover().map { it.name }.sorted()`. Everything below the
+      `isEmpty()` guard is unchanged.
+- [x] 2.5 Reword `displayKitsSection()`'s KDoc so "same detection as dynamic subcommand
+      registration" names the shared type instead of describing a coincidence.
+
+## 3. Enforce the invariant at install time
+
+- [x] 3.1 `services/InstallTemplateResolver.kt`, `resolveAdHoc` (lines 133-137): add a second
+      `require` beside the existing directory check, rejecting a template directory with no
+      `kit.yaml` (`Constants.Kit.CONFIG_FILE`). The message must name the missing file. This fails
+      before anything is written to the workspace.
+- [x] 3.2 `readInstallYamlContent`'s KDoc (lines 139-144) says `config.yaml` twice; the file it
+      reads is `kit.yaml`. One-line correction in a method being read for this change — folded in
+      because it documents the very rule this change is codifying.
+
+## 4. Tests
+
+All fast tier, `src/test/`. Nothing here needs Docker, TestContainers, the Fabric8 mock server, or a
+socket.
+
+- [x] 4.1 New `src/test/kotlin/com/rustyrazorblade/easydblab/services/WorkspaceKitScannerTest.kt`,
+      extending `BaseKoinTest`. Koin is needed only to obtain the test `Context`, whose
+      `workingDirectory` is already an isolated temp dir. No mocks — the class has no side effects
+      worth faking. Use AssertJ.
+- [x] 4.2 Cover: a `bin/start.sh`-only directory is not discovered; `trunk/bin/cassandra` plus
+      `.venv/bin/activate` yields an empty result (the issue's own reproduction — this is the test
+      that fails before the fix); a directory with `kit.yaml` is discovered; a directory with both
+      markers is discovered exactly once; a `kit.yaml` that is a directory rather than a file does
+      not qualify; a plain file at the workspace root is not discovered; an empty workspace returns
+      an empty list without throwing.
+- [x] 4.3 Add two cases to `commands/StatusTest.kt`, reusing its existing stdout capture: given
+      `clickhouse/kit.yaml` and an executable `trunk/bin/cassandra`, the output lists `clickhouse`
+      under `=== KITS ===` and does not contain `trunk`; given only a `bin/`-holding directory, no
+      `=== KITS ===` header is printed.
+- [x] 4.4 Cover `resolveAdHoc` in the existing `InstallTemplateResolver` test (or a new one if none
+      exists): a `--from` directory holding `bin/start.sh` and no `kit.yaml` is rejected, and the
+      message names the missing file; a directory holding `kit.yaml` resolves. Fast tier.
+
+## 5. Specs and documentation
+
+- [x] 5.1 `openspec/specs/workload-runner/spec.md`: edit the Purpose line (line 5) only. The
+      requirement sentence and every scenario under it live in this change's delta
+      (`openspec/changes/issue-888/specs/workload-runner/spec.md`) and are applied to the live
+      spec by `openspec archive`, in its own batch commit. A feature branch never edits a
+      requirement block here; doing so applies the delta twice.
+- [x] 5.2 `openspec/specs/install-command/spec.md`: edit the non-requirement narrative only — the
+      Purpose clause (lines 5-7) and the "Kit runner subcommands" section (lines 208-210), both of
+      which state the old rule, plus the example tree (lines 214-220), which depicts a kit
+      directory with no `kit.yaml`. Archive never touches narrative prose, so these must be
+      corrected in this branch. The additions to the "Kit descriptor filename" requirement are in
+      the delta and are applied by `openspec archive`.
+- [x] 5.3 `src/main/kotlin/com/rustyrazorblade/easydblab/commands/CLAUDE.md`, the
+      `<kit> start/stop subcommands` section (lines 146-155): replace the `bin/`-with-executable
+      sentence with the `kit.yaml` rule, naming `WorkspaceKitScanner` as the source of truth shared
+      with `status`.
+
+## 6. Verify
+
+- [x] 6.1 `./gradlew ktlintFormat && ./gradlew ktlintCheck`
+- [x] 6.2 `./gradlew test` — the full fast tier, not just the new tests.
+- [x] 6.3 `./gradlew detekt` (JDK 21; detekt 1.23.8 cannot run under JDK 25).
+- [x] 6.4 `openspec validate issue-888 --type change --strict`

--- a/openspec/specs/install-command/spec.md
+++ b/openspec/specs/install-command/spec.md
@@ -2,9 +2,10 @@
 
 ## Purpose
 
-The `install` command group scaffolds kit-specific files (Helm values, scripts, README) into a
-local directory. Users then run the kit via `easy-db-lab <kit> start` — the CLI reads the
-generated `bin/` scripts and registers them as top-level subcommands automatically.
+The `install` command group scaffolds kit-specific files (`kit.yaml`, Helm values, scripts,
+README) into a local directory. Users then run the kit via `easy-db-lab <kit> start` — the CLI
+recognises the directory by its `kit.yaml` and registers its `bin/` scripts as top-level
+subcommands automatically.
 
 ## Requirements
 
@@ -206,8 +207,9 @@ No Kotlin code changes are needed.
 ### Kit runner subcommands
 
 At startup, `CommandLineParser` scans `context.workingDirectory` for directories that contain a
-`bin/` subdirectory with at least one executable script. Each such directory becomes a top-level
-subcommand group; each script in `bin/` becomes a subcommand of that group.
+`kit.yaml`. Each such directory becomes a top-level subcommand group; each script in `bin/`
+becomes a subcommand of that group. A `bin/` directory alone does not qualify a directory —
+source checkouts and virtualenvs have one too.
 
 For example, after `easy-db-lab install clickhouse`:
 
@@ -216,6 +218,7 @@ clickhouse/
 ├── bin/
 │   ├── start.sh    → easy-db-lab clickhouse start
 │   └── stop.sh     → easy-db-lab clickhouse stop
+├── kit.yaml        → marks the directory as an installed kit
 └── clickhouseinstallation.yaml
 ```
 

--- a/openspec/specs/workload-runner/spec.md
+++ b/openspec/specs/workload-runner/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Discovers installed workload directories as top-level CLI subcommands, executes their `bin/` scripts with cluster state injected as environment variables, and installs their dashboards after a successful start.
+Discovers installed workload directories — those holding a `kit.yaml` descriptor — as top-level CLI subcommands, executes their `bin/` scripts with cluster state injected as environment variables, and installs their dashboards after a successful start.
 
 ## Requirements
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
@@ -48,6 +48,7 @@ import com.rustyrazorblade.easydblab.services.InstallTemplateResolver
 import com.rustyrazorblade.easydblab.services.KitCommandScanner
 import com.rustyrazorblade.easydblab.services.ScannedKitCommand
 import com.rustyrazorblade.easydblab.services.TemplateVariables
+import com.rustyrazorblade.easydblab.services.WorkspaceKitScanner
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
@@ -56,7 +57,6 @@ import picocli.CommandLine
 import picocli.CommandLine.Command
 import picocli.CommandLine.Model.CommandSpec
 import picocli.CommandLine.Spec
-import java.io.File
 import kotlin.system.exitProcess
 
 /**
@@ -249,34 +249,20 @@ class CommandLineParser : KoinComponent {
     }
 
     /**
-     * Scans the working directory for installed kit directories and registers a top-level
-     * PicoCLI subcommand for each one. A directory qualifies if it contains either:
-     * - a `bin/` subdirectory with at least one executable script, or
-     * - a `kit.yaml` with at least one typed lifecycle phase.
+     * Registers a top-level PicoCLI subcommand for every installed kit directory found by
+     * [WorkspaceKitScanner]. A directory qualifies only when it contains a `kit.yaml`; a `bin/`
+     * directory alone does not, because source checkouts and virtualenvs have one too.
      *
-     * For example, `<cwd>/clickhouse/bin/start.sh` → `easy-db-lab clickhouse start`, or
-     * `<cwd>/clickhouse/kit.yaml` with a `start` phase → `easy-db-lab clickhouse start`.
+     * For example, `<cwd>/clickhouse/kit.yaml` alongside `<cwd>/clickhouse/bin/start.sh` →
+     * `easy-db-lab clickhouse start`.
      */
     @Suppress("TooGenericExceptionCaught")
     private fun registerDynamicKitSubcommands() {
-        val ctx = get<Context>()
         val factory = KitRunnerCommandFactory()
 
-        ctx.workingDirectory
-            .listFiles()
-            .orEmpty()
-            .filter { it.isDirectory }
+        get<WorkspaceKitScanner>()
+            .discover()
             .forEach { kitDir ->
-                val hasBinScripts =
-                    File(kitDir, "bin").isDirectory &&
-                        File(kitDir, "bin")
-                            .listFiles()
-                            .orEmpty()
-                            .any { it.isFile && (it.canExecute() || it.name.endsWith(".sh")) }
-                val hasConfigYaml = File(kitDir, Constants.Kit.CONFIG_FILE).isFile
-
-                if (!hasBinScripts && !hasConfigYaml) return@forEach
-
                 val kitName = kitDir.name
                 if (kitName in commandLine.subcommands.keys) return@forEach
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/CLAUDE.md
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/CLAUDE.md
@@ -145,10 +145,17 @@ template files (including `bin/start.sh.template`, `bin/stop.sh.template`). No c
 
 ### &lt;kit&gt; start/stop subcommands
 
-`registerDynamicKitSubcommands()` scans `context.workingDirectory` for directories that
-contain a `bin/` subdirectory with at least one executable script. Each such directory becomes a
-top-level subcommand group (`easy-db-lab clickhouse`); each script becomes a subcommand
+`registerDynamicKitSubcommands()` registers the kit directories reported by
+`WorkspaceKitScanner` (`services/`). A working-directory subdirectory qualifies only when it
+contains a `kit.yaml`; a `bin/` directory alone does not, because Cassandra checkouts and
+virtualenvs have one too. Each qualifying directory becomes a top-level subcommand group
+(`easy-db-lab clickhouse`); each script in its `bin/` becomes a subcommand
 (`easy-db-lab clickhouse start`).
+
+`WorkspaceKitScanner` is the single source of truth for that rule, and the `=== KITS ===` section
+of `status` reads the same service, so both apply one discovery rule. Registration drops a
+discovered kit after the scan when its name collides with a core command, or when
+`buildKitGroup` throws, so `status` may list a kit that has no subcommand.
 
 Scripts are run by `KitRunnerCommand` with cluster state variables injected as environment
 variables. Dashboard JSON files in `<kit>/dashboards/` are installed into Grafana

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Status.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Status.kt
@@ -20,6 +20,7 @@ import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
 import com.rustyrazorblade.easydblab.proxy.ProxyAvailability
 import com.rustyrazorblade.easydblab.services.K8sService
 import com.rustyrazorblade.easydblab.services.StressJobService
+import com.rustyrazorblade.easydblab.services.WorkspaceKitScanner
 import com.rustyrazorblade.easydblab.services.aws.EC2InstanceService
 import com.rustyrazorblade.easydblab.services.aws.EMRService
 import com.rustyrazorblade.easydblab.services.aws.OpenSearchService
@@ -93,6 +94,7 @@ class Status :
     private val emrService: EMRService by inject()
     private val openSearchService: OpenSearchService by inject()
     private val stressJobService: StressJobService by inject()
+    private val workspaceKitScanner: WorkspaceKitScanner by inject()
 
     private data class NodeDetail(
         val alias: String,
@@ -415,22 +417,12 @@ class Status :
 
     /**
      * Display installed kits with a running indicator.
-     * Scans the working directory for kit directories (same detection as dynamic subcommand registration).
+     * Reads [WorkspaceKitScanner], the same discovery rule dynamic subcommand registration uses.
+     * Registration can still drop a discovered kit afterwards — on a name collision, or when
+     * building its command group fails — so this listing may name a kit that has no subcommand.
      */
     private fun displayKitsSection() {
-        val installedKits =
-            context.workingDirectory
-                .listFiles()
-                .orEmpty()
-                .filter { it.isDirectory }
-                .filter { kitDir ->
-                    (
-                        File(kitDir, "bin").isDirectory &&
-                            File(kitDir, "bin").listFiles().orEmpty().any { it.isFile && (it.canExecute() || it.name.endsWith(".sh")) }
-                    ) ||
-                        File(kitDir, Constants.Kit.CONFIG_FILE).isFile
-                }.map { it.name }
-                .sorted()
+        val installedKits = workspaceKitScanner.discover().map { it.name }.sorted()
 
         if (installedKits.isEmpty()) return
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/InstallTemplateResolver.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/InstallTemplateResolver.kt
@@ -128,18 +128,25 @@ class InstallTemplateResolver(
     /**
      * Wraps an ad-hoc path (from --from flag) as a [TemplateSource].
      *
-     * @throws IllegalArgumentException if [path] is not an existing directory
+     * Every installed kit directory carries a `kit.yaml`, and that descriptor is the sole marker
+     * the CLI uses to recognise one. A template without it would install a directory that
+     * registers no commands at all, so it is rejected here, before anything reaches the workspace.
+     *
+     * @throws IllegalArgumentException if [path] is not an existing directory, or holds no `kit.yaml`
      */
     fun resolveAdHoc(path: Path): TemplateSource {
         val dir = path.toFile()
         require(dir.isDirectory) { "Template path does not exist or is not a directory: $path" }
+        require(File(dir, Constants.Kit.CONFIG_FILE).isFile) {
+            "Template directory has no ${Constants.Kit.CONFIG_FILE}: $path"
+        }
         return TemplateSource.Directory(dir)
     }
 
     /**
-     * Reads and parses `config.yaml` from [source], returning null if the file is absent.
+     * Reads and parses `kit.yaml` from [source], returning null if the file is absent.
      *
-     * A missing `config.yaml` is not an error — templates without one simply have no
+     * A missing `kit.yaml` is not an error — templates without one simply have no
      * declared args and cannot generate dynamic subcommands.
      */
     fun readInstallYamlContent(source: TemplateSource): String? =

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
@@ -115,6 +115,9 @@ val servicesModule =
         // Kit source registry — persists additional kit parent directories in kit-sources.yaml
         singleOf(::KitSourcesProvider)
 
+        // Kit discovery — the single source of truth for which workspace directories are kits
+        singleOf(::WorkspaceKitScanner)
+
         // Cluster configuration service for writing config files
         factoryOf(::DefaultClusterConfigurationService) bind ClusterConfigurationService::class
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/WorkspaceKitScanner.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/WorkspaceKitScanner.kt
@@ -1,0 +1,39 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.Context
+import java.io.File
+
+/**
+ * The single source of truth for which working-directory subdirectories are installed kits.
+ *
+ * A directory qualifies if, and only if, it contains a `kit.yaml` descriptor. Every kit
+ * installed through `kit install` carries one, so the rule is an invariant rather than a
+ * heuristic. Kits registered in the tool in code are not discovered from the filesystem and
+ * never reach this class.
+ *
+ * A `bin/` directory does **not** qualify a directory. Cassandra checkouts, virtualenvs, and
+ * unrelated project trees all hold one, and treating that as proof of a kit registered them as
+ * top-level CLI commands, where a directory name could shadow a core command.
+ *
+ * Both dynamic subcommand registration and the `=== KITS ===` section of `status` read this
+ * class, so the two share one discovery rule. Registration can still drop a discovered kit
+ * afterwards — on a name collision with a core command, or when building its command group
+ * fails — so the listings are not guaranteed identical.
+ */
+class WorkspaceKitScanner(
+    private val context: Context,
+) {
+    /** Returns true when [dir] is a directory holding a `kit.yaml` file. */
+    fun isInstalledKit(dir: File): Boolean = dir.isDirectory && File(dir, Constants.Kit.CONFIG_FILE).isFile
+
+    /**
+     * Returns every installed kit directory in the working directory, in filesystem order.
+     * Callers that display the result sort it themselves.
+     */
+    fun discover(): List<File> =
+        context.workingDirectory
+            .listFiles()
+            .orEmpty()
+            .filter { isInstalledKit(it) }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/CommandLineParserTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/CommandLineParserTest.kt
@@ -1,0 +1,74 @@
+package com.rustyrazorblade.easydblab
+
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.services.DefaultKitCommandScanner
+import com.rustyrazorblade.easydblab.services.InstallTemplateResolver
+import com.rustyrazorblade.easydblab.services.KitCommandScanner
+import com.rustyrazorblade.easydblab.services.KitSourcesProvider
+import com.rustyrazorblade.easydblab.services.WorkspaceKitScanner
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.PrintStream
+
+/**
+ * Proves that `easy-db-lab --help` lists exactly the workspace directories holding a `kit.yaml`.
+ *
+ * This is the end-to-end guard for the registration path. `WorkspaceKitScannerTest` proves the
+ * rule; this proves the parser actually applies it, so re-inlining a `bin/` predicate or swapping
+ * the scanner for a local `listFiles()` walk fails a test instead of silently restoring the
+ * defect that flooded help output with Cassandra checkouts.
+ *
+ * Every collaborator is the real implementation. All three read the filesystem or the classpath
+ * and have no external side effects, and the whole point of the test is the wiring between them.
+ */
+class CommandLineParserTest : BaseKoinTest() {
+    private val stdout = ByteArrayOutputStream()
+    private val originalOut = System.out
+
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                single { WorkspaceKitScanner(get()) }
+                single { KitSourcesProvider(get()) }
+                single { InstallTemplateResolver(get(), get()) }
+                single<KitCommandScanner> { DefaultKitCommandScanner() }
+                single { ClusterStateManager(File(get<Context>().workingDirectory, "state.json")) }
+            },
+        )
+
+    @BeforeEach
+    fun captureStdout() {
+        System.setOut(PrintStream(stdout))
+    }
+
+    @AfterEach
+    fun restoreStdout() {
+        System.setOut(originalOut)
+        stdout.reset()
+    }
+
+    @Test
+    fun `help lists a directory holding a kit descriptor and omits a bin-only checkout`() {
+        val workspace = context.workingDirectory
+        File(workspace, "clickhouse").mkdirs()
+        File(File(workspace, "clickhouse"), Constants.Kit.CONFIG_FILE).writeText("name: clickhouse\n")
+        File(File(workspace, "trunk"), "bin").mkdirs()
+        File(File(File(workspace, "trunk"), "bin"), "cassandra").also {
+            it.writeText("#!/bin/bash\n")
+            it.setExecutable(true)
+        }
+
+        // --help exits 0, so eval() returns rather than reaching exitProcess.
+        CommandLineParser().eval(arrayOf("--help"))
+
+        val output = stdout.toString()
+        assertThat(output).contains("clickhouse")
+        assertThat(output).doesNotContain("trunk")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/StatusTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/StatusTest.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.commands
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.Version
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterState
@@ -28,6 +29,7 @@ import com.rustyrazorblade.easydblab.services.DefaultCommandExecutor
 import com.rustyrazorblade.easydblab.services.RequirementCheckDeps
 import com.rustyrazorblade.easydblab.services.ResourceManager
 import com.rustyrazorblade.easydblab.services.StressJobService
+import com.rustyrazorblade.easydblab.services.WorkspaceKitScanner
 import com.rustyrazorblade.easydblab.services.aws.EC2InstanceService
 import com.rustyrazorblade.easydblab.services.aws.EMRService
 import org.assertj.core.api.Assertions.assertThat
@@ -41,6 +43,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.io.PrintStream
 import java.time.Instant
 
@@ -134,6 +137,9 @@ class StatusTest : BaseKoinTest() {
                 single<EMRService> { mockEmrService }
                 single<StressJobService> { mockStressJobService }
                 single<ProxyAvailability> { DefaultProxyAvailability() }
+                // Real instance: the scanner only reads the filesystem, so faking it would
+                // hide the very rule these tests exercise.
+                single { WorkspaceKitScanner(get()) }
             },
         )
 
@@ -305,6 +311,51 @@ class StatusTest : BaseKoinTest() {
         val output = capturedOutput()
         assertThat(output).contains("=== S3 BUCKET ===")
         assertThat(output).contains("(no S3 bucket configured)")
+    }
+
+    // ========== KITS SECTION ==========
+    //
+    // `kit.yaml` is the sole marker of an installed kit. A `bin/` directory holding an
+    // executable proves nothing — Cassandra checkouts and virtualenvs have one — so the
+    // section must list the descriptor-bearing directory and nothing else.
+
+    @Test
+    fun `execute lists only directories holding a kit descriptor under KITS`() {
+        setupBasicClusterState()
+        createWorkspaceDir("clickhouse").also { File(it, Constants.Kit.CONFIG_FILE).writeText("name: clickhouse\n") }
+        createExecutableBinScript("trunk", "cassandra")
+
+        Status().execute()
+
+        val output = capturedOutput()
+        assertThat(output).contains("=== KITS ===")
+        // The rendered kit line, not a bare substring: "ClickHouse" also appears in the
+        // ClickHouse section's heading, so a loose match would pass without a kits listing.
+        assertThat(output).contains("○ clickhouse")
+        assertThat(output).doesNotContain("trunk")
+    }
+
+    @Test
+    fun `execute omits the KITS section when only bin-holding directories exist`() {
+        setupBasicClusterState()
+        createExecutableBinScript("trunk", "cassandra")
+
+        Status().execute()
+
+        assertThat(capturedOutput()).doesNotContain("=== KITS ===")
+    }
+
+    private fun createWorkspaceDir(name: String): File = File(context.workingDirectory, name).also { it.mkdirs() }
+
+    private fun createExecutableBinScript(
+        dirName: String,
+        scriptName: String,
+    ): File {
+        val bin = File(createWorkspaceDir(dirName), "bin").also { it.mkdirs() }
+        return File(bin, scriptName).also {
+            it.writeText("#!/bin/bash\n")
+            it.setExecutable(true)
+        }
     }
 
     // ========== DEGRADED STATUS (PROXY FAILURE) TESTS ==========

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/InstallTemplateResolverTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/InstallTemplateResolverTest.kt
@@ -95,12 +95,26 @@ class InstallTemplateResolverTest : BaseKoinTest() {
     // ── resolveAdHoc ────────────────────────────────────────────────────────
 
     @Test
-    fun `resolveAdHoc returns Directory source for existing directory`() {
+    fun `resolveAdHoc returns Directory source for a template holding a kit descriptor`() {
         val dir = File(tempDir, "my-templates").also { it.mkdirs() }
+        File(dir, Constants.Kit.CONFIG_FILE).writeText("name: my-templates\n")
 
         val source = resolver.resolveAdHoc(dir.toPath())
         assertThat(source).isInstanceOf(InstallTemplateResolver.TemplateSource.Directory::class.java)
         assertThat((source as InstallTemplateResolver.TemplateSource.Directory).dir).isEqualTo(dir)
+    }
+
+    @Test
+    fun `resolveAdHoc rejects a template with bin scripts but no kit descriptor`() {
+        // Installing such a template used to succeed and produce a kit directory that
+        // registers nothing — a silent failure. It is rejected before anything is written.
+        val dir = File(tempDir, "malformed").also { it.mkdirs() }
+        File(dir, "bin").mkdirs()
+        File(File(dir, "bin"), "start.sh").writeText("#!/bin/bash\n")
+
+        assertThatThrownBy { resolver.resolveAdHoc(dir.toPath()) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining(Constants.Kit.CONFIG_FILE)
     }
 
     @Test

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/WorkspaceKitScannerTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/WorkspaceKitScannerTest.kt
@@ -1,0 +1,111 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.TestContextFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Verifies that `kit.yaml` alone decides which workspace subdirectories are installed kits.
+ *
+ * The scanner reads the filesystem and nothing else, so every case here uses real directories
+ * under a temporary workspace. The `trunk` and `.venv` case is the defect this class exists to
+ * prevent: both hold an executable `bin/` script and neither is a kit.
+ */
+class WorkspaceKitScannerTest : BaseKoinTest() {
+    private lateinit var workspace: File
+    private lateinit var scanner: WorkspaceKitScanner
+
+    @BeforeEach
+    fun setupScanner() {
+        workspace = File(tempDir, "workspace").also { it.mkdirs() }
+        scanner = WorkspaceKitScanner(TestContextFactory.createTestContext(tempDir, workingDirectory = workspace))
+    }
+
+    private fun workspaceDir(name: String): File = File(workspace, name).also { it.mkdirs() }
+
+    private fun kitDir(name: String): File = workspaceDir(name).also { File(it, Constants.Kit.CONFIG_FILE).writeText("name: $name\n") }
+
+    private fun binScript(
+        dirName: String,
+        scriptName: String,
+    ): File {
+        val bin = File(workspaceDir(dirName), "bin").also { it.mkdirs() }
+        return File(bin, scriptName).also {
+            it.writeText("#!/bin/bash\n")
+            it.setExecutable(true)
+        }
+    }
+
+    @Test
+    fun `a directory holding only a bin script is not discovered`() {
+        binScript("tools", "start.sh")
+
+        assertThat(scanner.discover()).isEmpty()
+    }
+
+    @Test
+    fun `a workspace of source checkouts and virtualenvs discovers nothing`() {
+        binScript("trunk", "cassandra")
+        binScript(".venv", "activate")
+
+        assertThat(scanner.discover()).isEmpty()
+    }
+
+    @Test
+    fun `a directory holding a kit descriptor is discovered`() {
+        val clickhouse = kitDir("clickhouse")
+
+        assertThat(scanner.discover()).containsExactly(clickhouse)
+    }
+
+    @Test
+    fun `a directory holding both a descriptor and bin scripts is discovered once`() {
+        val clickhouse = kitDir("clickhouse")
+        binScript("clickhouse", "start.sh")
+
+        assertThat(scanner.discover()).containsExactly(clickhouse)
+    }
+
+    @Test
+    fun `a directory named kit yaml does not qualify its parent`() {
+        val impostor = workspaceDir("impostor")
+        File(impostor, Constants.Kit.CONFIG_FILE).mkdirs()
+
+        assertThat(scanner.isInstalledKit(impostor)).isFalse()
+        assertThat(scanner.discover()).isEmpty()
+    }
+
+    @Test
+    fun `a plain file at the workspace root is not discovered`() {
+        File(workspace, Constants.Kit.CONFIG_FILE).writeText("name: stray\n")
+
+        assertThat(scanner.discover()).isEmpty()
+    }
+
+    @Test
+    fun `a directory holding neither marker is not discovered`() {
+        workspaceDir("notes")
+
+        assertThat(scanner.discover()).isEmpty()
+    }
+
+    @Test
+    fun `an empty workspace yields an empty list`() {
+        assertThat(scanner.discover()).isEmpty()
+    }
+
+    @Test
+    fun `a working directory that does not exist yields an empty list`() {
+        // listFiles() returns null here, not an empty array. This is the case the shared
+        // discover() seam exists to handle once instead of at each call site.
+        val missing = File(tempDir, "never-created")
+        val scannerOverMissingDir =
+            WorkspaceKitScanner(TestContextFactory.createTestContext(tempDir, workingDirectory = missing))
+
+        assertThat(scannerOverMissingDir.discover()).isEmpty()
+    }
+}


### PR DESCRIPTION
Closes #888

`kit.yaml` is now the sole marker that a workspace subdirectory is an installed kit. Previously any directory holding a `bin/` with an executable or `.sh` file qualified, so `easy-db-lab -h` in a directory of Cassandra checkouts printed 24 false top-level commands — `trunk`, `5.0`, `4.0`, `21554-cursor-flush`, `.venv`. The rule was copied inline at two call sites, so `status` reported the same false kits under `=== KITS ===`.

## What changed

- **`WorkspaceKitScanner`** (new, `services/`) — a Koin singleton over `Context` exposing `isInstalledKit(dir)` and `discover(): List<File>`. Single source of truth for filesystem kit discovery.
- **`CommandLineParser.registerDynamicKitSubcommands()`** and **`Status.displayKitsSection()`** both consume it. Neither retains a copy of the rule. `Status` appends its own `.map { it.name }.sorted()`, since sort order is a display concern.
- **`InstallTemplateResolver.resolveAdHoc`** rejects a `--from` template directory with no `kit.yaml`, naming the missing file, before anything reaches the workspace. Without it the invariant would be stated and unenforced, and such an install would silently produce a kit that registers nothing.
- **Specs and docs** — the `workload-runner` and `install-command` narrative corrected, plus `commands/CLAUDE.md` and the `--from` requirement in `docs/user-guide/platform-substrate.md`. Requirement blocks live in the change delta and are applied by `openspec archive`, per this repo's convention.

## Behavior change

`kit install --from <dir>` on a template with no `kit.yaml` now fails where it previously succeeded. Deliberate — such an install would otherwise produce a kit directory that registers nothing, with no error. The template was always malformed; the old `bin/` predicate hid it. Every built-in kit ships a descriptor and no `--from` fixture without one exists in the repo, so expected blast radius is zero.

Kits installed by name are unaffected: `registerDynamicInstallSubcommands()` only registers an install subcommand when the template's `kit.yaml` parses, and `BaseInstallCommand` then writes that descriptor into the installed directory.

## Security

`security-review` noted the old rule was worse than a cosmetic bug: a registered kit is both a `ProcessBuilder` execution target via `KitRunnerCommand.executeScript` and a `kitDir.deleteRecursively()` target on the uninstall phase. So a stray source checkout or `.venv` in a workspace was exposed as both. Requiring `kit.yaml` removes both. No JVM proxy property appears anywhere in the diff, so REQ-NET-005 is unaffected.

## Tests

```
./gradlew ktlintFormat && ./gradlew ktlintCheck
./gradlew test
./gradlew detekt
./gradlew check          # both tiers, Docker running
openspec validate issue-888 --type change --strict
```

All green on JDK 21. Fast tier only for the new tests — nothing here needs Docker.

- `WorkspaceKitScannerTest` — 9 cases, including the issue's own reproduction (`trunk/bin/cassandra` plus `.venv/bin/activate` discovers nothing) and the `listFiles()` null guard.
- `CommandLineParserTest` (new) — renders `--help` over a workspace holding `clickhouse/kit.yaml` and an executable `trunk/bin/cassandra`, asserting `clickhouse` is listed and `trunk` is not. 3.891s, ~1.8% of summed fast-tier time.
- `StatusTest` — 2 added cases, anchored to the rendered `○ clickhouse` line rather than a bare substring match.
- `InstallTemplateResolverTest` — `--from` reject and accept.

Two tests were mutation-verified rather than assumed, once by the implementer and independently by the test-rigor lens. Re-inlining a `bin/` predicate turns `CommandLineParserTest` red — the failure dump shows `trunk   Kit commands for trunk` registered as a top-level subcommand, the original defect. `WorkspaceKitScannerTest` stays green under that same mutation, which is the argument for the new test: it covers a registration path no scanner-level test reaches. Swapping `.orEmpty()` for `!!` fails the null-guard case and nothing else.

## Review

Five lenses, round 1: all approved, zero blockers. A fix round addressed seven advisory findings; `spec` and `test-rigor` re-reviewed the delta and both approved. Production code is unchanged since round 1 apart from KDoc wording.

## Surfaced, non-blocking

- **Diagnosability of a rejected directory.** `discover()` drops a `bin/`-holding directory silently, so "never installed", "wrong working directory", and "`kit.yaml` renamed" are indistinguishable — the operator sees only picocli's "Unmatched argument". Squarely inside this issue's declared out-of-scope ("any new warning, hint, or diagnostic output for a rejected directory"); the observability lens withdrew the finding itself rather than have the fix loop implement around an approved boundary. Worth reopening as its own issue if you want it.
- **`InstallTemplateResolver.listAvailableTemplateDetails`** KDoc says `config.yaml` where it means `kit.yaml`.
- **`UninstalledKitHintHandler`** advises `easy-db-lab kit install <name>` for a template with no `kit.yaml`, which `registerDynamicInstallSubcommands` skipped — a dead-end hint. Pre-existing, outside this diff.
- **`WorkspaceKitScannerTest`** extends `BaseKoinTest` without resolving from Koin. Measured at 0.02s; declined as not worth the churn.
- **CI flake, unrelated to this change.** `SocksTcpBridgeTest > close stops the listener so subsequent connects are refused()` failed once at `fcd629e1`, a port-binding race. It passed on both later commits and on every local `./gradlew check`.
