### PR TITLE
chore(openspec): rename install-command spec to kit-install-command

### DIFF
--- a/openspec/changes/issue-888/ac-coverage.md
+++ b/openspec/changes/issue-888/ac-coverage.md
@@ -3,14 +3,14 @@
 | Source | Requirement | Covering scenario(s) | Status |
 |--------|-------------|----------------------|--------|
 | AC | `bin/start.sh` but no `kit.yaml` → not registered, absent from `-h` | `workload-runner: Dir without kit.yaml is not registered`; `workload-runner: Help omits a bin/-only directory` | ✅ Covered |
-| AC | Holds `kit.yaml` → registered under the directory name | `workload-runner: Kit dir with kit.yaml discovered`; `workload-runner: Multiple workloads discovered`; `install-command: An installed kit directory carries its descriptor` | ✅ Covered |
+| AC | Holds `kit.yaml` → registered under the directory name | `workload-runner: Kit dir with kit.yaml discovered`; `workload-runner: Multiple workloads discovered`; `kit-install-command: An installed kit directory carries its descriptor` | ✅ Covered |
 | AC | Holds both `kit.yaml` and `bin/start.sh` → `<kit> start` stays valid | `workload-runner: Kit dir with kit.yaml discovered` | ✅ Covered |
 | AC | Holds neither marker → not registered | `workload-runner: Dir with neither marker is not registered` | ✅ Covered |
 | AC | `status` lists only the `kit.yaml` directory | `workload-runner: status lists only directories holding kit.yaml` | ✅ Covered |
 | AC | Only `bin/`-only dirs → no `=== KITS ===` section | `workload-runner: status omits the KITS section when nothing qualifies` | ✅ Covered |
 | AC | Predicate changes → both call sites change; no inline copy remains | `workload-runner: Both listings agree` (requirement: Filesystem kit discovery has a single source of truth) | ✅ Covered |
-| Owner | `kit.yaml` invariant: every non-Kotlin kit directory has one, no exceptions | `install-command: Kit descriptor filename` (requirement text) + `An installed kit directory carries its descriptor` | ✅ Covered |
-| Risk | `kit install --from <dir>` with no `kit.yaml` installs a kit that no longer registers, silently | `install-command: --from rejects a template without kit.yaml`; `install-command: --from accepts a template with kit.yaml` | ✅ Covered |
-| Risk | Kits installed via `kit install <name>` could lose registration | `install-command: An installed kit directory carries its descriptor` | ✅ Covered |
+| Owner | `kit.yaml` invariant: every non-Kotlin kit directory has one, no exceptions | `kit-install-command: Kit descriptor filename` (requirement text) + `An installed kit directory carries its descriptor` | ✅ Covered |
+| Risk | `kit install --from <dir>` with no `kit.yaml` installs a kit that no longer registers, silently | `kit-install-command: --from rejects a template without kit.yaml`; `kit-install-command: --from accepts a template with kit.yaml` | ✅ Covered |
+| Risk | Kits installed via `kit install <name>` could lose registration | `kit-install-command: An installed kit directory carries its descriptor` | ✅ Covered |
 | Risk | `CommandLineParser` registration path is not directly tested end to end | `CommandLineParserTest` — renders `--help` over a workspace holding `clickhouse/kit.yaml` and an executable `trunk/bin/cassandra`, asserting `clickhouse` is listed and `trunk` is not | ✅ Covered — `design.md` records this as excluded on the premise that a test needed three mocked Koin dependencies. That premise was wrong: the test needs five real Koin definitions and no mocks, and costs 3.891s in the parallel run. Added in the review fix round, and mutation-tested — re-inlining a `bin/` predicate turns it red. |
 | Risk | `CommandLineParser` loses its last `java.io.File` use; stale import fails ktlint | — | ⚠️ Excluded — build-mechanical, not a behavior contract. Caught by task 5.1 (`ktlintCheck`), and called out explicitly in task 2.3. |

--- a/openspec/changes/issue-888/overrides.md
+++ b/openspec/changes/issue-888/overrides.md
@@ -27,7 +27,7 @@ neither marker.
 **This change:** it keys on `./clickhouse/kit.yaml` existing, and a second scenario asserts a
 `bin/`-only directory is absent from the listing. The requirement sentence itself is unchanged.
 
-### install-command: Kit descriptor filename
+### kit-install-command: Kit descriptor filename
 
 **Currently:** `kit.yaml` is named as the descriptor the loader looks for, across classpath,
 profile directory, and ad-hoc `--from` sources. Nothing states that an installed kit directory must
@@ -48,12 +48,12 @@ The three existing scenarios are unchanged; three are added.
 
 ## Conflicts with other in-flight changes
 
-- `kit-node-type-requirement` also touches `install-command` — **no conflict.** It adds a new
+- `kit-node-type-requirement` also touches `kit-install-command` — **no conflict.** It adds a new
   requirement, "Kit node-type requirement field", about a `type:` field inside `kit.yaml`. This
   change modifies "Kit descriptor filename". Different requirements, and the two are complementary:
   one says the descriptor must exist, the other describes a field within it.
 
-- `kit-subcommand-restructure` also touches `install-command` — **no conflict.** It modifies
+- `kit-subcommand-restructure` also touches `kit-install-command` — **no conflict.** It modifies
   "Dynamic install subcommands registered under `kit install`" and removes the `install --list` flag
   and `install` as a top-level command. That is about where the *install* subcommands live in the
   command tree. This change is about which *workspace directories* register as kit subcommands.

--- a/openspec/changes/issue-888/proposal.md
+++ b/openspec/changes/issue-888/proposal.md
@@ -48,7 +48,7 @@ None.
 - `workload-runner` — the discovery requirement and its scenarios currently specify `bin/` as the
   marker. The requirement sentence, three scenarios under it, and one scenario under the `--help`
   requirement all change to `kit.yaml`. A new requirement states the invariant.
-- `install-command` — the narrative describing how an installed kit is detected currently states
+- `kit-install-command` — the narrative describing how an installed kit is detected currently states
   the `bin/` rule, and its example directory tree depicts a kit directory with no `kit.yaml`, which
   would not register under the corrected rule.
 

--- a/openspec/changes/issue-888/specs/kit-install-command/spec.md
+++ b/openspec/changes/issue-888/specs/kit-install-command/spec.md
@@ -1,4 +1,4 @@
-# Install Command Spec
+# Kit Install Command Spec
 
 ## MODIFIED Requirements
 

--- a/openspec/changes/issue-888/tasks.md
+++ b/openspec/changes/issue-888/tasks.md
@@ -64,7 +64,7 @@ socket.
       (`openspec/changes/issue-888/specs/workload-runner/spec.md`) and are applied to the live
       spec by `openspec archive`, in its own batch commit. A feature branch never edits a
       requirement block here; doing so applies the delta twice.
-- [x] 5.2 `openspec/specs/install-command/spec.md`: edit the non-requirement narrative only — the
+- [x] 5.2 `openspec/specs/kit-install-command/spec.md`: edit the non-requirement narrative only — the
       Purpose clause (lines 5-7) and the "Kit runner subcommands" section (lines 208-210), both of
       which state the old rule, plus the example tree (lines 214-220), which depicts a kit
       directory with no `kit.yaml`. Archive never touches narrative prose, so these must be

--- a/openspec/specs/kit-install-command/spec.md
+++ b/openspec/specs/kit-install-command/spec.md
@@ -1,4 +1,4 @@
-# Install Command Spec
+# Kit Install Command Spec
 
 ## Purpose
 


### PR DESCRIPTION
The spec was named for a top-level `install` command group that no longer exists. `kit-subcommand-restructure` moved the whole install/list/uninstall surface under `kit`, and the spec's own requirements already describe `kit install` — the directory name was the last thing still pointing at the retired path.

Renames:

- `openspec/specs/install-command/` → `openspec/specs/kit-install-command/`
- `openspec/changes/issue-888/specs/install-command/` → `.../kit-install-command/`

The pending `issue-888` change carries a delta against this spec, so its delta directory and its four prose references move with it. Its one MODIFIED target (`Kit descriptor filename`) still resolves against the renamed canonical spec, so the next archive batch picks it up unchanged.

The 22 archived changes keep their original `install-command` references — they record what was true when they landed.

Spec tree validates 65/65; `issue-888` validates. No code changes.