### PR TITLE
Add a profile command group with profile show

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,8 @@ See [`commands/CLAUDE.md`](src/main/kotlin/com/rustyrazorblade/easydblab/command
 
 See [`providers/CLAUDE.md`](src/main/kotlin/com/rustyrazorblade/easydblab/providers/CLAUDE.md) for AWS/SSH/Docker patterns and retry logic.
 
+**Kernel (`kernel/`)**: The few types both of the layers above share. It holds `PicoCommand`, the interface `services/CommandExecutor` dispatches on and every command implements. Keeping it here is what stops `commands/` and `services/` from depending on each other. Add a type to `kernel/` only when both layers need it, and keep it free of dependencies on either.
+
 ### Server & REPL
 
 Two commands run as long-lived processes instead of the typical run-and-exit pattern:

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ See `bin/set-policies`.
 Run the interactive setup to configure your AWS credentials and create necessary resources:
 
 ```shell
-easy-db-lab setup-profile
+easy-db-lab profile setup
 ```
 
 This will:
@@ -168,7 +168,7 @@ alias easy-db-lab='docker run --rm \
 Then use it like the native command:
 
 ```shell
-easy-db-lab setup-profile
+easy-db-lab profile setup
 easy-db-lab init my-cluster --cassandra 5.0
 ```
 
@@ -247,7 +247,7 @@ You can skip this if you're using us-west-2
 This can be done once, and reused many times.
 The AMI should be rebuilt when updating easy-db-lab.
 
-If you haven't run `easy-db-lab setup-profile` yet, you'll be prompted to set up your profile before building.
+If you haven't run `easy-db-lab profile setup` yet, you'll be prompted to set up your profile before building.
 
 ```shell
 bin/easy-db-lab build-image
@@ -269,7 +269,7 @@ Run `easy-db-lab` without any parameters to view all the commands and all option
 
 ### Create The Environment
 
-Note: If you haven't run `easy-db-lab setup-profile` yet, you'll be prompted to set up your profile.
+Note: If you haven't run `easy-db-lab profile setup` yet, you'll be prompted to set up your profile.
 
 Important: If you've installed the project via homebrew or downloaded a release,
 please use the `us-west-2` region.  This limitation will be lifted soon.

--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -91,5 +91,6 @@ Commands (PicoCLI) → Services → External Systems (K8s, AWS, Filesystem)
 
 - **Commands** (`commands/`): Lightweight PicoCLI execution units
 - **Services** (`services/`, `providers/`): Business logic layer
+- **Kernel** (`kernel/`): Types both layers share, such as the `PicoCommand` interface. It keeps commands and services from depending on each other.
 
 For more details, see the project's `CLAUDE.md` file.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -236,7 +236,7 @@ Create custom assertions for:
 
 ## Testing Interactive Commands with TestPrompter
 
-Commands that require user input (like `setup-profile`) can be tested deterministically using `TestPrompter`. This test utility replaces the real `Prompter` interface and returns predefined responses.
+Commands that require user input (like `profile setup`) can be tested deterministically using `TestPrompter`. This test utility replaces the real `Prompter` interface and returns predefined responses.
 
 ### Basic Usage
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -47,7 +47,7 @@ The built distribution will be in `build/distributions/`.
 Run the interactive setup to configure your profile:
 
 ```bash
-easy-db-lab setup-profile
+easy-db-lab profile setup
 ```
 
 See the [Setup Guide](setup.md) for detailed instructions.

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -4,7 +4,7 @@ This guide walks you through the initial setup of easy-db-lab, including AWS cre
 
 ## Overview
 
-The `setup-profile` command handles all initial configuration interactively. It will:
+The `profile setup` command handles all initial configuration interactively. It will:
 
 1. Collect your email and AWS credentials
 2. Validate your AWS access
@@ -24,13 +24,7 @@ Before running setup:
 Run the interactive setup:
 
 ```bash
-easy-db-lab setup-profile
-```
-
-Or use the shorter alias:
-
-```bash
-easy-db-lab setup
+easy-db-lab profile setup
 ```
 
 The setup wizard will prompt you for:
@@ -49,7 +43,7 @@ The setup wizard will prompt you for:
 The AWS profile name is asked **first**. If you provide one, the access key and secret prompts are skipped — easy-db-lab resolves credentials through that profile (including [AWS SSO](#using-aws-sso-iam-identity-center) profiles). Static access keys are only collected when you leave the profile name blank.
 ```
 
-setup-profile validates your credentials against AWS immediately (and then provisions resources), so your credentials must be usable **before** you run it. For static keys this is automatic; for an SSO profile, run `aws sso login` first (see below).
+`profile setup` validates your credentials against AWS immediately (and then provisions resources), so your credentials must be usable **before** you run it. For static keys this is automatic; for an SSO profile, run `aws sso login` first (see below).
 
 ### What Gets Created
 
@@ -101,14 +95,14 @@ region = us-west-2
 aws sso login --profile edl
 ```
 
-**3. Run setup-profile** and enter `edl` when prompted for the AWS profile name (leave the access key and secret blank):
+**3. Run `profile setup`** and enter `edl` when prompted for the AWS profile name (leave the access key and secret blank):
 
 ```bash
-easy-db-lab setup-profile
+easy-db-lab profile setup
 ```
 
 ```admonish important
-Run `aws sso login` **before** `setup-profile`. setup-profile validates and provisions against AWS immediately, so it needs an active SSO session. This first-time `aws sso login` → `setup-profile` sequence is only needed once.
+Run `aws sso login` **before** `profile setup`. It validates and provisions against AWS immediately, so it needs an active SSO session. This first-time `aws sso login` → `profile setup` sequence is only needed once.
 ```
 
 #### Day-to-day usage

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ If you're looking for tools to help manage Cassandra in *production* environment
 ## Quick Start
 
 1. [Install easy-db-lab](getting-started/installation.md)
-2. [Set up your profile](getting-started/setup.md) - Run `easy-db-lab setup-profile`
+2. [Set up your profile](getting-started/setup.md) - Run `easy-db-lab profile setup`
 3. [Follow the tutorial](user-guide/tutorial.md)
 
 ## Features

--- a/docs/integrations/server.md
+++ b/docs/integrations/server.md
@@ -255,6 +255,6 @@ This is useful when:
 ## Notes
 
 - The server requires Docker to be installed
-- Your AWS profile must be configured (`easy-db-lab setup-profile`)
+- Your AWS profile must be configured (`easy-db-lab profile setup`)
 - The server runs in the foreground and logs to stdout
 - Use Ctrl+C to stop the server

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -12,17 +12,47 @@ Complete reference for all easy-db-lab commands.
 
 ---
 
-## Setup Commands
+## Profile Commands
 
-### setup-profile
+Profile inspection and setup. Not to be confused with `cassandra profile`, which controls runtime
+profiling of a running cluster.
+
+### profile
+
+Parent command for the profile group. Run without a subcommand to list what is available.
+
+```bash
+easy-db-lab profile
+```
+
+### profile show
+
+Report the active profile: its name, its directory, and the settings it holds.
+
+```bash
+easy-db-lab profile show
+```
+
+Reads only the profile directory, so it runs from anywhere — no cluster workspace needed. Secret
+values are never printed: AxonOps and Tailscale are reported as `ENABLED` or `DISABLED`, and the
+AWS access key and secret are not shown at all.
+
+The profile reported is the one named by `EASY_DB_LAB_PROFILE`, or `default` when that is unset:
+
+```bash
+EASY_DB_LAB_PROFILE=staging easy-db-lab profile show
+```
+
+If the profile has no `settings.yaml`, the command says so and points at `easy-db-lab profile
+setup`. If the file is present but unreadable, it reports that instead, naming the file.
+
+### profile setup
 
 Set up user profile interactively.
 
 ```bash
-easy-db-lab setup-profile
+easy-db-lab profile setup
 ```
-
-**Aliases:** `setup`
 
 Guides you through:
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -374,6 +374,9 @@ Runtime async-profiler control under `cassandra profile`. Every command applies 
 nodes by default; `--hosts` narrows it to a subset. A cluster profiles CPU automatically from
 cluster-up, so these are for changing what is profiled and for pulling profiles out.
 
+This is not the top-level `profile` group, which manages your easy-db-lab user profile. See
+[Profile Commands](#profile-commands) for that.
+
 See [Profiling](../user-guide/profiling.md) for the full guide.
 
 ### cassandra profile start

--- a/docs/user-guide/network-connectivity.md
+++ b/docs/user-guide/network-connectivity.md
@@ -62,7 +62,7 @@ The `autoApprovers` section automatically approves subnet routes, so you don't n
 #### Step 3: Configure easy-db-lab
 
 ```bash
-easy-db-lab setup-profile
+easy-db-lab profile setup
 ```
 
 Enter your Tailscale OAuth credentials when prompted.

--- a/docs/user-guide/tutorial.md
+++ b/docs/user-guide/tutorial.md
@@ -3,7 +3,7 @@
 This tutorial walks you through creating a database cluster from scratch, covering initialization, infrastructure provisioning, and database configuration. The examples below use Cassandra, but the same infrastructure supports [ClickHouse](clickhouse.md), [OpenSearch](opensearch.md), and [Spark](spark.md).
 
 ```admonish note title="Prerequisites"
-Before starting, ensure you've completed the [Setup](../getting-started/setup.md) process by running `easy-db-lab setup-profile`.
+Before starting, ensure you've completed the [Setup](../getting-started/setup.md) process by running `easy-db-lab profile setup`.
 ```
 
 ## Part 1: Initialize Your Cluster

--- a/openspec/changes/issue-892/.openspec.yaml
+++ b/openspec/changes/issue-892/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/issue-892/ac-coverage.md
+++ b/openspec/changes/issue-892/ac-coverage.md
@@ -20,7 +20,7 @@ surfaced.
 | AC | Docs name the new form, including bare-`setup` references | `setup: Guidance names the current command` | ✅ Covered — **verified by inspection, not by test.** Zero live `setup-profile` or bare-`setup` references remain outside the two archive paths. A guard test would be a grep-over-sources test: brittle, low value, deliberately not written. |
 | AC | The `commands↔services` cycle is closed | — | ⚠️ Excluded — a structural invariant, not observable product behavior. Verified by task 1.5 and enforced later by the ArchUnit rules that belong to 745; encoding it as a product requirement here would misplace ownership. |
 | Risk | `Repl.kt:38-68` holds a second command-tree copy; no existing test catches the drift | — | ⚠️ Excluded — internal wiring with no distinct user-visible contract beyond the two command-resolution scenarios already specified. Carried as task 2.4 with the "no test catches this" warning attached. |
-| Risk | `ProfileShow` must carry no `@RequireProfileSetup`, or setup launches instead of reporting | `profile-command-group: Missing settings.yaml reports not-configured` (the "interactive setup flow does not run" clause) | ✅ Covered |
+| Risk | `ProfileShow` must carry no `@RequireProfileSetup`, or setup launches instead of reporting | `profile-command-group: Missing settings.yaml reports not-configured` (the "interactive setup flow does not run" clause) | ✅ Covered — pinned by `ProfileCommandGroupTest`'s `ProfileShow carries no requirement annotation`, which checks all four requirement annotations directly. The scenario's own test is a pure `buildReport` call, which cannot see a class annotation and would stay green if one were added — the annotation test is what actually guards this |
 | Risk | `profile show` must not load cluster state, and must stay that way | `profile-command-group: Runs outside a cluster workspace` | ✅ Covered |
 | Risk | `buildReport` reusing `maskValue()` would leak a first character and still pass a sentinel test | `profile-command-group: Secret values are absent from the report` (requirement text forbids calling any masking helper) | ✅ Covered |
 | Risk | A workspace directory named `profile` with a `kit.yaml` shadows the group | `profile-command-group: A profile kit directory is skipped` | ✅ Covered — `CommandLineParserTest` creates `<tempCwd>/profile/kit.yaml` and asserts the `profile` subcommand is still a `Profile` instance (added in fix round 1, tr-2). Before that test the behavior rested on one untested line, `CommandLineParser.kt:272` |
@@ -51,10 +51,37 @@ definition replaces three copies of the rule.
 
 Issue AC5 and `tasks.md` 3.4 were updated to match.
 
+**`buildReport`'s signature.** `design.md` and `tasks.md` 3.2 both specify
+`buildReport(profileName: String, profileDir: String, user: User?)`. What shipped is
+`buildReport(profileName, profileDir, settings: ProfileSettings)`, where `ProfileSettings` is a new
+sealed interface with `Loaded(user)`, `Missing` and `Unreadable` cases.
+
+The approved signature was internally contradictory: a nullable `User` has two states, while
+`tasks.md` 3.3 required three branches and 4.1 required `buildReport` tests for both the
+not-configured and the malformed messages. Those cannot both be satisfied at that signature. The
+sealed type preserves what the design actually argued for — a pure function of three values with one
+call site, both branches testable without capturing stdout — and `Loaded` passes the `User` straight
+through, so the design's explicit "pass `User` directly" decision stands and the reason it rejected a
+`ProfileReportData` projection does not apply.
+
+No spec scenario constrains the signature, so this was correctly not raised as a `SPEC-DEFECT`. It is
+recorded here because the AxonOps amendment above was recorded and this deviation is the same kind of
+departure from an approved artifact; documenting one and not the other would misrepresent the branch.
+`design.md` and `tasks.md` 3.2 still carry the original signature — under the read-only-spec rule,
+editing them is the owner's call, and this section is the established place for the record.
+
 ## A note on what "Covered" means in this table
 
 The *Covering scenario(s)* column names **spec scenarios**, not tests. A reader who takes ✅ Covered
 to mean "verified by a test" can be misled, and was: three scenarios reached the review panel with
-no implementing test, and one row claimed an assertion that did not exist. Fix round 1 closed all
-four gaps, and each row above now names the test that pins it, or says plainly that it is verified
-by inspection instead.
+no implementing test, and one row claimed an assertion that did not exist.
+
+Fix round 1 closed all four gaps. The rows corrected as a result — the setup-binding row, the
+`println()`/no-events row, the docs-by-inspection row, the `profile` kit-directory risk row, and the
+`@RequireProfileSetup` risk row — now name the test that pins them, or say plainly that they are
+verified by inspection. The remaining ✅ rows still name only their spec scenario; the review panel
+walked each of those to a real implementing assertion, so none overclaims, but the column is not a
+test index and should not be read as one.
+
+Scenario-to-test traceability on the merged branch is 16 of 17. The one uncovered scenario is
+`setup: Guidance names the current command`, verified by inspection as its row states.

--- a/openspec/changes/issue-892/ac-coverage.md
+++ b/openspec/changes/issue-892/ac-coverage.md
@@ -1,0 +1,29 @@
+# AC coverage — issue 892
+
+One row per acceptance criterion on the issue, plus one per risk the architect and design-critic
+surfaced.
+
+| Source | Requirement | Covering scenario(s) | Status |
+|--------|-------------|----------------------|--------|
+| AC | Bare group prints help, lists `show` and `setup`, exits 0 | `profile-command-group: profile with no subcommand prints help` | ✅ Covered |
+| AC | `profile show` prints profile name, absolute directory, and all five settings | `profile-command-group: Configured profile reports its settings` | ✅ Covered |
+| AC | Works with no cluster workspace; no cluster state loaded, no cluster-state error | `profile-command-group: Runs outside a cluster workspace` | ✅ Covered |
+| AC | No secret value is printed | `profile-command-group: Secret values are absent from the report` | ✅ Covered |
+| AC | AxonOps status is a flag | `profile-command-group: AxonOps enabled when a key is present` + `AxonOps disabled when no key is present` | ✅ Covered |
+| AC | Tailscale status is a flag, via `User.isTailscaleEnabled()` | `profile-command-group: Tailscale enabled when both credentials are present` + `Tailscale disabled when either credential is missing` | ✅ Covered |
+| AC | Not-set-up profile gives a message, not interactive setup | `profile-command-group: Missing settings.yaml reports not-configured` | ✅ Covered |
+| AC | Malformed profile is reported, not thrown | `profile-command-group: Truncated settings.yaml is reported, not thrown` | ✅ Covered |
+| AC | Non-default profile is honored | `profile-command-group: Non-default profile is reported` | ✅ Covered |
+| AC | `profile setup` runs the existing setup flow | `profile-command-group: profile setup runs the setup workflow` + `setup: First-time user runs setup` | ✅ Covered |
+| AC | Neither `setup` nor `setup-profile` resolves at top level | `setup: Former top-level names no longer resolve` | ✅ Covered |
+| AC | Output is one block via `println()`, emits no events | `profile-command-group: Configured profile reports its settings` (asserts no `Event` for report content) | ✅ Covered |
+| AC | Docs name the new form, including bare-`setup` references | `setup: Guidance names the current command` | ✅ Covered |
+| AC | The `commands↔services` cycle is closed | — | ⚠️ Excluded — a structural invariant, not observable product behavior. Verified by task 1.5 and enforced later by the ArchUnit rules that belong to 745; encoding it as a product requirement here would misplace ownership. |
+| Risk | `Repl.kt:38-68` holds a second command-tree copy; no existing test catches the drift | — | ⚠️ Excluded — internal wiring with no distinct user-visible contract beyond the two command-resolution scenarios already specified. Carried as task 2.4 with the "no test catches this" warning attached. |
+| Risk | `ProfileShow` must carry no `@RequireProfileSetup`, or setup launches instead of reporting | `profile-command-group: Missing settings.yaml reports not-configured` (the "interactive setup flow does not run" clause) | ✅ Covered |
+| Risk | `profile show` must not load cluster state, and must stay that way | `profile-command-group: Runs outside a cluster workspace` | ✅ Covered |
+| Risk | `buildReport` reusing `maskValue()` would leak a first character and still pass a sentinel test | `profile-command-group: Secret values are absent from the report` (requirement text forbids calling any masking helper) | ✅ Covered |
+| Risk | A workspace directory named `profile` with a `kit.yaml` shadows the group | `profile-command-group: A profile kit directory is skipped` | ✅ Covered |
+| Risk | Missing Koin binding for `ProfileShow` fails silently via `KoinCommandFactory`'s fallback | — | ⚠️ Excluded — a wiring convention with no distinct observable behavior; the fallback makes the command work either way. Carried as task 3.5. |
+| Risk | Emitted event command name changes from `setup-profile` to `setup` | — | ⚠️ Excluded — deliberate consequence of the rename, recorded in `proposal.md` Impact. Nothing in the repo branches on `commandName`; it is a serialized field for external subscribers, and no committed spec constrains its value. |
+| Risk | AC3's no-cluster-state claim is conditional on `EASY_DB_LAB_RESTORE_VPC` being unset | — | ⚠️ Excluded — an environment-variable escape hatch outside this change's scope; noted in `design.md` Risks so the claim is not read as unconditional. |

--- a/openspec/changes/issue-892/ac-coverage.md
+++ b/openspec/changes/issue-892/ac-coverage.md
@@ -9,21 +9,52 @@ surfaced.
 | AC | `profile show` prints profile name, absolute directory, and all five settings | `profile-command-group: Configured profile reports its settings` | ✅ Covered |
 | AC | Works with no cluster workspace; no cluster state loaded, no cluster-state error | `profile-command-group: Runs outside a cluster workspace` | ✅ Covered |
 | AC | No secret value is printed | `profile-command-group: Secret values are absent from the report` | ✅ Covered |
-| AC | AxonOps status is a flag | `profile-command-group: AxonOps enabled when a key is present` + `AxonOps disabled when no key is present` | ✅ Covered |
+| AC | AxonOps status is a flag | `profile-command-group: AxonOps enabled when both the org and the key are present` + `AxonOps disabled when either credential is missing` | ✅ Covered — scenario amended during implementation, see note below |
 | AC | Tailscale status is a flag, via `User.isTailscaleEnabled()` | `profile-command-group: Tailscale enabled when both credentials are present` + `Tailscale disabled when either credential is missing` | ✅ Covered |
 | AC | Not-set-up profile gives a message, not interactive setup | `profile-command-group: Missing settings.yaml reports not-configured` | ✅ Covered |
 | AC | Malformed profile is reported, not thrown | `profile-command-group: Truncated settings.yaml is reported, not thrown` | ✅ Covered |
 | AC | Non-default profile is honored | `profile-command-group: Non-default profile is reported` | ✅ Covered |
-| AC | `profile setup` runs the existing setup flow | `profile-command-group: profile setup runs the setup workflow` + `setup: First-time user runs setup` | ✅ Covered |
+| AC | `profile setup` runs the existing setup flow | `profile-command-group: profile setup runs the setup workflow` + `setup: First-time user runs setup` | ✅ Covered — `SetupProfileTest` covers the workflow; `ProfileCommandGroupTest` asserts the `setup` key is bound to `SetupProfile` (added in fix round 1, tr-3) |
 | AC | Neither `setup` nor `setup-profile` resolves at top level | `setup: Former top-level names no longer resolve` | ✅ Covered |
-| AC | Output is one block via `println()`, emits no events | `profile-command-group: Configured profile reports its settings` (asserts no `Event` for report content) | ✅ Covered |
-| AC | Docs name the new form, including bare-`setup` references | `setup: Guidance names the current command` | ✅ Covered |
+| AC | Output is one block via `println()`, emits no events | `profile-command-group: Configured profile reports its settings` | ✅ Covered — `ProfileCommandGroupTest` asserts the `BufferedOutputHandler`'s `messages` and `errors` are empty after `execute()`; `TestModules.testEventBusModule()` forwards every emitted event to that handler, so empty is direct proof no event was emitted (added in fix round 1, tr-4) |
+| AC | Docs name the new form, including bare-`setup` references | `setup: Guidance names the current command` | ✅ Covered — **verified by inspection, not by test.** Zero live `setup-profile` or bare-`setup` references remain outside the two archive paths. A guard test would be a grep-over-sources test: brittle, low value, deliberately not written. |
 | AC | The `commands↔services` cycle is closed | — | ⚠️ Excluded — a structural invariant, not observable product behavior. Verified by task 1.5 and enforced later by the ArchUnit rules that belong to 745; encoding it as a product requirement here would misplace ownership. |
 | Risk | `Repl.kt:38-68` holds a second command-tree copy; no existing test catches the drift | — | ⚠️ Excluded — internal wiring with no distinct user-visible contract beyond the two command-resolution scenarios already specified. Carried as task 2.4 with the "no test catches this" warning attached. |
 | Risk | `ProfileShow` must carry no `@RequireProfileSetup`, or setup launches instead of reporting | `profile-command-group: Missing settings.yaml reports not-configured` (the "interactive setup flow does not run" clause) | ✅ Covered |
 | Risk | `profile show` must not load cluster state, and must stay that way | `profile-command-group: Runs outside a cluster workspace` | ✅ Covered |
 | Risk | `buildReport` reusing `maskValue()` would leak a first character and still pass a sentinel test | `profile-command-group: Secret values are absent from the report` (requirement text forbids calling any masking helper) | ✅ Covered |
-| Risk | A workspace directory named `profile` with a `kit.yaml` shadows the group | `profile-command-group: A profile kit directory is skipped` | ✅ Covered |
+| Risk | A workspace directory named `profile` with a `kit.yaml` shadows the group | `profile-command-group: A profile kit directory is skipped` | ✅ Covered — `CommandLineParserTest` creates `<tempCwd>/profile/kit.yaml` and asserts the `profile` subcommand is still a `Profile` instance (added in fix round 1, tr-2). Before that test the behavior rested on one untested line, `CommandLineParser.kt:272` |
 | Risk | Missing Koin binding for `ProfileShow` fails silently via `KoinCommandFactory`'s fallback | — | ⚠️ Excluded — a wiring convention with no distinct observable behavior; the fallback makes the command work either way. Carried as task 3.5. |
 | Risk | Emitted event command name changes from `setup-profile` to `setup` | — | ⚠️ Excluded — deliberate consequence of the rename, recorded in `proposal.md` Impact. Nothing in the repo branches on `commandName`; it is a serialized field for external subscribers, and no committed spec constrains its value. |
 | Risk | AC3's no-cluster-state claim is conditional on `EASY_DB_LAB_RESTORE_VPC` being unset | — | ⚠️ Excluded — an environment-variable escape hatch outside this change's scope; noted in `design.md` Risks so the claim is not read as unconditional. |
+
+## Amendments after Seam 1
+
+The owner approved this change at Seam 1 on 2026-09-05. One committed scenario was amended during
+implementation, with the owner's explicit approval, and it is recorded here rather than silently
+edited.
+
+**`profile-command-group`: the AxonOps flag scenarios.** As approved, the scenario read *GIVEN
+`axonOpsKey` is non-empty THEN the output reports AxonOps as `ENABLED`*, with no condition on
+`axonOpsOrg`. The correctness lens found that both real consumers — `Up.kt:706` and
+`cassandra/Start.kt:78` — require **both** fields to be non-blank before enabling AxonOps, so the
+approved scenario described a report that would assert a capability the next `up` or `cassandra
+start` would silently skip. Two reachable states produced the wrong answer: a key set with a blank
+org (which `SetupProfile` can produce, since it prompts for the two independently and either can be
+skipped), and a whitespace-only key.
+
+The scenario encoded the bug, so the code could not be both correct and conformant. The implementer
+raised it as a `SPEC-DEFECT` rather than editing the spec to match its own code. The owner chose to
+amend the scenario. The requirement now names `User.isAxonOpsEnabled()` as the shared predicate and
+requires both fields; `Up.kt` and `cassandra/Start.kt` were repointed at that same predicate, so one
+definition replaces three copies of the rule.
+
+Issue AC5 and `tasks.md` 3.4 were updated to match.
+
+## A note on what "Covered" means in this table
+
+The *Covering scenario(s)* column names **spec scenarios**, not tests. A reader who takes ✅ Covered
+to mean "verified by a test" can be misled, and was: three scenarios reached the review panel with
+no implementing test, and one row claimed an assertion that did not exist. Fix round 1 closed all
+four gaps, and each row above now names the test that pins it, or says plainly that it is verified
+by inspection instead.

--- a/openspec/changes/issue-892/design.md
+++ b/openspec/changes/issue-892/design.md
@@ -1,0 +1,224 @@
+# Design — issue 892: `profile` command group with `profile show`
+
+## Context
+
+Design was produced by the `architect` agent, stress-tested by `design-critic`, and decided by the
+owner at the activation design stop. Both agents verified picocli 4.7.7 behaviour by compiling and
+running probes against the real jar rather than reasoning from documentation; their probes agreed.
+
+## Structure
+
+New package `commands/profile/`:
+
+- `Profile.kt` — the group. `Runnable`, `@Command(name = "profile", mixinStandardHelpOptions = true,
+  subcommands = [ProfileShow::class, SetupProfile::class])`, `run()` prints usage. The `Kit.kt`
+  shape exactly.
+- `ProfileShow.kt` — `@Command(name = "show")`, extends `PicoBaseCommand`, **no requirement
+  annotations**.
+- `SetupProfile.kt` — moved from `commands/`, renamed to `@Command(name = "setup")`, `aliases`
+  removed.
+
+`CommandLineParser` registers `Profile::class` and drops `SetupProfile::class` from the top-level
+list. `Repl.kt:61`'s `ShellCommands` entry changes correspondingly.
+
+`PicoCommand` moves out of `commands/` to a kernel package in the main module. Not `core` — it
+imports `annotations.PreExecute`/`PostExecute`, which would drag that package along and widen the
+change well past this issue. `PicoBaseCommand` stays in `commands/`; only the interface moves.
+
+`services/ProfileSetupCommandProvider.kt` — a `fun interface` returning a `PicoCommand`, so
+`CommandExecutor.checkRequirements()` names an abstraction instead of `SetupProfile()`. A provider
+rather than a `ProfileSetupRunner { fun run() }`: a runner would call back into
+`CommandExecutor.execute`, creating a Koin construction cycle that then needs a lazy `get()` to
+break. The provider needs only the `SetupProfile` factory, so there is no wiring cycle to break.
+
+## Report construction
+
+```kotlin
+companion object {
+    fun buildReport(profileName: String, profileDir: String, user: User?): String
+}
+
+override fun execute() { … println(buildReport(…)) }
+```
+
+One function, one call site, following `KitList.buildListText` / `KitInfo.buildInfoText` so tests
+assert on returned text rather than capturing stdout.
+
+`buildReport` is the right surface for the report *text* and the wrong surface for anything about
+the lifecycle — see **Test surface** below. That split is the single most important correction the
+critic made to this design.
+
+Use `getUserConfig()`, not `loadExistingConfig()`: the typed `User` is what provides
+`isTailscaleEnabled()` (`User.kt:52`), which the acceptance criteria require the command to call
+rather than re-derive. Guard with `isSetup()` first, since `loadUserConfig()` calls `error()` when
+`settings.yaml` is absent (`UserConfigProvider.kt:76-81`).
+
+Profile identity comes from `Context` — `context.profile` and `context.profileDir.absolutePath`
+resolve `EASY_DB_LAB_PROFILE` at `Context.kt:49-51`. `Context`'s `init` runs `profileDir.mkdirs()`
+(`Context.kt:57`), so the directory always exists; only `settings.yaml`'s presence distinguishes
+configured from unconfigured. `UserConfigProvider` is already bound to the active profile —
+`di/ContextModule.kt:29` constructs it as `UserConfigProvider(context.profileDir)`.
+
+## Test surface
+
+`buildReport` is a pure function of three plain values. It cannot observe what the command lifecycle
+did, so it proves the report-text criteria and nothing else. A second, lifecycle-level test class
+covers:
+
+| Criterion | Why `buildReport` cannot prove it |
+|---|---|
+| Bare group prints help, exits 0 | Property of the picocli tree, not the formatter |
+| No cluster state loaded | `buildReport` cannot load cluster state under any input, so the assertion is *vacuously* green — and would stay green through exactly the regression this guards against |
+| Does not launch interactive setup | Property of `CommandExecutor.checkRequirements()` (`CommandExecutor.kt:228-236`) and of `ProfileShow`'s annotations. Cheapest real proof: assert `ProfileShow::class.annotations` carries no `RequireProfileSetup` |
+| Non-default profile honored | `buildReport` receives the profile name as a parameter, so a test there proves only that it prints the string it was handed. Reachable only through `Context` construction |
+| Old top-level names no longer resolve | Property of the picocli tree |
+
+## Alternatives Considered
+
+### The `setup-profile` alias — dropped entirely (owner decision)
+
+The issue assumed the alias was a given and left only its *registration mechanism* open. The
+architect probed four mechanisms against picocli 4.7.7:
+
+| Candidate | Measured behaviour |
+|---|---|
+| `aliases = ["setup"]` on `@Command` | The alias becomes an extra key in the **same parent's** map — root map returned `[profile, setup-profile, setup]`. Aliases are sibling names; they cannot cross a level. |
+| Same class in two `subcommands` arrays | Works; picocli builds two independent instances. But both take the name from the annotation, so you get `profile setup-profile`, not `profile setup`. |
+| `addSubcommand("setup", CommandLine(SetupProfile()))` | Parses, and the group's help shows `setup`. But `spec.name()` stays `setup-profile` and `qualifiedName()` returns `root profile setup-profile` — the subcommand's own usage header prints the wrong path. |
+| Thin subclass | Works completely. Root map `[profile, setup-profile]`, group map `[setup]`, both usage headers correct. |
+
+The architect recommended the thin subclass. The critic then found a materially simpler variant the
+architect never considered — **reversing the subclass direction**, leaving `SetupProfile` in place
+as `setup-profile` and making the *new* class the subclass — which put the churn on new code instead
+of pre-existing code, kept the 15 Kotlin references and both existing test classes put, and avoided
+silently retagging events on `CommandExecutor`'s forced-setup path.
+
+**The owner rejected the premise instead: drop `setup-profile` altogether.** Aliasing was a
+nice-to-have. This removes the new class, the `open` keyword, the second Koin binding, and three of
+the critic's minor findings (event retagging on the forced-setup path; the latent hook-inheritance
+trap, since `PicoCommand.call()` selects hooks with `declaredMemberFunctions`, which excludes
+inherited functions; and a silently-failing missing Koin binding).
+
+Rejected alternatives, for the record:
+- **`CommandSpec.forAnnotatedObject(...).name(...)`**, the `KitRunnerCommandFactory.kt:97`
+  precedent. Renames correctly, but binds one instance into the spec for the process lifetime —
+  the thing `factory { }` exists to avoid.
+- **A delegating alias class** that calls `commandExecutor.execute { SetupProfile() }`. Runs a
+  second full lifecycle inside the first and pushes two names onto `EventContext`.
+
+### The emitted event command name — let it be `setup`
+
+`PicoBaseCommand.call()` reads `this::class.java.getAnnotation(Command::class.java)?.name`
+(`PicoBaseCommand.kt:48`) and pushes it onto `EventContext`; `EventBus.emit` stamps it onto
+`EventEnvelope.commandName` (`EventBus.kt:31`). The architect grepped every `commandName` reference
+in `src/main`: the only producers and consumers are `EventContext`, `EventBus`, and `EventEnvelope`
+itself. No listener branches on the value — it is a serialized field for external subscribers.
+
+**Rejected: emit the fully-qualified `profile setup`.** Not reachable from `@Command(name = ...)`,
+which holds the leaf name only. It would require `PicoBaseCommand.call()` to push
+`spec.qualifiedName()`, changing the emitted name for *every* grouped command in the tree at once —
+`kit list`, `cassandra start`, `tailscale status`. A repository-wide change to the event stream
+shape, and a separate issue.
+
+**Rejected: an overridable `eventName` on `PicoBaseCommand`.** A new base-class mechanism for one
+command.
+
+### The 745 fold-in — full (owner decision)
+
+- **Narrow** (the provider only): 6 files, 2 tests touched mechanically. Closes **no** cycle —
+  `CommandExecutor.kt:10` still imports `commands.PicoCommand`, and that edge *is* the cycle.
+- **Full** (provider + relocate `PicoCommand`): narrow's 6 plus 11 more files, every one a single
+  import line; 5 tests, all one-line import edits. The 56 files importing `PicoBaseCommand` are
+  unaffected — they extend the base class, not the interface.
+
+The architect's headline claim was that full closes **two** of 745's cycles. **The critic showed
+that is wrong.** `McpToolRegistry` names its 20 command classes by fully-qualified name, not by
+import (`McpToolRegistry.kt:46-65`), so removing its `PicoCommand` import deletes a line and no
+dependency; and `Server.kt:7` imports `mcp.McpServer`, so the reverse edge stands. `mcp↔commands`
+survives either way, and since ArchUnit works on bytecode, 745's eventual rule would still fail on
+it. Full closes **one** cycle.
+
+The `commands↔services` half holds: the critic grepped for fully-qualified references as well as
+imports, and `CommandExecutor.kt:10-11` are the only two `commands` references anywhere under
+`services/`.
+
+Owner chose full on the corrected framing.
+
+### The secret-omission criterion — simplified (owner decision)
+
+The original AC forbade "no substring of any of them, in plain, masked, or truncated form". The
+critic showed this is **unsatisfiable**: every non-empty secret has one-character substrings and the
+report prints letters. It is also value-dependent rather than a property of the code —
+`awsSecret` set to `us-east-1` while `region` is `us-east-1` fails a `doesNotContain` assertion
+though nothing leaked.
+
+The critic proposed two shapes that would hold for all values: a property test (no contiguous run of
+4+ characters from any secret), or a `ProfileReportData` projection so secrets never reach the
+formatter at all.
+
+**The owner judged both overkill for five fields** and restated the criterion as: the output
+contains none of those five values. Sentinel-value test, `doesNotContain` per secret.
+
+The residual risk is named rather than designed away: `SetupProfile.maskValue()`
+(`SetupProfile.kt:357-362`) — in the sibling file this change edits — returns `"${value[0]}****"`,
+and a `buildReport` reusing it would leak a first character and pass. `buildReport` must not call
+any masking helper.
+
+### Report input — pass `User` directly
+
+**Rejected: a `ProfileReportData` value type.** It would make leakage structurally impossible inside
+the formatter, but relocates the leak risk into an unmapped projection step and adds a type for one
+call site. With the simplified criterion, the direct-`User` test is adequate evidence.
+
+## Domain Facts
+
+No domain-expert agent was consulted — this is CLI structure, not a database-domain question.
+
+## Risks
+
+- **`Repl.kt:38-68` is a second, hand-maintained copy of the command tree**, listing
+  `SetupProfile::class` at line 61 independently of `CommandLineParser`. Required edit. The critic
+  confirmed no *other* hand-maintained copy exists: `Commands.kt` walks the live picocli tree at
+  runtime, `McpToolRegistry` names no profile or setup command, and the repo ships no completion
+  script. It also confirmed `ReplTest` asserts only on `status`, `cassandra`, `spark`, `cls` and
+  `cassandra stress`, so **nothing existing tests this edit** — it depends on the implementer
+  remembering it.
+- **`ProfileShow` must carry no requirement annotation.** `checkRequirements()`
+  (`CommandExecutor.kt:228-236`) responds to `@RequireProfileSetup` by running `SetupProfile()` and
+  `exitProcess(0)`. An annotation added later "for consistency" breaks the command's whole purpose.
+- **`profile show` loads no cluster state, and that must stay true by omission.** `PicoBaseCommand`
+  exposes `clusterState` as `by lazy`, so not naming it means no `state.json` read. A later reviewer
+  adding a "helpful" cluster line breaks the no-workspace criterion — which is why that criterion is
+  tested at the lifecycle level, where the regression is visible.
+- **The AC3 claim carries one unstated condition.** `executeTopLevel` calls
+  `handleVpcReconstructionFromEnv()` before every command (`CommandExecutor.kt:124`), which returns
+  immediately unless `EASY_DB_LAB_RESTORE_VPC` is set (`CommandExecutor.kt:355`). The criterion
+  holds, but not unconditionally.
+- **Six user-facing strings name `setup-profile`**: `Event.kt:2881`, `Event.kt:3632`,
+  `UserConfigProvider.kt:79`, `providers/aws/AWS.kt:260`, `containers/Packer.kt:86`,
+  `commands/tailscale/TailscaleStart.kt:91`. Nine more in KDoc and comments. Live total outside the
+  two archive paths is 33 lines, 15 Kotlin — the issue's count; the architect's 34/19 was an
+  arithmetic error against its own enumeration.
+- **Register `ProfileShow` in `di/CommandsModule.kt`.** `KoinCommandFactory` falls back to picocli's
+  default factory when Koin has no binding (`KoinCommandFactory.kt:22-30`), and the fallback happens
+  to work because `PicoBaseCommand` is a `KoinComponent` — so an omission fails **silently**.
+- **A workspace directory named `profile` holding a `kit.yaml`** stops registering as a kit command
+  (`CommandLineParser.kt:267`). Improbable, but a real behaviour change.
+
+## Structural debt near this change, not folded in
+
+Recommended as separate issues; none filed. The owner was shown these at the design stop and left
+them for later.
+
+- `Repl.ShellCommands` duplicates the root command tree and has drifted — missing `Kit`,
+  `Tailscale`, `Logs`, `Metrics`, `Platform`, `Grafana`, `Cleanup`, `Down`, `Server`, `Commands`.
+  The real fix is one shared subcommand list behind both roots.
+- `Context`'s constructor performs I/O (`profileDir.mkdirs()`, `Context.kt:57`).
+- `UserConfigProvider.loadUserConfig()` emits user-facing CLI guidance from a persistence class
+  (`UserConfigProvider.kt:76-81`).
+- `McpToolRegistry.mcpCommandClasses` is a hardcoded 20-class literal (`McpToolRegistry.kt:44-66`) —
+  the underlying reason MCP exposure of `profile show` is out of scope.
+
+Folded in: the dead branch in `SetupProfile.maskValue()` (`SetupProfile.kt:357-362`), where
+`value.length == 1` returns exactly what `else` returns. Two-line deletion in a file this change
+already edits.

--- a/openspec/changes/issue-892/overrides.md
+++ b/openspec/changes/issue-892/overrides.md
@@ -1,0 +1,39 @@
+# Overrides and conflicts — issue 892
+
+## Overrides existing behavior
+
+### setup: Profile Setup
+
+**Currently:**
+
+> The system MUST provide an interactive workflow to create a user profile with AWS credentials,
+> region, and key pair configuration.
+
+Two scenarios, both naming the workflow generically ("run the setup workflow", "runs setup") — the
+baseline requirement does not pin a command name at all.
+
+**This change:** same guarantee, plus an explicit command name and the removal of the two former
+top-level names:
+
+> The workflow SHALL be reached as `easy-db-lab profile setup`. The former top-level names
+> `setup-profile` and `setup` SHALL NOT resolve.
+
+Two scenarios are added: one asserting neither old name resolves, one requiring any CLI message that
+directs a user to configure their profile to name `easy-db-lab profile setup`.
+
+**This is a breaking user-visible change, made deliberately.** `easy-db-lab setup` and
+`easy-db-lab setup-profile` both stop working. The owner decided at the design stop that aliasing
+was a nice-to-have not worth carrying a second class for. Nothing in the baseline spec promised
+either name — the requirement was command-name-agnostic — so no committed promise is being broken;
+the change makes the spec stricter than it was, not different from it.
+
+No `REMOVED Requirements` sections in this change.
+
+## Conflicts with other in-flight changes
+
+One other open change exists: `issue-888`. It touches `kit-install-command` and `workload-runner`.
+This change touches `profile-command-group` (new) and `setup`. No capability is shared, so there is
+no conflict.
+
+`profile-command-group` is a new capability with no baseline file, so it cannot conflict with
+anything on the current baseline either.

--- a/openspec/changes/issue-892/proposal.md
+++ b/openspec/changes/issue-892/proposal.md
@@ -1,0 +1,63 @@
+# Add a `profile` command group with `profile show`
+
+## Why
+
+Nothing in the CLI reports what the active profile actually holds. `status` prints the *cluster's*
+bucket from `state.json` (`Status.kt:397-415`), not the profile's, and it fails outside a cluster
+workspace. The only way to read the profile's `s3Bucket` today is a hand-written grep of
+`~/.easy-db-lab/profiles/<profile>/settings.yaml`.
+
+That gap is worst exactly when it matters most. A user debugging a misconfigured profile has no
+command to ask "what am I configured with?", and the multi-profile mechanism
+(`EASY_DB_LAB_PROFILE`) makes "which profile am I even on?" a real question with no answer.
+
+Setup is also mis-shelved. `setup-profile` sits at the top level with a bare `setup` alias, while
+every comparable area of the CLI — `kit`, `tailscale`, `cassandra` — groups its operations under a
+parent command. Adding profile inspection as a second top-level command would compound that; adding
+it under a `profile` group fixes the shelving and creates the obvious home for later `profile list`
+and `profile use`.
+
+## What Changes
+
+**A new `profile` top-level command group**, following `kit` and `tailscale`. The group class is a
+`Runnable`, not a `PicoCommand` — the execution strategy at `CommandLineParser.kt:161-167` routes
+only `PicoCommand` through `CommandExecutor`, so a bare `easy-db-lab profile` falls through to
+`CommandLine.RunLast()`, prints usage, and exits 0. `Kit` already proves this path.
+
+**A new `profile show` command** that reports the active profile's name, absolute directory,
+`email`, `region`, `keyName`, `awsProfile`, and `s3Bucket`, plus `ENABLED`/`DISABLED` flags for
+AxonOps and Tailscale. It prints none of the five secret values. It carries no requirement
+annotation and reads no cluster state, so it works in any directory. Report text is built by a
+`companion object` function so it is unit-testable without capturing stdout, following `KitList`
+and `KitInfo`.
+
+It has three branches, not two: configured, no `settings.yaml`, and — new — a `settings.yaml` that
+exists but cannot be deserialized. `isSetup()` is a bare `exists()` check
+(`UserConfigProvider.kt:42`) while `User` has six constructor parameters with no defaults
+(`User.kt:31-37`), so a truncated or hand-edited file currently throws a raw Jackson error through
+the very command added to diagnose it.
+
+**`setup-profile` becomes `profile setup`, with both old names removed.** The bare `setup` alias
+and the top-level `setup-profile` name both stop resolving. All 33 live `setup-profile` references
+are updated, plus two docs passages naming the bare `setup` alias that contain no `setup-profile`
+string. `Repl.kt:38-68` holds a second, hand-maintained copy of the command tree and needs its own
+edit.
+
+**The `commands↔services` package dependency cycle is closed** — one of the seven cycles named in
+745. `PicoCommand` moves out of `commands/` to a kernel package in the main module, and a
+`ProfileSetupCommandProvider` in `services/` replaces `CommandExecutor`'s direct construction of
+`SetupProfile()`. `CommandExecutor.kt:10-11` are the only two `commands` references anywhere under
+`services/`.
+
+## Impact
+
+- **Breaking, deliberately.** `easy-db-lab setup` and `easy-db-lab setup-profile` stop resolving.
+  Aliasing was a nice-to-have and is not worth carrying a second class for.
+- The emitted event command name for setup changes from `setup-profile` to `setup`. Nothing in the
+  repo branches on `commandName`; it is a serialized field for external subscribers.
+- The tree will carry two unrelated `profile` groups under different parents — the new one and the
+  existing `cassandra profile` (`commands/cassandra/profiler/Profiler.kt:25`). Not a conflict.
+- A workspace directory named `profile` holding a `kit.yaml` stops registering as a kit command
+  (`CommandLineParser.kt:267`).
+- Does **not** add the ArchUnit cycle rules. They would fail immediately on the five cycles this
+  change does not touch; 745 owns them.

--- a/openspec/changes/issue-892/specs/profile-command-group/spec.md
+++ b/openspec/changes/issue-892/specs/profile-command-group/spec.md
@@ -1,0 +1,119 @@
+# Profile Command Group Spec
+
+## ADDED Requirements
+
+### Requirement: `profile` top-level parent command
+The CLI SHALL expose a `profile` top-level parent command that groups profile inspection and setup
+operations. When invoked without a subcommand, `profile` SHALL print its help text and exit 0.
+
+#### Scenario: `profile` with no subcommand prints help
+- **WHEN** the user runs `easy-db-lab profile`
+- **THEN** the CLI prints the help text listing the `show` and `setup` subcommands
+- **AND** exits with status 0
+
+### Requirement: `profile show` reports the active profile
+The CLI SHALL expose a `profile show` subcommand that reports the active profile's name, its
+absolute directory, and the `email`, `region`, `keyName`, `awsProfile`, and `s3Bucket` settings.
+
+The report SHALL be written with `println()` from a single multiline string. No `Event` SHALL be
+emitted for the report content.
+
+#### Scenario: Configured profile reports its settings
+- **GIVEN** a profile whose `settings.yaml` sets `email`, `region`, `keyName`, `awsProfile`, and `s3Bucket`
+- **WHEN** the user runs `easy-db-lab profile show`
+- **THEN** the output contains the profile name, the absolute profile directory, and all five values
+- **AND** no `Event` is emitted for the report content
+
+### Requirement: `profile show` never prints secret values
+`profile show` SHALL NOT print the value of `awsAccessKey`, `awsSecret`, `axonOpsKey`,
+`tailscaleClientId`, or `tailscaleClientSecret`. The report builder SHALL NOT call any masking
+helper, so that no partial or truncated form of a secret can reach the output.
+
+#### Scenario: Secret values are absent from the report
+- **GIVEN** `awsAccessKey`, `awsSecret`, `axonOpsKey`, `tailscaleClientId`, and `tailscaleClientSecret` are each set to a known non-empty value
+- **WHEN** the user runs `easy-db-lab profile show`
+- **THEN** the output contains none of those five values
+
+### Requirement: `profile show` reports AxonOps and Tailscale as flags
+`profile show` SHALL report AxonOps and Tailscale as `ENABLED` or `DISABLED` rather than printing
+their credentials. Tailscale status SHALL be determined by calling `User.isTailscaleEnabled()`
+rather than re-deriving the rule.
+
+#### Scenario: AxonOps enabled when a key is present
+- **GIVEN** `axonOpsKey` is non-empty
+- **WHEN** the user runs `easy-db-lab profile show`
+- **THEN** the output reports AxonOps as `ENABLED`
+
+#### Scenario: AxonOps disabled when no key is present
+- **GIVEN** `axonOpsKey` is empty
+- **WHEN** the user runs `easy-db-lab profile show`
+- **THEN** the output reports AxonOps as `DISABLED`
+
+#### Scenario: Tailscale enabled when both credentials are present
+- **GIVEN** `tailscaleClientId` and `tailscaleClientSecret` are both non-empty
+- **WHEN** the user runs `easy-db-lab profile show`
+- **THEN** the output reports Tailscale as `ENABLED`
+
+#### Scenario: Tailscale disabled when either credential is missing
+- **GIVEN** either `tailscaleClientId` or `tailscaleClientSecret` is empty or blank
+- **WHEN** the user runs `easy-db-lab profile show`
+- **THEN** the output reports Tailscale as `DISABLED`
+
+### Requirement: `profile show` requires no cluster workspace
+`profile show` SHALL run in any working directory. It SHALL NOT load cluster state and SHALL NOT
+carry any requirement annotation that would trigger interactive setup.
+
+#### Scenario: Runs outside a cluster workspace
+- **GIVEN** the working directory holds no `state.json`, `env.sh`, or `sshConfig`
+- **WHEN** the user runs `easy-db-lab profile show`
+- **THEN** the command exits 0 and prints the full report
+- **AND** no cluster state is loaded and no cluster-state error is raised
+
+### Requirement: `profile show` reports an unconfigured profile
+When the active profile has no `settings.yaml`, `profile show` SHALL report that the profile is not
+configured and name `easy-db-lab profile setup`. It SHALL NOT launch the interactive setup flow and
+SHALL NOT throw.
+
+#### Scenario: Missing settings.yaml reports not-configured
+- **GIVEN** the active profile's `settings.yaml` does not exist
+- **WHEN** the user runs `easy-db-lab profile show`
+- **THEN** the CLI prints that the profile is not configured and names `easy-db-lab profile setup`
+- **AND** the interactive setup flow does not run and no exception is raised
+
+### Requirement: `profile show` reports a malformed profile
+When the active profile's `settings.yaml` exists but cannot be deserialized, `profile show` SHALL
+report the profile as present but unreadable, naming the file path and `easy-db-lab profile setup`.
+It SHALL NOT surface a raw deserialization error.
+
+#### Scenario: Truncated settings.yaml is reported, not thrown
+- **GIVEN** the active profile's `settings.yaml` exists but omits a field that has no default
+- **WHEN** the user runs `easy-db-lab profile show`
+- **THEN** the CLI reports the profile as present but unreadable and names the file path and `easy-db-lab profile setup`
+- **AND** no raw deserialization error is shown
+
+### Requirement: `profile show` honors the active profile selection
+`profile show` SHALL report the profile named by `EASY_DB_LAB_PROFILE`, reading its values from that
+profile's own directory.
+
+#### Scenario: Non-default profile is reported
+- **GIVEN** `EASY_DB_LAB_PROFILE` is set to `staging` and that profile's `settings.yaml` exists
+- **WHEN** the user runs `easy-db-lab profile show`
+- **THEN** the report names `staging` and prints values read from the `staging` profile directory
+
+### Requirement: `profile setup` subcommand
+The CLI SHALL expose `profile setup`, running the same interactive profile setup workflow
+previously reached through `setup-profile`.
+
+#### Scenario: `profile setup` runs the setup workflow
+- **WHEN** the user runs `easy-db-lab profile setup`
+- **THEN** the interactive profile setup workflow runs as it did under the previous command name
+
+### Requirement: A workspace directory named `profile` does not register as a kit
+Dynamic kit registration SHALL skip a workspace directory whose name collides with an existing
+top-level command, so a directory named `profile` holding a `kit.yaml` does not shadow the profile
+command group.
+
+#### Scenario: A `profile` kit directory is skipped
+- **GIVEN** the working directory contains a subdirectory named `profile` holding a `kit.yaml`
+- **WHEN** the user runs `easy-db-lab profile`
+- **THEN** the profile command group runs and the directory is not registered as a kit command

--- a/openspec/changes/issue-892/specs/profile-command-group/spec.md
+++ b/openspec/changes/issue-892/specs/profile-command-group/spec.md
@@ -36,16 +36,22 @@ helper, so that no partial or truncated form of a secret can reach the output.
 
 ### Requirement: `profile show` reports AxonOps and Tailscale as flags
 `profile show` SHALL report AxonOps and Tailscale as `ENABLED` or `DISABLED` rather than printing
-their credentials. Tailscale status SHALL be determined by calling `User.isTailscaleEnabled()`
-rather than re-deriving the rule.
+their credentials.
 
-#### Scenario: AxonOps enabled when a key is present
-- **GIVEN** `axonOpsKey` is non-empty
+Each flag SHALL be determined by calling the shared predicate on `User` rather than re-deriving the
+rule — `User.isAxonOpsEnabled()` and `User.isTailscaleEnabled()` respectively. A flag SHALL report
+`ENABLED` only where the feature will actually run: AxonOps requires **both** `axonOpsOrg` and
+`axonOpsKey` to be non-blank, matching what `Up` and `cassandra start` require before they enable
+it. A report that asserted a capability the next command would silently skip would be worse than no
+report at all.
+
+#### Scenario: AxonOps enabled when both the org and the key are present
+- **GIVEN** `axonOpsOrg` and `axonOpsKey` are both non-blank
 - **WHEN** the user runs `easy-db-lab profile show`
 - **THEN** the output reports AxonOps as `ENABLED`
 
-#### Scenario: AxonOps disabled when no key is present
-- **GIVEN** `axonOpsKey` is empty
+#### Scenario: AxonOps disabled when either credential is missing
+- **GIVEN** either `axonOpsOrg` or `axonOpsKey` is empty or blank
 - **WHEN** the user runs `easy-db-lab profile show`
 - **THEN** the output reports AxonOps as `DISABLED`
 

--- a/openspec/changes/issue-892/specs/setup/spec.md
+++ b/openspec/changes/issue-892/specs/setup/spec.md
@@ -1,0 +1,34 @@
+# Setup Spec
+
+## MODIFIED Requirements
+
+### Requirement: Profile Setup
+
+The system MUST provide an interactive workflow to create a user profile with AWS credentials,
+region, and key pair configuration.
+
+The workflow SHALL be reached as `easy-db-lab profile setup`. The former top-level names
+`setup-profile` and `setup` SHALL NOT resolve.
+
+#### Scenario: First-time user runs setup
+
+- **GIVEN** a first-time user
+- **WHEN** they run `easy-db-lab profile setup`
+- **THEN** they are prompted for AWS profile or credentials, region, and key pair selection.
+
+#### Scenario: Existing profile reviewed on re-run
+
+- **GIVEN** a completed profile
+- **WHEN** the user runs `easy-db-lab profile setup` again
+- **THEN** existing settings are available for review and modification.
+
+#### Scenario: Former top-level names no longer resolve
+
+- **WHEN** the user runs `easy-db-lab setup-profile` or `easy-db-lab setup`
+- **THEN** the CLI does not resolve either as a top-level command.
+
+#### Scenario: Guidance names the current command
+
+- **GIVEN** any CLI message that directs the user to configure their profile
+- **WHEN** that message is shown
+- **THEN** it names `easy-db-lab profile setup`.

--- a/openspec/changes/issue-892/tasks.md
+++ b/openspec/changes/issue-892/tasks.md
@@ -62,26 +62,26 @@
 
 ## 5. Docs and strings
 
-- [ ] 5.1 Update the 6 user-facing Kotlin strings: `Event.kt:2881`, `Event.kt:3632`
+- [x] 5.1 Update the 6 user-facing Kotlin strings: `Event.kt:2881`, `Event.kt:3632`
       (`ProfileNotConfigured`), `UserConfigProvider.kt:79`, `providers/aws/AWS.kt:260`,
       `containers/Packer.kt:86`, `commands/tailscale/TailscaleStart.kt:91`.
-- [ ] 5.2 Update the remaining 9 Kotlin KDoc/comment references.
-- [ ] 5.3 Update the 18 README and `docs/` references.
-- [ ] 5.4 Update the two bare-`setup` docs passages that contain no `setup-profile` string:
+- [x] 5.2 Update the remaining 9 Kotlin KDoc/comment references.
+- [x] 5.3 Update the 18 README and `docs/` references.
+- [x] 5.4 Update the two bare-`setup` docs passages that contain no `setup-profile` string:
       `docs/getting-started/setup.md:33` and `docs/reference/commands.md:25`.
-- [ ] 5.5 Document `profile` and `profile show` in `docs/reference/commands.md`. Note the existing
+- [x] 5.5 Document `profile` and `profile show` in `docs/reference/commands.md`. Note the existing
       unrelated `cassandra profile` group already documented there.
-- [ ] 5.6 Verify no live `setup-profile` or bare-`setup` reference remains outside
+- [x] 5.6 Verify no live `setup-profile` or bare-`setup` reference remains outside
       `openspec/archive/` and `openspec/changes/archive/`.
 
 ## 6. Folded-in debt
 
-- [ ] 6.1 Delete the dead branch in `SetupProfile.maskValue()` (`SetupProfile.kt:357-362`) — the
+- [x] 6.1 Delete the dead branch in `SetupProfile.maskValue()` (`SetupProfile.kt:357-362`) — the
       `value.length == 1` case returns exactly what `else` returns.
 
 ## 7. Verification
 
-- [ ] 7.1 `./gradlew ktlintFormat` then `./gradlew check` (JDK 21 — detekt 1.23.8 cannot run under
+- [x] 7.1 `./gradlew ktlintFormat` then `./gradlew check` (JDK 21 — detekt 1.23.8 cannot run under
       JDK 25).
-- [ ] 7.2 Run the command locally against a real profile: `profile`, `profile show`, a non-default
+- [x] 7.2 Run the command locally against a real profile: `profile`, `profile show`, a non-default
       `EASY_DB_LAB_PROFILE`, and from a directory with no cluster workspace.

--- a/openspec/changes/issue-892/tasks.md
+++ b/openspec/changes/issue-892/tasks.md
@@ -1,0 +1,87 @@
+# Tasks — issue 892
+
+## 1. Close the `commands↔services` cycle
+
+- [ ] 1.1 Move the `PicoCommand` interface out of `commands/` to a kernel package in the main module
+      (not `core` — it imports `annotations.PreExecute`/`PostExecute`). `PicoBaseCommand` stays in
+      `commands/`.
+- [ ] 1.2 Update the 5 `src/main` importers (`CommandLineParser.kt`, `commands/aws/Region.kt`,
+      `commands/aws/S3Bucket.kt`, `mcp/McpToolRegistry.kt`, `services/CommandExecutor.kt`), the 3
+      `src/test` importers (`TestModules.kt`, `mcp/McpAnnotationTest.kt`,
+      `commands/cassandra/UseCassandraTest.kt`), and the 3 same-package files that gain an import
+      (`commands/PicoBaseCommand.kt`, `commands/Commands.kt`, `commands/Ip.kt`).
+- [ ] 1.3 Add `services/ProfileSetupCommandProvider.kt` — a `fun interface` returning a
+      `PicoCommand` — and bind it. Replace the direct `SetupProfile()` construction at
+      `CommandExecutor.kt:231` with `profileSetupProvider.create()`.
+- [ ] 1.4 Add the constructor argument at the two direct `DefaultCommandExecutor(...)` construction
+      sites in tests (`CommandExecutorTest.kt:86`, `StatusTest.kt:448`).
+- [ ] 1.5 Verify no file under `services/` references any type in `commands/`, by import **or**
+      fully-qualified name.
+
+## 2. Build the `profile` command group
+
+- [ ] 2.1 Add `commands/profile/Profile.kt` — a `Runnable` group, not a `PicoCommand`, so a bare
+      invocation falls through to `CommandLine.RunLast()` and exits 0. Class-level KDoc required.
+- [ ] 2.2 Move `SetupProfile.kt` to `commands/profile/`, rename to `@Command(name = "setup")`, and
+      remove the `aliases = ["setup"]` entry.
+- [ ] 2.3 Register `Profile::class` in `CommandLineParser.kt` and remove `SetupProfile::class` from
+      the top-level list.
+- [ ] 2.4 Update `Repl.kt:61`'s `ShellCommands` entry — a second, hand-maintained copy of the
+      command tree. **No existing test catches this**; `ReplTest` asserts only on `status`,
+      `cassandra`, `spark`, `cls`, and `cassandra stress`.
+- [ ] 2.5 Update the Koin binding in `di/CommandsModule.kt` for `SetupProfile`'s new package.
+
+## 3. Implement `profile show`
+
+- [ ] 3.1 Add `commands/profile/ProfileShow.kt` — `@Command(name = "show")`, extends
+      `PicoBaseCommand`, **no requirement annotations**, never references `clusterState`.
+      Class-level KDoc required.
+- [ ] 3.2 Implement `buildReport(profileName, profileDir, user: User?)` as a `companion object`
+      function returning one multiline string, following `KitList.buildListText` /
+      `KitInfo.buildInfoText`. It must **not** call any masking helper.
+- [ ] 3.3 Handle all three branches: configured; `settings.yaml` absent (not-configured message
+      naming `easy-db-lab profile setup`); `settings.yaml` present but undeserializable (report
+      present-but-unreadable with the file path, no raw Jackson error).
+- [ ] 3.4 Read profile identity from `context.profile` / `context.profileDir.absolutePath`; use
+      `getUserConfig()` guarded by `isSetup()`; call `User.isTailscaleEnabled()` for the Tailscale
+      flag and `axonOpsKey.isNotEmpty()` for AxonOps.
+- [ ] 3.5 Register `ProfileShow` in `di/CommandsModule.kt` — omission fails **silently** via
+      `KoinCommandFactory`'s fallback.
+
+## 4. Tests
+
+- [ ] 4.1 `buildReport` unit tests: all five settings present; each secret absent from output
+      (sentinel values); AxonOps `ENABLED`/`DISABLED`; Tailscale `ENABLED`/`DISABLED` including the
+      blank-credential case; not-configured message; malformed-profile message.
+- [ ] 4.2 Lifecycle-level test class for what `buildReport` cannot observe: bare `profile` exits 0
+      and lists `show` and `setup`; `setup` and `setup-profile` no longer resolve at top level;
+      `ProfileShow::class.annotations` carries no `RequireProfileSetup`; `ClusterStateManager.load()`
+      is never called for `profile show`; `EASY_DB_LAB_PROFILE` resolution through `Context`.
+- [ ] 4.3 Confirm the existing `SetupProfileTest` and `SetupProfileIntegrationTest` still pass after
+      the move.
+
+## 5. Docs and strings
+
+- [ ] 5.1 Update the 6 user-facing Kotlin strings: `Event.kt:2881`, `Event.kt:3632`
+      (`ProfileNotConfigured`), `UserConfigProvider.kt:79`, `providers/aws/AWS.kt:260`,
+      `containers/Packer.kt:86`, `commands/tailscale/TailscaleStart.kt:91`.
+- [ ] 5.2 Update the remaining 9 Kotlin KDoc/comment references.
+- [ ] 5.3 Update the 18 README and `docs/` references.
+- [ ] 5.4 Update the two bare-`setup` docs passages that contain no `setup-profile` string:
+      `docs/getting-started/setup.md:33` and `docs/reference/commands.md:25`.
+- [ ] 5.5 Document `profile` and `profile show` in `docs/reference/commands.md`. Note the existing
+      unrelated `cassandra profile` group already documented there.
+- [ ] 5.6 Verify no live `setup-profile` or bare-`setup` reference remains outside
+      `openspec/archive/` and `openspec/changes/archive/`.
+
+## 6. Folded-in debt
+
+- [ ] 6.1 Delete the dead branch in `SetupProfile.maskValue()` (`SetupProfile.kt:357-362`) — the
+      `value.length == 1` case returns exactly what `else` returns.
+
+## 7. Verification
+
+- [ ] 7.1 `./gradlew ktlintFormat` then `./gradlew check` (JDK 21 — detekt 1.23.8 cannot run under
+      JDK 25).
+- [ ] 7.2 Run the command locally against a real profile: `profile`, `profile show`, a non-default
+      `EASY_DB_LAB_PROFILE`, and from a directory with no cluster workspace.

--- a/openspec/changes/issue-892/tasks.md
+++ b/openspec/changes/issue-892/tasks.md
@@ -44,7 +44,10 @@
       present-but-unreadable with the file path, no raw Jackson error).
 - [x] 3.4 Read profile identity from `context.profile` / `context.profileDir.absolutePath`; use
       `getUserConfig()` guarded by `isSetup()`; call `User.isTailscaleEnabled()` for the Tailscale
-      flag and `axonOpsKey.isNotEmpty()` for AxonOps.
+      flag and `User.isAxonOpsEnabled()` for AxonOps — both require BOTH credentials to be
+      non-blank, matching what `Up.kt:706` and `cassandra/Start.kt:78` require before enabling
+      each feature. (Amended after Seam 1: this task originally said `axonOpsKey.isNotEmpty()`,
+      which disagreed with both consumers. See `ac-coverage.md`'s Amendments section.)
 - [x] 3.5 Register `ProfileShow` in `di/CommandsModule.kt` — omission fails **silently** via
       `KoinCommandFactory`'s fallback.
 

--- a/openspec/changes/issue-892/tasks.md
+++ b/openspec/changes/issue-892/tasks.md
@@ -2,20 +2,20 @@
 
 ## 1. Close the `commands↔services` cycle
 
-- [ ] 1.1 Move the `PicoCommand` interface out of `commands/` to a kernel package in the main module
+- [x] 1.1 Move the `PicoCommand` interface out of `commands/` to a kernel package in the main module
       (not `core` — it imports `annotations.PreExecute`/`PostExecute`). `PicoBaseCommand` stays in
       `commands/`.
-- [ ] 1.2 Update the 5 `src/main` importers (`CommandLineParser.kt`, `commands/aws/Region.kt`,
+- [x] 1.2 Update the 5 `src/main` importers (`CommandLineParser.kt`, `commands/aws/Region.kt`,
       `commands/aws/S3Bucket.kt`, `mcp/McpToolRegistry.kt`, `services/CommandExecutor.kt`), the 3
       `src/test` importers (`TestModules.kt`, `mcp/McpAnnotationTest.kt`,
       `commands/cassandra/UseCassandraTest.kt`), and the 3 same-package files that gain an import
       (`commands/PicoBaseCommand.kt`, `commands/Commands.kt`, `commands/Ip.kt`).
-- [ ] 1.3 Add `services/ProfileSetupCommandProvider.kt` — a `fun interface` returning a
+- [x] 1.3 Add `services/ProfileSetupCommandProvider.kt` — a `fun interface` returning a
       `PicoCommand` — and bind it. Replace the direct `SetupProfile()` construction at
       `CommandExecutor.kt:231` with `profileSetupProvider.create()`.
-- [ ] 1.4 Add the constructor argument at the two direct `DefaultCommandExecutor(...)` construction
+- [x] 1.4 Add the constructor argument at the two direct `DefaultCommandExecutor(...)` construction
       sites in tests (`CommandExecutorTest.kt:86`, `StatusTest.kt:448`).
-- [ ] 1.5 Verify no file under `services/` references any type in `commands/`, by import **or**
+- [x] 1.5 Verify no file under `services/` references any type in `commands/`, by import **or**
       fully-qualified name.
 
 ## 2. Build the `profile` command group

--- a/openspec/changes/issue-892/tasks.md
+++ b/openspec/changes/issue-892/tasks.md
@@ -33,31 +33,31 @@
 
 ## 3. Implement `profile show`
 
-- [ ] 3.1 Add `commands/profile/ProfileShow.kt` — `@Command(name = "show")`, extends
+- [x] 3.1 Add `commands/profile/ProfileShow.kt` — `@Command(name = "show")`, extends
       `PicoBaseCommand`, **no requirement annotations**, never references `clusterState`.
       Class-level KDoc required.
-- [ ] 3.2 Implement `buildReport(profileName, profileDir, user: User?)` as a `companion object`
+- [x] 3.2 Implement `buildReport(profileName, profileDir, user: User?)` as a `companion object`
       function returning one multiline string, following `KitList.buildListText` /
       `KitInfo.buildInfoText`. It must **not** call any masking helper.
-- [ ] 3.3 Handle all three branches: configured; `settings.yaml` absent (not-configured message
+- [x] 3.3 Handle all three branches: configured; `settings.yaml` absent (not-configured message
       naming `easy-db-lab profile setup`); `settings.yaml` present but undeserializable (report
       present-but-unreadable with the file path, no raw Jackson error).
-- [ ] 3.4 Read profile identity from `context.profile` / `context.profileDir.absolutePath`; use
+- [x] 3.4 Read profile identity from `context.profile` / `context.profileDir.absolutePath`; use
       `getUserConfig()` guarded by `isSetup()`; call `User.isTailscaleEnabled()` for the Tailscale
       flag and `axonOpsKey.isNotEmpty()` for AxonOps.
-- [ ] 3.5 Register `ProfileShow` in `di/CommandsModule.kt` — omission fails **silently** via
+- [x] 3.5 Register `ProfileShow` in `di/CommandsModule.kt` — omission fails **silently** via
       `KoinCommandFactory`'s fallback.
 
 ## 4. Tests
 
-- [ ] 4.1 `buildReport` unit tests: all five settings present; each secret absent from output
+- [x] 4.1 `buildReport` unit tests: all five settings present; each secret absent from output
       (sentinel values); AxonOps `ENABLED`/`DISABLED`; Tailscale `ENABLED`/`DISABLED` including the
       blank-credential case; not-configured message; malformed-profile message.
-- [ ] 4.2 Lifecycle-level test class for what `buildReport` cannot observe: bare `profile` exits 0
+- [x] 4.2 Lifecycle-level test class for what `buildReport` cannot observe: bare `profile` exits 0
       and lists `show` and `setup`; `setup` and `setup-profile` no longer resolve at top level;
       `ProfileShow::class.annotations` carries no `RequireProfileSetup`; `ClusterStateManager.load()`
       is never called for `profile show`; `EASY_DB_LAB_PROFILE` resolution through `Context`.
-- [ ] 4.3 Confirm the existing `SetupProfileTest` and `SetupProfileIntegrationTest` still pass after
+- [x] 4.3 Confirm the existing `SetupProfileTest` and `SetupProfileIntegrationTest` still pass after
       the move.
 
 ## 5. Docs and strings

--- a/openspec/changes/issue-892/tasks.md
+++ b/openspec/changes/issue-892/tasks.md
@@ -20,16 +20,16 @@
 
 ## 2. Build the `profile` command group
 
-- [ ] 2.1 Add `commands/profile/Profile.kt` — a `Runnable` group, not a `PicoCommand`, so a bare
+- [x] 2.1 Add `commands/profile/Profile.kt` — a `Runnable` group, not a `PicoCommand`, so a bare
       invocation falls through to `CommandLine.RunLast()` and exits 0. Class-level KDoc required.
-- [ ] 2.2 Move `SetupProfile.kt` to `commands/profile/`, rename to `@Command(name = "setup")`, and
+- [x] 2.2 Move `SetupProfile.kt` to `commands/profile/`, rename to `@Command(name = "setup")`, and
       remove the `aliases = ["setup"]` entry.
-- [ ] 2.3 Register `Profile::class` in `CommandLineParser.kt` and remove `SetupProfile::class` from
+- [x] 2.3 Register `Profile::class` in `CommandLineParser.kt` and remove `SetupProfile::class` from
       the top-level list.
-- [ ] 2.4 Update `Repl.kt:61`'s `ShellCommands` entry — a second, hand-maintained copy of the
+- [x] 2.4 Update `Repl.kt:61`'s `ShellCommands` entry — a second, hand-maintained copy of the
       command tree. **No existing test catches this**; `ReplTest` asserts only on `status`,
       `cassandra`, `spark`, `cls`, and `cassandra stress`.
-- [ ] 2.5 Update the Koin binding in `di/CommandsModule.kt` for `SetupProfile`'s new package.
+- [x] 2.5 Update the Koin binding in `di/CommandsModule.kt` for `SetupProfile`'s new package.
 
 ## 3. Implement `profile show`
 

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/commands/profile/SetupProfileIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/commands/profile/SetupProfileIntegrationTest.kt
@@ -1,4 +1,4 @@
-package com.rustyrazorblade.easydblab.commands
+package com.rustyrazorblade.easydblab.commands.profile
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
 import com.rustyrazorblade.easydblab.Prompter

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
@@ -13,7 +13,6 @@ import com.rustyrazorblade.easydblab.commands.Down
 import com.rustyrazorblade.easydblab.commands.Hosts
 import com.rustyrazorblade.easydblab.commands.Init
 import com.rustyrazorblade.easydblab.commands.Ip
-import com.rustyrazorblade.easydblab.commands.PicoCommand
 import com.rustyrazorblade.easydblab.commands.PruneAMIs
 import com.rustyrazorblade.easydblab.commands.Repl
 import com.rustyrazorblade.easydblab.commands.Server
@@ -42,6 +41,7 @@ import com.rustyrazorblade.easydblab.configuration.UserConfigProvider
 import com.rustyrazorblade.easydblab.di.KoinCommandFactory
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.events.EventBus
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import com.rustyrazorblade.easydblab.services.CommandExecutor
 import com.rustyrazorblade.easydblab.services.DefaultCommandExecutor
 import com.rustyrazorblade.easydblab.services.InstallTemplateResolver

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
@@ -124,8 +124,13 @@ class EasyDBLabCommand : Runnable {
 class CommandLineParser : KoinComponent {
     private val eventBus: EventBus by inject()
 
-    /** The main PicoCLI CommandLine instance with all subcommands registered. */
-    private val commandLine: CommandLine =
+    /**
+     * The main PicoCLI CommandLine instance with all subcommands registered.
+     *
+     * `internal` rather than private so a test can inspect the registered tree directly. Help
+     * output alone cannot tell a static command group from a kit runner that shadowed its name.
+     */
+    internal val commandLine: CommandLine =
         CommandLine(EasyDBLabCommand::class.java, KoinCommandFactory()).apply {
             // Set exception handler to ensure non-zero exit code on exceptions
             executionExceptionHandler =

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
@@ -17,7 +17,6 @@ import com.rustyrazorblade.easydblab.commands.PruneAMIs
 import com.rustyrazorblade.easydblab.commands.Repl
 import com.rustyrazorblade.easydblab.commands.Server
 import com.rustyrazorblade.easydblab.commands.SetupInstance
-import com.rustyrazorblade.easydblab.commands.SetupProfile
 import com.rustyrazorblade.easydblab.commands.ShowIamPolicies
 import com.rustyrazorblade.easydblab.commands.Status
 import com.rustyrazorblade.easydblab.commands.Up
@@ -34,6 +33,7 @@ import com.rustyrazorblade.easydblab.commands.logs.Logs
 import com.rustyrazorblade.easydblab.commands.metrics.Metrics
 import com.rustyrazorblade.easydblab.commands.opensearch.OpenSearch
 import com.rustyrazorblade.easydblab.commands.platform.Platform
+import com.rustyrazorblade.easydblab.commands.profile.Profile
 import com.rustyrazorblade.easydblab.commands.spark.Spark
 import com.rustyrazorblade.easydblab.commands.tailscale.Tailscale
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
@@ -88,7 +88,6 @@ import kotlin.system.exitProcess
         Init::class,
         SetupInstance::class,
         Up::class,
-        SetupProfile::class,
         Repl::class,
         Server::class,
         // Parent command groups
@@ -102,6 +101,7 @@ import kotlin.system.exitProcess
         Tailscale::class,
         Platform::class,
         Kit::class,
+        Profile::class,
         Cleanup::class,
     ],
 )

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
@@ -142,7 +142,7 @@ object Constants {
         const val S3_BUCKET = "EASY_DB_LAB_S3_BUCKET"
 
         // When truthy, AMI builds leave the instance running on failure (packer -on-error=abort),
-        // regardless of how the build was invoked (e.g. via setup-profile, which has no flag).
+        // regardless of how the build was invoked (e.g. via profile setup, which has no flag).
         const val BUILD_KEEP_ON_FAILURE = "EASY_DB_LAB_BUILD_KEEP_ON_FAILURE"
     }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
@@ -184,6 +184,9 @@ object Constants {
     object ConfigPaths {
         // Local config files
         const val CASSANDRA_PATCH_FILE = "cassandra.patch.yaml"
+
+        // Per-profile user settings, written under the active profile directory
+        const val PROFILE_SETTINGS_FILE = "settings.yaml"
     }
 
     // K3s configuration

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/CLAUDE.md
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/CLAUDE.md
@@ -42,11 +42,14 @@ class MyCommand : PicoBaseCommand(context) {
 
 ## Package Organization
 
+The `PicoCommand` interface itself lives in `kernel/`, not here. `services/CommandExecutor` needs
+it, and keeping it in `commands/` made `services` depend on `commands` while `commands` already
+depended on `services`. `PicoBaseCommand` stays in this package.
+
 ```
 commands/
 ├── CLAUDE.md              # This file
 ├── PicoBaseCommand.kt     # Base class for all commands
-├── PicoCommand.kt         # Interface for commands
 ├── cassandra/             # Cassandra-related commands
 │   ├── Cassandra.kt       # Parent command group
 │   ├── stress/            # Stress testing subcommands
@@ -70,6 +73,7 @@ commands/
 ├── metrics/               # Metrics import/listing commands
 ├── opensearch/            # OpenSearch commands
 ├── platform/              # Platform substrate commands (platform create-pvs, platform info)
+├── profile/               # Profile inspection and setup (profile show, profile setup)
 ├── spark/                 # Spark commands
 ├── tailscale/             # Tailscale VPN commands
 ├── mixins/                # Reusable PicoCLI mixins

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Clean.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Clean.kt
@@ -4,6 +4,7 @@ import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.events.EventBus
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import picocli.CommandLine.Command

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Commands.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Commands.kt
@@ -1,5 +1,6 @@
 package com.rustyrazorblade.easydblab.commands
 
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import org.koin.core.component.KoinComponent
 import picocli.CommandLine
 import picocli.CommandLine.Command

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Hosts.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Hosts.kt
@@ -8,6 +8,7 @@ import com.rustyrazorblade.easydblab.configuration.Host
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.events.EventBus
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import picocli.CommandLine.Command

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Ip.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Ip.kt
@@ -4,6 +4,7 @@ import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import picocli.CommandLine.Command

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/PicoBaseCommand.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/PicoBaseCommand.kt
@@ -4,6 +4,7 @@ import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.events.EventBus
 import com.rustyrazorblade.easydblab.events.EventContext
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Repl.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Repl.kt
@@ -8,6 +8,7 @@ import com.rustyrazorblade.easydblab.commands.opensearch.OpenSearch
 import com.rustyrazorblade.easydblab.commands.spark.Spark
 import com.rustyrazorblade.easydblab.di.KoinCommandFactory
 import com.rustyrazorblade.easydblab.events.Event
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import com.rustyrazorblade.easydblab.services.CommandExecutor
 import com.rustyrazorblade.easydblab.services.DefaultCommandExecutor
 import com.rustyrazorblade.easydblab.services.ResourceManager

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Repl.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Repl.kt
@@ -5,6 +5,7 @@ import com.rustyrazorblade.easydblab.commands.aws.Aws
 import com.rustyrazorblade.easydblab.commands.cassandra.Cassandra
 import com.rustyrazorblade.easydblab.commands.exec.Exec
 import com.rustyrazorblade.easydblab.commands.opensearch.OpenSearch
+import com.rustyrazorblade.easydblab.commands.profile.Profile
 import com.rustyrazorblade.easydblab.commands.spark.Spark
 import com.rustyrazorblade.easydblab.di.KoinCommandFactory
 import com.rustyrazorblade.easydblab.events.Event
@@ -60,12 +61,12 @@ import java.util.function.Supplier
         Init::class,
         SetupInstance::class,
         Up::class,
-        SetupProfile::class,
         // Parent command groups
         Spark::class,
         Cassandra::class,
         OpenSearch::class,
         Aws::class,
+        Profile::class,
     ],
 )
 class ShellCommands : Runnable {

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Status.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Status.kt
@@ -11,6 +11,7 @@ import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.events.EventBus
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import com.rustyrazorblade.easydblab.kubernetes.KubernetesJob
 import com.rustyrazorblade.easydblab.kubernetes.getLocalKubeconfigPath
 import com.rustyrazorblade.easydblab.providers.aws.InstanceDetails

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
@@ -241,7 +241,7 @@ class Up(
 
     /**
      * Configures the account-level S3 bucket and per-cluster data bucket.
-     * Uses the bucket name from the user profile (set during setup-profile).
+     * Uses the bucket name from the user profile (set during profile setup).
      * Applies bucket policy for IAM role access.
      * Creates a per-cluster data bucket for ClickHouse data and CloudWatch metrics.
      */

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
@@ -703,7 +703,7 @@ class Up(
             startProxyIfNeeded()
             startK3sOnAllNodes()
 
-            if (userConfig.axonOpsKey.isNotBlank() && userConfig.axonOpsOrg.isNotBlank()) {
+            if (userConfig.isAxonOpsEnabled()) {
                 eventBus.emit(Event.Provision.AxonOpsSetup(userConfig.axonOpsOrg))
                 runNestedCommand { ConfigureAxonOps() }
             }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
@@ -18,6 +18,7 @@ import com.rustyrazorblade.easydblab.configuration.InitConfig
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.events.Event
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import com.rustyrazorblade.easydblab.network.CidrBlock
 import com.rustyrazorblade.easydblab.network.TcpReachabilityProbe
 import com.rustyrazorblade.easydblab.providers.aws.DiscoveredInstance

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Version.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Version.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.commands
 
 import com.rustyrazorblade.easydblab.Context
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import picocli.CommandLine.Command

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/aws/Region.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/aws/Region.kt
@@ -2,8 +2,8 @@ package com.rustyrazorblade.easydblab.commands.aws
 
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
-import com.rustyrazorblade.easydblab.commands.PicoCommand
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import picocli.CommandLine.Command

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/aws/S3Bucket.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/aws/S3Bucket.kt
@@ -2,8 +2,8 @@ package com.rustyrazorblade.easydblab.commands.aws
 
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
-import com.rustyrazorblade.easydblab.commands.PicoCommand
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import picocli.CommandLine.Command

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Start.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Start.kt
@@ -75,7 +75,7 @@ class Start : PicoBaseCommand() {
         }
 
         // Start axon-agent on Cassandra nodes if configured
-        if (userConfig.axonOpsOrg.isNotBlank() && userConfig.axonOpsKey.isNotBlank()) {
+        if (userConfig.isAxonOpsEnabled()) {
             eventBus.emit(Event.Cassandra.AxonAgentStarting)
             hostOperationsService.withHosts(clusterState.hosts, ServerType.Cassandra, "", parallel = true) { host ->
                 remoteOps.executeRemotely(host.toHost(), "sudo systemctl start axon-agent")

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/profile/Profile.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/profile/Profile.kt
@@ -22,6 +22,7 @@ import picocli.CommandLine.Spec
     description = ["Profile management: show the active profile or set one up"],
     mixinStandardHelpOptions = true,
     subcommands = [
+        ProfileShow::class,
         SetupProfile::class,
     ],
 )

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/profile/Profile.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/profile/Profile.kt
@@ -1,0 +1,35 @@
+package com.rustyrazorblade.easydblab.commands.profile
+
+import picocli.CommandLine.Command
+import picocli.CommandLine.Model.CommandSpec
+import picocli.CommandLine.Spec
+
+/**
+ * Top-level parent command for profile inspection and setup.
+ *
+ * Subcommands:
+ * - `profile show`  — report the active profile's name, directory, and settings
+ * - `profile setup` — run the interactive profile setup workflow
+ *
+ * Deliberately a [Runnable] rather than a
+ * [com.rustyrazorblade.easydblab.kernel.PicoCommand]: the execution strategy in
+ * [com.rustyrazorblade.easydblab.CommandLineParser] routes only `PicoCommand`s through
+ * `CommandExecutor`, so a group that is merely `Runnable` falls through to picocli's `RunLast`,
+ * which prints usage and exits 0 when no subcommand is given.
+ */
+@Command(
+    name = "profile",
+    description = ["Profile management: show the active profile or set one up"],
+    mixinStandardHelpOptions = true,
+    subcommands = [
+        SetupProfile::class,
+    ],
+)
+class Profile : Runnable {
+    @Spec
+    lateinit var spec: CommandSpec
+
+    override fun run() {
+        spec.commandLine().usage(spec.commandLine().out)
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/profile/ProfileShow.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/profile/ProfileShow.kt
@@ -60,7 +60,7 @@ class ProfileShow : PicoBaseCommand() {
                 try {
                     ProfileSettings.Loaded(userConfigProvider.getUserConfig())
                 } catch (e: Exception) {
-                    log.debug(e) { "Could not deserialize settings for profile ${context.profile}" }
+                    log.warn { "Could not deserialize settings for profile ${context.profile}: ${e::class.simpleName}" }
                     ProfileSettings.Unreadable
                 }
             }
@@ -118,7 +118,7 @@ class ProfileShow : PicoBaseCommand() {
             |  awsProfile  ${orNotSet(user.awsProfile)}
             |  s3Bucket    ${orNotSet(user.s3Bucket)}
             |
-            |  AxonOps     ${flag(user.axonOpsKey.isNotEmpty())}
+            |  AxonOps     ${flag(user.isAxonOpsEnabled())}
             |  Tailscale   ${flag(user.isTailscaleEnabled())}
             """.trimMargin()
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/profile/ProfileShow.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/profile/ProfileShow.kt
@@ -1,0 +1,129 @@
+package com.rustyrazorblade.easydblab.commands.profile
+
+import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
+import com.rustyrazorblade.easydblab.configuration.User
+import com.rustyrazorblade.easydblab.configuration.UserConfigProvider
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.koin.core.component.inject
+import picocli.CommandLine.Command
+
+/**
+ * The three states the active profile's `settings.yaml` can be in.
+ *
+ * A sum type rather than a nullable [User], because "absent" and "present but undeserializable"
+ * produce different reports and a `User?` cannot tell them apart. [User] has six constructor
+ * parameters with no defaults, so a hand-edited or truncated file throws during deserialization
+ * instead of yielding a partial object.
+ */
+sealed interface ProfileSettings {
+    /** `settings.yaml` exists and deserialized into a [User]. */
+    data class Loaded(
+        val user: User,
+    ) : ProfileSettings
+
+    /** `settings.yaml` does not exist: the profile has never been set up. */
+    data object Missing : ProfileSettings
+
+    /** `settings.yaml` exists but could not be deserialized. */
+    data object Unreadable : ProfileSettings
+}
+
+/**
+ * Reports the active profile: its name, its directory, and the settings it holds.
+ *
+ * Carries no requirement annotation on purpose. `CommandExecutor.checkRequirements()` responds to
+ * `@RequireProfileSetup` by running profile setup and exiting, which would replace this command's
+ * report with an interactive prompt — the opposite of what it exists to do. Adding one "for
+ * consistency" breaks the command.
+ *
+ * It also never touches `clusterState`. `PicoBaseCommand` exposes that as `by lazy`, so leaving it
+ * unnamed is what lets the command run in any working directory, with no cluster workspace present.
+ *
+ * Uses `println()` directly: this is a read-only display command, so nothing happened that an
+ * external system would need to hear about.
+ */
+@Command(
+    name = "show",
+    description = ["Show the active profile's name, directory, and settings"],
+    mixinStandardHelpOptions = true,
+)
+class ProfileShow : PicoBaseCommand() {
+    private val userConfigProvider: UserConfigProvider by inject()
+
+    @Suppress("TooGenericExceptionCaught")
+    override fun execute() {
+        val settings =
+            if (!userConfigProvider.isSetup()) {
+                ProfileSettings.Missing
+            } else {
+                try {
+                    ProfileSettings.Loaded(userConfigProvider.getUserConfig())
+                } catch (e: Exception) {
+                    log.debug(e) { "Could not deserialize settings for profile ${context.profile}" }
+                    ProfileSettings.Unreadable
+                }
+            }
+
+        println(buildReport(context.profile, context.profileDir.absolutePath, settings))
+    }
+
+    companion object {
+        private val log = KotlinLogging.logger {}
+
+        private const val SETUP_HINT = "Run: easy-db-lab profile setup"
+
+        /**
+         * Renders the whole report as one string.
+         *
+         * Deliberately does not call any masking helper. `SetupProfile.maskValue()` renders a
+         * secret as its first character followed by asterisks, which is still a leak; secrets are
+         * reported here only as `ENABLED` / `DISABLED` flags.
+         */
+        fun buildReport(
+            profileName: String,
+            profileDir: String,
+            settings: ProfileSettings,
+        ): String {
+            val header =
+                """
+                |Profile:   $profileName
+                |Directory: $profileDir
+                """.trimMargin()
+
+            val body =
+                when (settings) {
+                    is ProfileSettings.Loaded -> settingsBlock(settings.user)
+                    ProfileSettings.Missing ->
+                        """
+                        |This profile is not configured.
+                        |$SETUP_HINT
+                        """.trimMargin()
+                    ProfileSettings.Unreadable ->
+                        """
+                        |This profile is configured but could not be read:
+                        |  $profileDir/${Constants.ConfigPaths.PROFILE_SETTINGS_FILE}
+                        |$SETUP_HINT
+                        """.trimMargin()
+                }
+
+            return "$header\n\n$body"
+        }
+
+        private fun settingsBlock(user: User): String =
+            """
+            |  email       ${orNotSet(user.email)}
+            |  region      ${orNotSet(user.region)}
+            |  keyName     ${orNotSet(user.keyName)}
+            |  awsProfile  ${orNotSet(user.awsProfile)}
+            |  s3Bucket    ${orNotSet(user.s3Bucket)}
+            |
+            |  AxonOps     ${flag(user.axonOpsKey.isNotEmpty())}
+            |  Tailscale   ${flag(user.isTailscaleEnabled())}
+            """.trimMargin()
+
+        private fun flag(enabled: Boolean): String = if (enabled) "ENABLED" else "DISABLED"
+
+        private fun orNotSet(value: String): String = value.ifBlank { "(not set)" }
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/profile/SetupProfile.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/profile/SetupProfile.kt
@@ -359,7 +359,6 @@ class SetupProfile : PicoBaseCommand() {
     private fun maskValue(value: String): String =
         when {
             value.isEmpty() -> "(not set)"
-            value.length == 1 -> "${value[0]}****"
             else -> "${value[0]}****"
         }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/profile/SetupProfile.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/profile/SetupProfile.kt
@@ -1,7 +1,10 @@
-package com.rustyrazorblade.easydblab.commands
+package com.rustyrazorblade.easydblab.commands.profile
 
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.Prompter
+import com.rustyrazorblade.easydblab.commands.BuildImage
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
+import com.rustyrazorblade.easydblab.commands.SetupProfileException
 import com.rustyrazorblade.easydblab.configuration.Arch
 import com.rustyrazorblade.easydblab.configuration.Policy
 import com.rustyrazorblade.easydblab.configuration.User
@@ -30,8 +33,7 @@ import software.amazon.awssdk.regions.Region
  * 5. Ensure AWS resources exist (key pair, IAM roles, S3 bucket, VPC, AMI)
  */
 @Command(
-    name = "setup-profile",
-    aliases = ["setup"],
+    name = "setup",
     description = ["Set up user profile interactively"],
 )
 class SetupProfile : PicoBaseCommand() {

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/tailscale/Tailscale.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/tailscale/Tailscale.kt
@@ -16,12 +16,12 @@ import picocli.CommandLine.Spec
  * - status: Show Tailscale connection status
  *
  * Prerequisites:
- * - Tailscale OAuth credentials configured via setup-profile or CLI args
+ * - Tailscale OAuth credentials configured via profile setup or CLI args
  * - A running cluster with a control node
  *
  * Usage:
  * ```
- * # Start Tailscale (uses credentials from setup-profile)
+ * # Start Tailscale (uses credentials from profile setup)
  * easy-db-lab tailscale start
  *
  * # Start with explicit credentials

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/tailscale/TailscaleStart.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/tailscale/TailscaleStart.kt
@@ -27,7 +27,7 @@ import picocli.CommandLine.Option
  *
  * OAuth credentials can be provided via:
  * - CLI arguments (--client-id, --client-secret)
- * - User configuration (setup-profile)
+ * - User configuration (profile setup)
  */
 @McpCommand
 @RequireProfileSetup
@@ -88,7 +88,7 @@ class TailscaleStart : PicoBaseCommand() {
 
                 Please provide credentials via:
                 1. CLI arguments: --client-id and --client-secret
-                2. Setup profile: easy-db-lab setup-profile
+                2. Setup profile: easy-db-lab profile setup
 
                 To get OAuth credentials:
                 1. Go to https://login.tailscale.com/admin/settings/oauth

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/User.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/User.kt
@@ -51,6 +51,12 @@ data class User(
      */
     fun isTailscaleEnabled(): Boolean = tailscaleClientId.isNotBlank() && tailscaleClientSecret.isNotBlank()
 
+    /**
+     * Returns true when both AxonOps credentials are configured in this profile.
+     * Both are required: [Up] and [cassandra.Start] skip AxonOps unless the org and the key are set.
+     */
+    fun isAxonOpsEnabled(): Boolean = axonOpsOrg.isNotBlank() && axonOpsKey.isNotBlank()
+
     companion object {
         val log = KotlinLogging.logger {}
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/UserConfigProvider.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/UserConfigProvider.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.rustyrazorblade.easydblab.Constants
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.File
 
@@ -20,7 +21,7 @@ class UserConfigProvider(
     }
 
     private val yaml: ObjectMapper = ObjectMapper(YAMLFactory()).registerKotlinModule()
-    private val userConfigFile = File(profileDir, "settings.yaml")
+    private val userConfigFile = File(profileDir, Constants.ConfigPaths.PROFILE_SETTINGS_FILE)
 
     /**
      * SSH key path is always ${profileDir}/secret.pem

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/UserConfigProvider.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/UserConfigProvider.kt
@@ -77,7 +77,7 @@ class UserConfigProvider(
         if (!userConfigFile.exists()) {
             error(
                 "User configuration file not found: $userConfigFile\n" +
-                    "Please run 'easy-db-lab setup-profile' to create your profile.",
+                    "Please run 'easy-db-lab profile setup' to create your profile.",
             )
         }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/containers/Packer.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/containers/Packer.kt
@@ -83,7 +83,7 @@ class Packer(
             )
 
         require(user.keyName.isNotEmpty() && secretKeyFile.exists()) {
-            "AWS keypair not configured (key: '${user.keyName}', file: ${secretKeyFile.absolutePath}). Run setup-profile first."
+            "AWS keypair not configured (key: '${user.keyName}', file: ${secretKeyFile.absolutePath}). Run profile setup first."
         }
 
         command.addAll(
@@ -133,7 +133,7 @@ class Packer(
 
     /**
      * Whether the EASY_DB_LAB_BUILD_KEEP_ON_FAILURE env var is set to a truthy value. Lets builds
-     * triggered indirectly (e.g. by setup-profile) keep the instance up on failure without a flag.
+     * triggered indirectly (e.g. by profile setup) keep the instance up on failure without a flag.
      */
     private fun keepOnErrorFromEnv(): Boolean =
         System.getenv(Constants.Environment.BUILD_KEEP_ON_FAILURE)?.lowercase() in setOf("1", "true", "yes", "on")

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/di/CommandsModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/di/CommandsModule.kt
@@ -14,7 +14,6 @@ import com.rustyrazorblade.easydblab.commands.PruneAMIs
 import com.rustyrazorblade.easydblab.commands.Repl
 import com.rustyrazorblade.easydblab.commands.Server
 import com.rustyrazorblade.easydblab.commands.SetupInstance
-import com.rustyrazorblade.easydblab.commands.SetupProfile
 import com.rustyrazorblade.easydblab.commands.ShowIamPolicies
 import com.rustyrazorblade.easydblab.commands.Status
 import com.rustyrazorblade.easydblab.commands.Up
@@ -48,6 +47,7 @@ import com.rustyrazorblade.easydblab.commands.grafana.GrafanaUpdateConfig
 import com.rustyrazorblade.easydblab.commands.opensearch.OpenSearchStart
 import com.rustyrazorblade.easydblab.commands.opensearch.OpenSearchStatus
 import com.rustyrazorblade.easydblab.commands.opensearch.OpenSearchStop
+import com.rustyrazorblade.easydblab.commands.profile.SetupProfile
 import com.rustyrazorblade.easydblab.commands.spark.SparkJobs
 import com.rustyrazorblade.easydblab.commands.spark.SparkLogs
 import com.rustyrazorblade.easydblab.commands.spark.SparkStatus

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/di/CommandsModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/di/CommandsModule.kt
@@ -52,6 +52,7 @@ import com.rustyrazorblade.easydblab.commands.spark.SparkJobs
 import com.rustyrazorblade.easydblab.commands.spark.SparkLogs
 import com.rustyrazorblade.easydblab.commands.spark.SparkStatus
 import com.rustyrazorblade.easydblab.commands.spark.SparkSubmit
+import com.rustyrazorblade.easydblab.services.ProfileSetupCommandProvider
 import org.koin.dsl.module
 
 /**
@@ -127,4 +128,7 @@ val commandsModule =
         factory { SparkLogs() }
         factory { SparkStatus() }
         factory { SparkSubmit() }
+
+        // Supplies the profile setup command to CommandExecutor, which must not name a command class
+        single<ProfileSetupCommandProvider> { ProfileSetupCommandProvider { get<SetupProfile>() } }
     }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/di/CommandsModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/di/CommandsModule.kt
@@ -47,6 +47,7 @@ import com.rustyrazorblade.easydblab.commands.grafana.GrafanaUpdateConfig
 import com.rustyrazorblade.easydblab.commands.opensearch.OpenSearchStart
 import com.rustyrazorblade.easydblab.commands.opensearch.OpenSearchStatus
 import com.rustyrazorblade.easydblab.commands.opensearch.OpenSearchStop
+import com.rustyrazorblade.easydblab.commands.profile.ProfileShow
 import com.rustyrazorblade.easydblab.commands.profile.SetupProfile
 import com.rustyrazorblade.easydblab.commands.spark.SparkJobs
 import com.rustyrazorblade.easydblab.commands.spark.SparkLogs
@@ -78,6 +79,7 @@ val commandsModule =
         factory { Repl() }
         factory { Server() }
         factory { SetupInstance() }
+        factory { ProfileShow() }
         factory { SetupProfile() }
         factory { ShowIamPolicies() }
         factory { Status() }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
@@ -2878,7 +2878,7 @@ sealed interface Event {
                 |  1. Remove incorrect profile: rm -rf ~/.easy_cass_lab/profiles/<PROFILE>
                 |     (Replace <PROFILE> with your profile name, usually 'default')
                 |
-                |  2. Run: easy-db-lab setup-profile
+                |  2. Run: easy-db-lab profile setup
                 |
                 |  3. When prompted, enter your AWS access key and secret key
                 |
@@ -3629,7 +3629,7 @@ sealed interface Event {
         @SerialName("Command.ProfileNotConfigured")
         data object ProfileNotConfigured : Command {
             override fun toDisplayString(): String =
-                "\nProfile not configured. Please run 'easy-db-lab setup-profile' to configure your environment.\n"
+                "\nProfile not configured. Please run 'easy-db-lab profile setup' to configure your environment.\n"
         }
     }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/kernel/PicoCommand.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/kernel/PicoCommand.kt
@@ -1,4 +1,4 @@
-package com.rustyrazorblade.easydblab.commands
+package com.rustyrazorblade.easydblab.kernel
 
 import com.rustyrazorblade.easydblab.annotations.PostExecute
 import com.rustyrazorblade.easydblab.annotations.PreExecute

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/kernel/PicoCommand.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/kernel/PicoCommand.kt
@@ -14,6 +14,12 @@ import kotlin.reflect.jvm.isAccessible
  * Implements Callable<Int> for PicoCLI compatibility.
  * Executes methods annotated with @PreExecute before the main execute() method,
  * and methods annotated with @PostExecute afterward.
+ *
+ * Lives in `kernel/`, not `commands/`, on purpose. `services/CommandExecutor` dispatches on this
+ * interface, and `commands/` already depends on `services/`; declaring it in `commands/` therefore
+ * made the two packages depend on each other. `kernel/` holds the small set of types both layers
+ * share, so neither has to name the other. Moving this file back into `commands/` restores the
+ * cycle. `PicoBaseCommand` is not shared that way and stays in `commands/`.
  */
 interface PicoCommand : Callable<Int> {
     /**

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/McpToolRegistry.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/McpToolRegistry.kt
@@ -1,9 +1,9 @@
 package com.rustyrazorblade.easydblab.mcp
 
 import com.rustyrazorblade.easydblab.annotations.McpCommand
-import com.rustyrazorblade.easydblab.commands.PicoCommand
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.events.EventBus
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import com.rustyrazorblade.easydblab.services.CommandExecutor
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.serialization.json.JsonArray

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/AWS.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/AWS.kt
@@ -257,7 +257,7 @@ class AWS(
                 log.error(e) { "Failed to apply S3 bucket policy: $bucketName - ${e.message}" }
                 throw IllegalStateException(
                     "Could not apply the S3 bucket policy because the easy-db-lab IAM roles are not yet " +
-                        "visible to S3 (IAM propagation delay). Wait a moment and re-run setup-profile.",
+                        "visible to S3 (IAM propagation delay). Wait a moment and re-run profile setup.",
                     e,
                 )
             }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/CommandExecutor.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/CommandExecutor.kt
@@ -7,12 +7,11 @@ import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.annotations.RequireSSHKey
 import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.annotations.TriggerBackup
-import com.rustyrazorblade.easydblab.commands.PicoCommand
-import com.rustyrazorblade.easydblab.commands.SetupProfile
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.UserConfigProvider
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.events.EventBus
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import com.rustyrazorblade.easydblab.providers.docker.DockerClientProvider
 import com.rustyrazorblade.easydblab.proxy.ProxyAvailability
 import com.rustyrazorblade.easydblab.proxy.SocksProxyService
@@ -91,6 +90,7 @@ class DefaultCommandExecutor(
     private val eventBus: EventBus,
     private val socksProxyService: SocksProxyService,
     private val proxyAvailability: ProxyAvailability,
+    private val profileSetupProvider: ProfileSetupCommandProvider,
 ) : CommandExecutor,
     KoinComponent {
     // Lazy injection - only resolves when first accessed (defers AWS dependency chain)
@@ -228,7 +228,7 @@ class DefaultCommandExecutor(
         if (annotations.any { it is RequireProfileSetup }) {
             if (!requirementCheckDeps.userConfigProvider.isSetup()) {
                 // Run setup command with full lifecycle
-                executeWithLifecycle(SetupProfile())
+                executeWithLifecycle(profileSetupProvider.create())
 
                 // Show message and exit
                 eventBus.emit(Event.Command.RetryInstruction)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ProfileSetupCommandProvider.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ProfileSetupCommandProvider.kt
@@ -1,0 +1,21 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
+
+/**
+ * Supplies the interactive profile setup command to [DefaultCommandExecutor].
+ *
+ * `checkRequirements()` must run profile setup when a command carries `@RequireProfileSetup` and
+ * no profile exists. Naming the concrete command class there would make the `services` package
+ * depend on the `commands` package, which already depends on `services` — a cycle. This provider
+ * is the abstraction that breaks it: `services` owns the interface, and the DI module in `di`
+ * binds it to the concrete command.
+ *
+ * A provider rather than a runner: a runner would call back into [CommandExecutor.execute],
+ * which creates a construction cycle in Koin. Producing the command and letting the executor run
+ * it keeps the wiring one-directional.
+ */
+fun interface ProfileSetupCommandProvider {
+    /** Creates a fresh profile setup command instance. */
+    fun create(): PicoCommand
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
@@ -176,7 +176,7 @@ val servicesModule =
 
         // Command executor for scheduling and executing commands with full lifecycle
         // Note: BackupRestoreService is lazily injected in DefaultCommandExecutor to avoid
-        // triggering the AWS dependency chain during setup-profile (when settings.yaml doesn't exist yet)
+        // triggering the AWS dependency chain during profile setup (when settings.yaml doesn't exist yet)
         single<CommandExecutor> {
             DefaultCommandExecutor(
                 get<Context>(),

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
@@ -189,6 +189,7 @@ val servicesModule =
                 get<EventBus>(),
                 get<SocksProxyService>(),
                 get<ProxyAvailability>(),
+                get<ProfileSetupCommandProvider>(),
             )
         }
     }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/AwsS3BucketService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/AwsS3BucketService.kt
@@ -39,7 +39,7 @@ class AwsS3BucketService(
      *
      * This lets profiles that predate (or never completed) bucket setup migrate automatically —
      * `up` and the AMI build path call this so the bucket (and the S3 build cache it backs) come
-     * online without re-running `setup-profile`.
+     * online without re-running `profile setup`.
      */
     fun ensureAccountBucket(user: User): String {
         if (user.s3Bucket.isNotBlank()) {

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/CommandLineParserTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/CommandLineParserTest.kt
@@ -1,5 +1,6 @@
 package com.rustyrazorblade.easydblab
 
+import com.rustyrazorblade.easydblab.commands.profile.Profile
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.services.DefaultKitCommandScanner
 import com.rustyrazorblade.easydblab.services.InstallTemplateResolver
@@ -70,5 +71,21 @@ class CommandLineParserTest : BaseKoinTest() {
         val output = stdout.toString()
         assertThat(output).contains("clickhouse")
         assertThat(output).doesNotContain("trunk")
+    }
+
+    @Test
+    fun `a workspace directory named profile does not shadow the profile command group`() {
+        // registerDynamicKitSubcommands() drops a discovered kit whose name collides with a static
+        // top-level command. Without that guard a directory named "profile" replaces the command
+        // group with a kit runner, and `profile show` stops resolving.
+        val kitDir = File(context.workingDirectory, "profile")
+        kitDir.mkdirs()
+        File(kitDir, Constants.Kit.CONFIG_FILE).writeText("name: profile\n")
+
+        val commandLine = CommandLineParser().commandLine
+        val profileGroup = commandLine.subcommands.getValue("profile")
+
+        assertThat(profileGroup.commandSpec.userObject()).isInstanceOf(Profile::class.java)
+        assertThat(profileGroup.subcommands.keys).contains("show", "setup")
     }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/TestModules.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/TestModules.kt
@@ -1,6 +1,5 @@
 package com.rustyrazorblade.easydblab
 
-import com.rustyrazorblade.easydblab.commands.PicoCommand
 import com.rustyrazorblade.easydblab.configuration.Host
 import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.configuration.UserConfigProvider
@@ -9,6 +8,7 @@ import com.rustyrazorblade.easydblab.di.prompterModule
 import com.rustyrazorblade.easydblab.events.EventBus
 import com.rustyrazorblade.easydblab.events.EventEnvelope
 import com.rustyrazorblade.easydblab.events.EventListener
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
 import com.rustyrazorblade.easydblab.output.OutputHandler
 import com.rustyrazorblade.easydblab.providers.aws.AWS

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/PicoCommandLifecycleTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/PicoCommandLifecycleTest.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.commands
 
 import com.rustyrazorblade.easydblab.annotations.PostExecute
 import com.rustyrazorblade.easydblab.annotations.PreExecute
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/StatusTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/StatusTest.kt
@@ -26,6 +26,7 @@ import com.rustyrazorblade.easydblab.proxy.ProxyAvailability
 import com.rustyrazorblade.easydblab.proxy.SocksProxyService
 import com.rustyrazorblade.easydblab.services.CommandExecutor
 import com.rustyrazorblade.easydblab.services.DefaultCommandExecutor
+import com.rustyrazorblade.easydblab.services.ProfileSetupCommandProvider
 import com.rustyrazorblade.easydblab.services.RequirementCheckDeps
 import com.rustyrazorblade.easydblab.services.ResourceManager
 import com.rustyrazorblade.easydblab.services.StressJobService
@@ -457,6 +458,7 @@ class StatusTest : BaseKoinTest() {
                 eventBus = getKoin().get(),
                 socksProxyService = mockSocksProxyService,
                 proxyAvailability = proxyAvailability,
+                profileSetupProvider = ProfileSetupCommandProvider { error("profile setup must not run here") },
             )
 
         // When - status is run through the real executor, exactly as it would be from the CLI

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/UpTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/UpTest.kt
@@ -11,6 +11,7 @@ import com.rustyrazorblade.easydblab.configuration.Host
 import com.rustyrazorblade.easydblab.configuration.InitConfig
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.configuration.User
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import com.rustyrazorblade.easydblab.network.TcpReachabilityProbe
 import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
 import com.rustyrazorblade.easydblab.output.OutputHandler

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/UseCassandraTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/UseCassandraTest.kt
@@ -1,12 +1,12 @@
 package com.rustyrazorblade.easydblab.commands.cassandra
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
-import com.rustyrazorblade.easydblab.commands.PicoCommand
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.InitConfig
 import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
 import com.rustyrazorblade.easydblab.output.OutputHandler
 import com.rustyrazorblade.easydblab.services.CommandExecutor

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/profile/ProfileCommandGroupTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/profile/ProfileCommandGroupTest.kt
@@ -1,12 +1,29 @@
 package com.rustyrazorblade.easydblab.commands.profile
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.EasyDBLabCommand
+import com.rustyrazorblade.easydblab.annotations.RequireDocker
+import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequireSSHKey
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.configuration.User
+import com.rustyrazorblade.easydblab.configuration.UserConfigProvider
 import com.rustyrazorblade.easydblab.di.KoinCommandFactory
 import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
 import picocli.CommandLine
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.PrintStream
 import java.io.PrintWriter
 import java.io.StringWriter
 
@@ -14,12 +31,40 @@ import java.io.StringWriter
  * Lifecycle-level guards for the `profile` command group.
  *
  * `ProfileShow.buildReport` is a pure function of three plain values, so it cannot observe the
- * shape of the picocli tree or the annotations a command carries. Everything asserted here is
- * invisible at that surface and would stay green through exactly the regressions it guards
- * against.
+ * shape of the picocli tree, the annotations a command carries, or which collaborators the command
+ * lifecycle touched. Every assertion here is invisible at that surface and would stay green
+ * through exactly the regressions it guards against.
  */
 class ProfileCommandGroupTest : BaseKoinTest() {
+    private val stdout = ByteArrayOutputStream()
+    private val originalOut = System.out
+
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                // A real manager over a state.json that does not exist: any read of clusterState
+                // throws FileNotFoundException, which is precisely the regression being guarded.
+                single { ClusterStateManager(File(get<Context>().workingDirectory, "state.json")) }
+                // Rebuilt on resolution rather than at module construction, so a test can point the
+                // context at another profile first.
+                single { UserConfigProvider(get<Context>().profileDir) }
+            },
+        )
+
+    @BeforeEach
+    fun captureStdout() {
+        System.setOut(PrintStream(stdout))
+    }
+
+    @AfterEach
+    fun restoreStdout() {
+        System.setOut(originalOut)
+        stdout.reset()
+    }
+
     private fun rootCommandLine() = CommandLine(EasyDBLabCommand::class.java, KoinCommandFactory())
+
+    private fun settingsFile(profileDir: File) = File(profileDir, Constants.ConfigPaths.PROFILE_SETTINGS_FILE)
 
     @Test
     fun `profile group exposes show and setup`() {
@@ -40,14 +85,14 @@ class ProfileCommandGroupTest : BaseKoinTest() {
     @Test
     fun `bare profile prints usage listing its subcommands and exits zero`() {
         val commandLine = rootCommandLine()
-        val output = StringWriter()
-        commandLine.out = PrintWriter(output)
+        val usage = StringWriter()
+        commandLine.out = PrintWriter(usage)
 
         val exitCode = commandLine.execute("profile")
 
         assertThat(exitCode).isZero()
-        assertThat(output.toString()).contains("show")
-        assertThat(output.toString()).contains("setup")
+        assertThat(usage.toString()).contains("show")
+        assertThat(usage.toString()).contains("setup")
     }
 
     @Test
@@ -60,4 +105,72 @@ class ProfileCommandGroupTest : BaseKoinTest() {
         assertThat(profileGroup.commandSpec.userObject()).isNotInstanceOf(PicoCommand::class.java)
         assertThat(profileGroup.commandSpec.userObject()).isInstanceOf(Runnable::class.java)
     }
+
+    @Test
+    fun `ProfileShow carries no requirement annotation`() {
+        // @RequireProfileSetup would make checkRequirements() run interactive setup and exit,
+        // replacing the report the command exists to print. The other three would refuse to run
+        // outside a provisioned cluster.
+        val annotations = ProfileShow::class.annotations
+
+        assertThat(annotations.filterIsInstance<RequireProfileSetup>()).isEmpty()
+        assertThat(annotations.filterIsInstance<RequireSSHKey>()).isEmpty()
+        assertThat(annotations.filterIsInstance<RequireDocker>()).isEmpty()
+        assertThat(annotations.filterIsInstance<RequiresProxy>()).isEmpty()
+    }
+
+    @Test
+    fun `profile show reports without loading cluster state`() {
+        // The working directory holds no state.json, so ClusterStateManager.load() throws. Reaching
+        // the assertions proves the command never touched clusterState.
+        assertThat(File(context.workingDirectory, "state.json")).doesNotExist()
+
+        ProfileShow().execute()
+
+        assertThat(stdout.toString()).contains("Profile:")
+    }
+
+    @Test
+    fun `profile show reports the profile named by the context rather than the default`() {
+        // EASY_DB_LAB_PROFILE is resolved into Context.profile/profileDir at Context.kt:49-51;
+        // this is that value's path through the command.
+        context.profile = "staging"
+        context.profileDir = File(context.profilesDir, "staging").apply { mkdirs() }
+        context.yaml.writeValue(
+            settingsFile(context.profileDir),
+            userWith(email = "staging-user@example.com"),
+        )
+
+        getKoin().get<ProfileShow>().execute()
+
+        val output = stdout.toString()
+        assertThat(output).contains("staging")
+        assertThat(output).contains(context.profileDir.absolutePath)
+        assertThat(output).contains("staging-user@example.com")
+    }
+
+    @Test
+    fun `profile show reports a truncated settings file instead of throwing`() {
+        // User has six constructor parameters with no defaults, so a file missing one of them
+        // fails deserialization. The command must report that, not surface the Jackson error.
+        settingsFile(context.profileDir).writeText("email: partial@example.com\n")
+
+        assertThatCode { getKoin().get<ProfileShow>().execute() }.doesNotThrowAnyException()
+
+        val output = stdout.toString()
+        assertThat(output).contains("could not be read")
+        assertThat(output).contains("easy-db-lab profile setup")
+        assertThat(output).doesNotContain("Exception")
+        assertThat(output).doesNotContain("com.fasterxml.jackson")
+    }
+
+    private fun userWith(email: String) =
+        User(
+            email = email,
+            region = "eu-west-1",
+            keyName = "staging-key",
+            awsProfile = "staging-aws",
+            awsAccessKey = "",
+            awsSecret = "",
+        )
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/profile/ProfileCommandGroupTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/profile/ProfileCommandGroupTest.kt
@@ -1,0 +1,63 @@
+package com.rustyrazorblade.easydblab.commands.profile
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.EasyDBLabCommand
+import com.rustyrazorblade.easydblab.di.KoinCommandFactory
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import picocli.CommandLine
+import java.io.PrintWriter
+import java.io.StringWriter
+
+/**
+ * Lifecycle-level guards for the `profile` command group.
+ *
+ * `ProfileShow.buildReport` is a pure function of three plain values, so it cannot observe the
+ * shape of the picocli tree or the annotations a command carries. Everything asserted here is
+ * invisible at that surface and would stay green through exactly the regressions it guards
+ * against.
+ */
+class ProfileCommandGroupTest : BaseKoinTest() {
+    private fun rootCommandLine() = CommandLine(EasyDBLabCommand::class.java, KoinCommandFactory())
+
+    @Test
+    fun `profile group exposes show and setup`() {
+        val profileGroup = rootCommandLine().subcommands["profile"]
+
+        assertThat(profileGroup).isNotNull
+        assertThat(profileGroup!!.subcommands.keys).contains("show", "setup")
+    }
+
+    @Test
+    fun `former top-level setup names no longer resolve`() {
+        val topLevel = rootCommandLine().subcommands.keys
+
+        assertThat(topLevel).contains("profile")
+        assertThat(topLevel).doesNotContain("setup", "setup-profile")
+    }
+
+    @Test
+    fun `bare profile prints usage listing its subcommands and exits zero`() {
+        val commandLine = rootCommandLine()
+        val output = StringWriter()
+        commandLine.out = PrintWriter(output)
+
+        val exitCode = commandLine.execute("profile")
+
+        assertThat(exitCode).isZero()
+        assertThat(output.toString()).contains("show")
+        assertThat(output.toString()).contains("setup")
+    }
+
+    @Test
+    fun `profile group is not a PicoCommand so the executor never routes it`() {
+        // CommandLineParser's execution strategy routes a matched command through CommandExecutor
+        // only when it is a PicoCommand; anything else falls through to RunLast, which is what
+        // makes a bare `profile` print usage and exit 0 instead of running a command lifecycle.
+        val profileGroup = rootCommandLine().subcommands.getValue("profile")
+
+        assertThat(profileGroup.commandSpec.userObject()).isNotInstanceOf(PicoCommand::class.java)
+        assertThat(profileGroup.commandSpec.userObject()).isInstanceOf(Runnable::class.java)
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/profile/ProfileCommandGroupTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/profile/ProfileCommandGroupTest.kt
@@ -13,6 +13,9 @@ import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.configuration.UserConfigProvider
 import com.rustyrazorblade.easydblab.di.KoinCommandFactory
 import com.rustyrazorblade.easydblab.kernel.PicoCommand
+import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
+import com.rustyrazorblade.easydblab.output.OutputHandler
+import com.rustyrazorblade.easydblab.services.ProfileSetupCommandProvider
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.AfterEach
@@ -72,6 +75,27 @@ class ProfileCommandGroupTest : BaseKoinTest() {
 
         assertThat(profileGroup).isNotNull
         assertThat(profileGroup!!.subcommands.keys).contains("show", "setup")
+        // The names alone would stay green with either subcommand bound to the wrong class, which
+        // is the one thing the rename could plausibly get wrong.
+        assertThat(
+            profileGroup.subcommands
+                .getValue("show")
+                .commandSpec
+                .userObject(),
+        ).isInstanceOf(ProfileShow::class.java)
+        assertThat(
+            profileGroup.subcommands
+                .getValue("setup")
+                .commandSpec
+                .userObject(),
+        ).isInstanceOf(SetupProfile::class.java)
+    }
+
+    @Test
+    fun `the production graph binds the profile setup provider to SetupProfile`() {
+        // checkRequirements() runs whatever this provider yields. Bound to the wrong command, a
+        // first-run user gets a report printed instead of interactive setup, and then exit 0.
+        assertThat(getKoin().get<ProfileSetupCommandProvider>().create()).isInstanceOf(SetupProfile::class.java)
     }
 
     @Test
@@ -128,6 +152,19 @@ class ProfileCommandGroupTest : BaseKoinTest() {
         ProfileShow().execute()
 
         assertThat(stdout.toString()).contains("Profile:")
+    }
+
+    @Test
+    fun `profile show emits no event for the report it prints`() {
+        // The test EventBus forwards every emitted event to the BufferedOutputHandler, so an empty
+        // buffer alongside a printed report is direct proof the report went to stdout only. An
+        // event here would put profile settings on the MCP and Redis subscriber streams.
+        ProfileShow().execute()
+
+        val outputHandler = getKoin().get<OutputHandler>() as BufferedOutputHandler
+        assertThat(stdout.toString()).contains("Profile:")
+        assertThat(outputHandler.messages).isEmpty()
+        assertThat(outputHandler.errors).isEmpty()
     }
 
     @Test

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/profile/ProfileShowTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/profile/ProfileShowTest.kt
@@ -1,0 +1,136 @@
+package com.rustyrazorblade.easydblab.commands.profile
+
+import com.rustyrazorblade.easydblab.configuration.User
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests the report text `profile show` produces.
+ *
+ * `buildReport` is a pure function, so these tests assert on the returned string rather than
+ * capturing stdout. What the report text cannot prove — the picocli tree, the command's
+ * annotations, which collaborators the lifecycle touched — lives in [ProfileCommandGroupTest].
+ */
+class ProfileShowTest {
+    private companion object {
+        const val PROFILE_NAME = "default"
+        const val PROFILE_DIR = "/home/tester/.easy-db-lab/profiles/default"
+
+        // Sentinels chosen so they cannot appear in the report by coincidence.
+        const val ACCESS_KEY = "SENTINELACCESSKEYVALUE"
+        const val SECRET = "SENTINELSECRETVALUE"
+        const val AXONOPS_KEY = "SENTINELAXONOPSKEYVALUE"
+        const val TAILSCALE_ID = "SENTINELTAILSCALEIDVALUE"
+        const val TAILSCALE_SECRET = "SENTINELTAILSCALESECRETVALUE"
+    }
+
+    private fun user(
+        axonOpsKey: String = AXONOPS_KEY,
+        tailscaleClientId: String = TAILSCALE_ID,
+        tailscaleClientSecret: String = TAILSCALE_SECRET,
+    ) = User(
+        email = "tester@example.com",
+        region = "eu-central-1",
+        keyName = "tester-keypair",
+        awsProfile = "tester-aws-profile",
+        awsAccessKey = ACCESS_KEY,
+        awsSecret = SECRET,
+        axonOpsOrg = "tester-org",
+        axonOpsKey = axonOpsKey,
+        tailscaleClientId = tailscaleClientId,
+        tailscaleClientSecret = tailscaleClientSecret,
+        s3Bucket = "easy-db-lab-tester-bucket",
+    )
+
+    private fun reportFor(user: User) = ProfileShow.buildReport(PROFILE_NAME, PROFILE_DIR, ProfileSettings.Loaded(user))
+
+    @Test
+    fun `report names the profile, its directory, and all five visible settings`() {
+        val report = reportFor(user())
+
+        assertThat(report)
+            .contains(PROFILE_NAME)
+            .contains(PROFILE_DIR)
+            .contains("tester@example.com")
+            .contains("eu-central-1")
+            .contains("tester-keypair")
+            .contains("tester-aws-profile")
+            .contains("easy-db-lab-tester-bucket")
+    }
+
+    @Test
+    fun `report contains none of the five secret values`() {
+        val report = reportFor(user())
+
+        assertThat(report)
+            .doesNotContain(ACCESS_KEY)
+            .doesNotContain(SECRET)
+            .doesNotContain(AXONOPS_KEY)
+            .doesNotContain(TAILSCALE_ID)
+            .doesNotContain(TAILSCALE_SECRET)
+    }
+
+    @Test
+    fun `a masking helper would leak the first character, so no leading fragment appears either`() {
+        // SetupProfile.maskValue renders "S****" for every one of these. If buildReport ever
+        // reuses it the sentinel assertions above still pass, so guard the leading fragment too.
+        val report = reportFor(user())
+
+        assertThat(report).doesNotContain("****")
+    }
+
+    @Test
+    fun `AxonOps is ENABLED when a key is present`() {
+        assertThat(reportFor(user(axonOpsKey = AXONOPS_KEY))).contains("AxonOps").contains("ENABLED")
+    }
+
+    @Test
+    fun `AxonOps is DISABLED when no key is present`() {
+        val report = reportFor(user(axonOpsKey = ""))
+
+        assertThat(report).containsPattern("AxonOps\\s+DISABLED")
+    }
+
+    @Test
+    fun `Tailscale is ENABLED when both credentials are present`() {
+        val report = reportFor(user())
+
+        assertThat(report).containsPattern("Tailscale\\s+ENABLED")
+    }
+
+    @Test
+    fun `Tailscale is DISABLED when the client id is empty`() {
+        val report = reportFor(user(tailscaleClientId = ""))
+
+        assertThat(report).containsPattern("Tailscale\\s+DISABLED")
+    }
+
+    @Test
+    fun `Tailscale is DISABLED when the client secret is blank rather than empty`() {
+        // isTailscaleEnabled() uses isNotBlank(), so whitespace must not read as configured.
+        val report = reportFor(user(tailscaleClientSecret = "   "))
+
+        assertThat(report).containsPattern("Tailscale\\s+DISABLED")
+    }
+
+    @Test
+    fun `a missing settings file reports the profile as not configured and names profile setup`() {
+        val report = ProfileShow.buildReport(PROFILE_NAME, PROFILE_DIR, ProfileSettings.Missing)
+
+        assertThat(report)
+            .contains(PROFILE_NAME)
+            .contains(PROFILE_DIR)
+            .contains("not configured")
+            .contains("easy-db-lab profile setup")
+    }
+
+    @Test
+    fun `an unreadable settings file names the file path and profile setup`() {
+        val report = ProfileShow.buildReport(PROFILE_NAME, PROFILE_DIR, ProfileSettings.Unreadable)
+
+        assertThat(report)
+            .contains("$PROFILE_DIR/settings.yaml")
+            .contains("could not be read")
+            .contains("easy-db-lab profile setup")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/profile/ProfileShowTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/profile/ProfileShowTest.kt
@@ -25,6 +25,7 @@ class ProfileShowTest {
     }
 
     private fun user(
+        axonOpsOrg: String = "tester-org",
         axonOpsKey: String = AXONOPS_KEY,
         tailscaleClientId: String = TAILSCALE_ID,
         tailscaleClientSecret: String = TAILSCALE_SECRET,
@@ -35,7 +36,7 @@ class ProfileShowTest {
         awsProfile = "tester-aws-profile",
         awsAccessKey = ACCESS_KEY,
         awsSecret = SECRET,
-        axonOpsOrg = "tester-org",
+        axonOpsOrg = axonOpsOrg,
         axonOpsKey = axonOpsKey,
         tailscaleClientId = tailscaleClientId,
         tailscaleClientSecret = tailscaleClientSecret,
@@ -80,13 +81,32 @@ class ProfileShowTest {
     }
 
     @Test
-    fun `AxonOps is ENABLED when a key is present`() {
-        assertThat(reportFor(user(axonOpsKey = AXONOPS_KEY))).contains("AxonOps").contains("ENABLED")
+    fun `AxonOps is ENABLED when both the org and the key are present`() {
+        // Anchored to the AxonOps line: the same fixture renders "Tailscale ENABLED", so two
+        // independent contains() calls would pass even if this line read DISABLED.
+        assertThat(reportFor(user())).containsPattern("AxonOps\\s+ENABLED")
     }
 
     @Test
     fun `AxonOps is DISABLED when no key is present`() {
         val report = reportFor(user(axonOpsKey = ""))
+
+        assertThat(report).containsPattern("AxonOps\\s+DISABLED")
+    }
+
+    @Test
+    fun `AxonOps is DISABLED when the key is set but the org is blank`() {
+        // SetupProfile prompts for the org and the key as independent skippable fields, so this
+        // state is reachable. Up and cassandra Start both skip AxonOps in it.
+        val report = reportFor(user(axonOpsOrg = "", axonOpsKey = AXONOPS_KEY))
+
+        assertThat(report).containsPattern("AxonOps\\s+DISABLED")
+    }
+
+    @Test
+    fun `AxonOps is DISABLED when the key is whitespace rather than empty`() {
+        // isAxonOpsEnabled() uses isNotBlank(), so whitespace must not read as configured.
+        val report = reportFor(user(axonOpsKey = "   "))
 
         assertThat(report).containsPattern("AxonOps\\s+DISABLED")
     }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/profile/SetupProfileTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/profile/SetupProfileTest.kt
@@ -1,8 +1,10 @@
-package com.rustyrazorblade.easydblab.commands
+package com.rustyrazorblade.easydblab.commands.profile
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
 import com.rustyrazorblade.easydblab.Prompter
 import com.rustyrazorblade.easydblab.TestPrompter
+import com.rustyrazorblade.easydblab.commands.BuildImage
+import com.rustyrazorblade.easydblab.commands.SetupProfileException
 import com.rustyrazorblade.easydblab.configuration.Arch
 import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.configuration.UserConfigProvider

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/UserAxonOpsTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/UserAxonOpsTest.kt
@@ -43,4 +43,11 @@ class UserAxonOpsTest {
     fun `isAxonOpsEnabled returns false when the org is whitespace rather than empty`() {
         assertThat(user(org = "   ", key = "axon-key").isAxonOpsEnabled()).isFalse()
     }
+
+    @Test
+    fun `isAxonOpsEnabled returns false when the key is whitespace rather than empty`() {
+        // isNotEmpty() would accept "   "; isNotBlank() rejects it. Without this case the whole
+        // class stays green under a weakened key operand.
+        assertThat(user(org = "acme", key = "   ").isAxonOpsEnabled()).isFalse()
+    }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/UserAxonOpsTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/UserAxonOpsTest.kt
@@ -1,0 +1,46 @@
+package com.rustyrazorblade.easydblab.configuration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Guards the rule that AxonOps needs both credentials.
+ *
+ * `Up` and `cassandra start` both skip AxonOps unless the org and the key are set, so a helper
+ * that reads either one alone would report a profile as enabled while nothing runs at runtime.
+ */
+class UserAxonOpsTest {
+    private fun user(
+        org: String = "",
+        key: String = "",
+    ) = User(
+        email = "test@example.com",
+        region = "us-east-1",
+        keyName = "test-key",
+        awsProfile = "default",
+        awsAccessKey = "",
+        awsSecret = "",
+        axonOpsOrg = org,
+        axonOpsKey = key,
+    )
+
+    @Test
+    fun `isAxonOpsEnabled returns true when both credentials are non-blank`() {
+        assertThat(user(org = "acme", key = "axon-key").isAxonOpsEnabled()).isTrue()
+    }
+
+    @Test
+    fun `isAxonOpsEnabled returns false when the org is blank`() {
+        assertThat(user(org = "", key = "axon-key").isAxonOpsEnabled()).isFalse()
+    }
+
+    @Test
+    fun `isAxonOpsEnabled returns false when the key is blank`() {
+        assertThat(user(org = "acme", key = "").isAxonOpsEnabled()).isFalse()
+    }
+
+    @Test
+    fun `isAxonOpsEnabled returns false when the org is whitespace rather than empty`() {
+        assertThat(user(org = "   ", key = "axon-key").isAxonOpsEnabled()).isFalse()
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/McpAnnotationTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/McpAnnotationTest.kt
@@ -3,8 +3,8 @@ package com.rustyrazorblade.easydblab.mcp
 import com.rustyrazorblade.easydblab.BaseKoinTest
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
-import com.rustyrazorblade.easydblab.commands.PicoCommand
 import com.rustyrazorblade.easydblab.events.Event
+import com.rustyrazorblade.easydblab.kernel.PicoCommand
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.assertj.core.api.Assertions.assertThat

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/CommandExecutorTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/CommandExecutorTest.kt
@@ -95,6 +95,7 @@ class CommandExecutorTest : BaseKoinTest() {
                 eventBus = EventBus(),
                 socksProxyService = mockSocksProxyService,
                 proxyAvailability = proxyAvailability,
+                profileSetupProvider = ProfileSetupCommandProvider { error("profile setup must not run here") },
             )
     }
 


### PR DESCRIPTION
Closes #892

Adds a `profile` command group with `profile show`, moves `setup-profile` under it as `profile setup`, and closes the `commands↔services` package dependency cycle.

## What this does

**`profile show`** reports the active profile's name, absolute directory, `email`, `region`, `keyName`, `awsProfile` and `s3Bucket`, plus `ENABLED`/`DISABLED` flags for AxonOps and Tailscale. It prints no secret value, carries no requirement annotation, and reads no cluster state — so it works in any directory. It has three branches, not two: configured, no `settings.yaml`, and a `settings.yaml` that exists but will not deserialize. That third case previously surfaced as a raw Jackson error through the very command added to diagnose it.

**The command group.** `profile` follows `kit` and `tailscale`. The group class is a `Runnable`, not a `PicoCommand`, because `CommandLineParser`'s execution strategy routes only `PicoCommand`s through `CommandExecutor` — that is what makes a bare `easy-db-lab profile` print usage and exit 0.

**Breaking, deliberately.** `easy-db-lab setup` and `easy-db-lab setup-profile` no longer resolve. Aliasing was a nice-to-have and was dropped rather than carrying a second class for it. All 33 live `setup-profile` references were updated, plus two docs passages naming the bare `setup` alias that contained no `setup-profile` string and would have been missed by a single-term sweep.

**The cycle.** `PicoCommand` moved from `commands/` to a new `kernel/` package, and a `ProfileSetupCommandProvider` in `services/` replaced `CommandExecutor`'s direct construction of `SetupProfile()`. `CommandExecutor` held the only two `commands` references anywhere under `services/`, so this genuinely closes `commands↔services` — one of the seven cycles named in #745. It closes **one**, not two: `McpToolRegistry` names its classes by fully-qualified name rather than import, and `Server.kt:7` imports `mcp.McpServer`, so `mcp↔commands` survives regardless. The ArchUnit rules stay with #745.

## Tests

`./gradlew ktlintFormat` then `./gradlew check` — BUILD SUCCESSFUL on JDK 21 (Corretto 21.0.10) with Docker up, so `:test`, `:integrationTest`, `:detekt` and `:ktlintMainSourceSetCheck` all ran for real. The spec-conformance lens forced attributable executions (`--rerun --no-build-cache`) after finding 23 of 26 tasks `UP-TO-DATE` from another reviewer's run.

Scenario-to-test traceability is 16 of 17. The one uncovered scenario is the docs sweep, verified by inspection — a grep-over-sources guard test would be brittle and low value, and `ac-coverage.md` says so plainly rather than claiming coverage.

## Review

Five lenses, two full rounds. Round 1 found three must-fix issues; all were fixed and re-verified in round 2, where all five approved with zero blocking findings.

The one that mattered: **the AxonOps flag disagreed with its own consumers.** It used `axonOpsKey.isNotEmpty()`, while `Up.kt:706` and `cassandra/Start.kt:78` both require `axonOpsOrg` *and* `axonOpsKey` to be non-blank. So `profile show` would report `ENABLED` in two reachable states where AxonOps is silently skipped at runtime — a diagnostic command asserting a capability the next `up` would not deliver. Fixed by extracting `User.isAxonOpsEnabled()` and repointing all three call sites, so one definition replaces three copies of the rule.

**The committed spec was amended after approval.** The approved scenario required only a non-empty key, so it encoded that same bug — the code could not be both correct and conformant. The implementer raised it as a `SPEC-DEFECT` rather than editing the spec to match its own code, and the owner approved the amendment. It is recorded in `ac-coverage.md`'s **Amendments after Seam 1** section, along with the `buildReport` signature deviation (`User?` → a sealed `ProfileSettings`, because a nullable `User` cannot express three branches).

## Surfaced, non-blocking

Recorded for triage; none of these blocks this change and none was filed.

- **A pre-existing secret leak.** `CommandExecutor.kt:197` logs every command failure's full throwable at ERROR. A corrupt `settings.yaml` produces a SnakeYAML exception whose message embeds the offending source line verbatim — verified against the project's own jars as ~31 characters of a 40-character AWS secret, reaching `info.log` and `debug.log`, both 30-day gzipped, plus OTLP export when configured. Per `providers/CLAUDE.md`'s redaction-is-a-boundary rule the fix belongs inside `UserConfigProvider`. This PR does not cause it and narrows it for this one command.
- **Two flaky tests, neither in this diff.** `WriteConfigTest > execute uses custom token count` — `WriteConfigTest`, `UpdateConfigTest` and `UseCassandraTest` all write `File("cassandra.patch.yaml")` relative to the JVM working directory rather than a `@TempDir`, under `maxParallelForks = 8`. And `SocksTcpBridgeTest > close stops the listener so subsequent connects are refused`, which failed once in CI on this branch and passed on the two runs after with nothing addressing it.
- **`checkRequirements()`'s `@RequireProfileSetup` branch is untested**, and is currently untestable: `exitProcess(0)` sits three lines after the provider call, so any test reaching the provider kills the JVM. Extracting an injectable exit would unblock the first test of that branch.
- **`Repl.ShellCommands`** (`Repl.kt:38-68`) is a second hand-maintained copy of the command tree, still missing ten registered command groups, with no test catching drift. This change makes its own required one-line edit there.
- **`Context`'s constructor performs I/O** (`profileDir.mkdirs()`, `Context.kt:57`), so naming an unknown profile creates a directory for it.
- **KDoc links `[Up]` and `[cassandra.Start]` in `User.kt` do not resolve** from the `configuration` package. Left alone deliberately: the adjacent `isTailscaleEnabled` has the identical problem with `[Init]`, so fixing only the new one would make it inconsistent.
