### PR TITLE
feat(cassandra): build a branch locally and install it by name from S3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,12 @@ Before pushing code, verify it passes all checks:
 
 **Note**: `ktlintFormat` auto-fixes many violations but can't fix all issues (e.g., line length). Always run `ktlintCheck` after formatting to catch remaining issues.
 
+### Building AMIs
+
+**`build-image` / `build-base` / `build-cassandra` bake from `build/install/easy-db-lab/packer/`, not from the working tree.** `Context.appHome` points at the Gradle `installDist` output, so a change under `packer/` does not reach an AMI until `./gradlew installDist` has run — committing it is not enough, and nothing in the build output says which copy it used. Always run `./gradlew installDist` before baking, exactly as you would after changing Kotlin source.
+
+The images are stacked: `cassandra = base + Cassandra tarballs`, and `cassandra.pkr.hcl` selects the most recent base AMI. A change under `packer/base/` therefore needs **both** images rebuilt (`build-image`), not just the Cassandra one.
+
 ### Packer Script Testing
 
 Test packer provisioning scripts locally using Docker (no AWS required):

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -417,6 +417,17 @@ tasks.register<Exec>("testCassandraAgentSelection") {
     commandLine = listOf("bash", "packer/cassandra/lib/edl-cassandra-agents.test.sh")
 }
 
+// Unit-test cached_fetch, which every provisioning script and install-cassandra-version routes
+// downloads through. Covers the s3:// dispatch (curl has no s3 protocol, and an object already in
+// the account bucket must not be copied into the download cache), plus cache hit, cache miss and
+// no-bucket-configured. aws and curl are stubbed; no network, no credentials, no node.
+tasks.register<Exec>("testCacheLib") {
+    group = "Verification"
+    description = "Unit-test the S3-backed download cache helper"
+    workingDir = file(".")
+    commandLine = listOf("bash", "packer/base/install/edl-cache-lib.test.sh")
+}
+
 tasks.register("testCassandraScripts") {
     group = "Verification"
     description = "Run all Cassandra shell script unit tests"
@@ -425,6 +436,7 @@ tasks.register("testCassandraScripts") {
         "testCassandraInstallLoop",
         "testCassandraUseScript",
         "testCassandraAgentSelection",
+        "testCacheLib",
     )
 }
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -231,6 +231,72 @@ Versions: 3.0, 3.11, 4.0, 4.1, 5.0, 5.0-HEAD, 6.0-HEAD, trunk
 Fails if the version is not installed on a targeted node — install it first with
 `cassandra install`.
 
+### cassandra build
+
+Build a Cassandra branch checkout on your own machine and publish it to the profile's S3 bucket,
+where `cassandra install` can find it by name.
+
+```bash
+easy-db-lab cassandra build [<dir>] --java <N> [options]
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `<dir>` | Cassandra source checkout to build | current directory |
+| `--java`, `-j` | JDK major version to build with. Required — it forms part of the build's name | — |
+| `--jira` | Ticket this build is for, e.g. `CASSANDRA-19000` | none |
+| `--name` | Label folded into the name, to tell your builds apart at a glance | none |
+| `--ant-flags` | Extra flags passed to ant | none |
+
+The build runs `ant realclean` then `ant artifacts` in the checkout, under the JDK you name.
+`JAVA_HOME` is set for ant only — your shell's default JDK is untouched.
+
+The version comes from the `base.version` property in the checkout's `build.xml`. Nothing is ever
+inferred from the branch name — not the version, not the ticket. A branch naming convention is a
+habit, not a contract, and this name is permanent once published, so `--jira` and `--name` are the
+only ways anything gets into it. The result is named for what identifies it:
+
+```
+5.1-CASSANDRA-19000-flushfix-20260905-a1b2c3d-jdk17
+<version>-<JIRA>------<--name>--<date>--<sha>--<jdk>
+```
+
+The ticket and `--name` segments are dropped entirely when absent, giving
+`5.1-20260905-a1b2c3d-jdk17`. `--name` is for the case the rest of the name cannot help with: two
+builds of the same commit that differ in something only you know. It sits after the ticket so the
+version stays the leading segment and a bucket listing still sorts by release. Letters, digits,
+`.`, `_` and `-` only, 40 characters or fewer — anything else is refused rather than quietly
+rewritten, because this name is the build's identity in S3 and on every node.
+That name is the build's S3 directory, the directory it installs into on a node, and the name
+`cassandra install` takes.
+
+A checkout with uncommitted changes builds normally — that is the case this command exists for —
+but you are warned, because the sha then does not fully describe what was built, and the manifest
+records the tree as dirty.
+
+No cluster is needed. Builds belong to the profile, so one made on your desktop installs from your
+laptop.
+
+**Published layout**, under the profile's account bucket:
+
+```
+cassandra-builds/5.1-CASSANDRA-19000-20260905-a1b2c3d-jdk17/
+    apache-cassandra-5.1-CASSANDRA-19000-20260905-a1b2c3d-jdk17-bin.tar.gz
+    manifest.json
+```
+
+`manifest.json` records the base version, the full and short sha, the branch and remote, whether
+the tree was dirty, the ticket, the ant flags, when it was built and by which profile, and the
+tarball's size and SHA-256.
+
+Then install it on a cluster:
+
+```bash
+easy-db-lab cassandra install 5.1-CASSANDRA-19000-20260905-a1b2c3d-jdk17
+```
+
+Nodes fetch the tarball straight from the bucket with their instance profile.
+
 ### cassandra install
 
 Install an additional Cassandra version onto a running cluster, without rebuilding the AMI.
@@ -249,7 +315,9 @@ easy-db-lab cassandra install <version> [options]
 | `--hosts` | Filter to specific hosts | all Cassandra nodes |
 
 Each option falls back to the version's `cassandra_versions.yaml` entry when not supplied, so a
-declared version needs no options at all. Every targeted node is attempted regardless of what
+declared version needs no options at all. A name that is not declared locally is looked up among
+the builds published by [`cassandra build`](#cassandra-build), so a build installs by name with no
+options either. Every targeted node is attempted regardless of what
 happens on the others, and each node's outcome is reported individually.
 
 A version already installed on a node is never rebuilt:
@@ -364,7 +432,9 @@ easy-db-lab cassandra list
 **Aliases:** `ls`
 
 Versions installed on the node are listed first. A version declared with `lazy: true` that is not
-installed on that node is listed too, marked `(declared, not installed)`.
+installed on that node is listed too, marked `(declared, not installed)`, as is any build published
+by [`cassandra build`](#cassandra-build) and not yet installed there, marked
+`(build, not installed)`.
 
 ---
 

--- a/docs/user-guide/installing-cassandra.md
+++ b/docs/user-guide/installing-cassandra.md
@@ -193,8 +193,32 @@ Configuration is located at `/etc/cassandra-sidecar/cassandra-sidecar.yaml` on e
 ## Custom Builds
 
 To run a custom Cassandra build (your own fork, a feature branch, or a prebuilt
-tarball), you can either install it onto a cluster that is already running, or
-bake it into the AMI so every future cluster has it.
+tarball), you can build it on your own machine and publish it, install it onto a
+cluster that is already running, or bake it into the AMI so every future cluster
+has it.
+
+### Build your working branch and install it by name
+
+If you are developing Cassandra itself, build the checkout you are already
+working in and publish it once, rather than making every node build the same
+branch:
+
+```bash
+cd ~/dev/cassandra
+easy-db-lab cassandra build --java 17
+# -> 5.1-CASSANDRA-19000-20260905-a1b2c3d-jdk17
+
+easy-db-lab cassandra install 5.1-CASSANDRA-19000-20260905-a1b2c3d-jdk17
+easy-db-lab cassandra use 5.1-CASSANDRA-19000-20260905-a1b2c3d-jdk17
+```
+
+The build is published to your profile's S3 bucket, so it outlives the cluster
+and installs onto whatever you bring up next. Uncommitted changes are fine — the
+manifest records the tree as dirty so you can tell later. `cassandra list` shows
+everything you have published that is not yet on the node.
+
+See [`cassandra build`](../reference/commands.md#cassandra-build) for the naming
+scheme and what the manifest records.
 
 ### Install onto a running cluster
 

--- a/openspec/changes/cassandra-local-builds/.openspec.yaml
+++ b/openspec/changes/cassandra-local-builds/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/cassandra-local-builds/proposal.md
+++ b/openspec/changes/cassandra-local-builds/proposal.md
@@ -1,0 +1,41 @@
+# Build a Cassandra branch locally and install it by name
+
+## Why
+
+A Cassandra committer testing their own work on a real cluster has no supported path today. The
+two that exist both miss:
+
+- `cassandra install <v> --url <repo> --branch <b>` clones and builds **on every node**, in place.
+  It produces no artifact, so a three-node cluster builds the same branch three times, and nothing
+  survives the cluster's teardown. It also cannot build a branch that only exists on the
+  committer's machine.
+- `.github/workflows/build-cassandra-ref.yml` builds properly and publishes a tarball, but it
+  builds a **pushed ref** in CI. Uncommitted work — the normal state of a branch being developed —
+  cannot be tested at all.
+
+What is missing is the inner loop: build the tree you are already working in, once, and install
+the result by name onto a cluster.
+
+## What changes
+
+A new `cassandra build [<dir>] --java <N>` builds a Cassandra checkout on the developer's machine
+with `ant artifacts` and publishes the tarball plus a manifest to the profile's account S3 bucket
+under `cassandra-builds/<name>/`.
+
+The build is named for what identifies it — `<version>-[JIRA-]<date>-<sha>-jdk<N>` — and that name
+is its S3 directory, the version a node installs it under, and the handle `cassandra install`
+takes. `cassandra list` shows published builds alongside declared versions.
+
+Builds are discovered by listing the bucket, not from a local file, so a build belongs to the
+profile rather than to the machine that produced it.
+
+## Impact
+
+- New: `cassandra build`, `CassandraBuildService`, `CassandraBuildCatalog`, `CassandraBuildManifest`.
+- Changed: `cassandra list` gains published builds; `cassandra install` resolves a build name from
+  S3 when the name is not declared locally.
+- Changed: `cached_fetch` in `edl-cache-lib.sh` accepts an `s3://` source, which is how a node
+  fetches a published build with its instance profile.
+
+Out of scope: building in a container, pruning old builds, and surfacing artifacts from the
+separate `cassandra-builds` repository.

--- a/openspec/changes/cassandra-local-builds/specs/cassandra-local-builds/spec.md
+++ b/openspec/changes/cassandra-local-builds/specs/cassandra-local-builds/spec.md
@@ -1,0 +1,221 @@
+# Cassandra Local Builds Spec
+
+## ADDED Requirements
+
+### Requirement: Local build of a Cassandra checkout
+
+The system MUST support building a Cassandra source checkout on the operator's own machine via
+`cassandra build [<dir>] --java <N>`, defaulting `<dir>` to the current directory.
+
+The build MUST run `ant realclean` followed by `ant artifacts -Dno-checkstyle=true` in the
+checkout, under the JDK named by `--java`, which is REQUIRED because it forms part of the build's
+identity. `JAVA_HOME` MUST be set for the ant process only, never for the calling shell, and the
+operator's default JDK MUST NOT be changed.
+
+The system MUST reject a directory that is not a Cassandra git checkout — no `build.xml`, or no
+`.git` — naming what is missing, before running any build.
+
+The system MUST derive the version from the `base.version` property declared in the checkout's
+`build.xml`, and MUST fail naming that file when the property cannot be read. The version MUST NOT
+be inferred from the branch name.
+
+The system MUST build a checkout with uncommitted changes rather than refusing it, MUST warn that
+the recorded sha does not fully describe the result, and MUST record the tree as dirty in the
+manifest.
+
+The system MUST require no cluster. A build MUST succeed against a profile that has never
+provisioned one.
+
+#### Scenario: Building the current checkout
+
+- **GIVEN** the working directory is a Cassandra git checkout whose `build.xml` declares
+  `base.version` `5.1`
+- **WHEN** the operator runs `cassandra build --java 17`
+- **THEN** `ant realclean` and `ant artifacts` run in that directory under a JDK 17 `JAVA_HOME`
+- **AND** the resulting binary tarball is published.
+
+#### Scenario: A directory that is not a Cassandra checkout
+
+- **WHEN** the operator runs `cassandra build <dir> --java 17` against a directory with no
+  `build.xml`
+- **THEN** the command fails naming the missing `build.xml`
+- **AND** no build is started and nothing is uploaded.
+
+#### Scenario: A dirty tree builds and is recorded as dirty
+
+- **GIVEN** a checkout with uncommitted changes
+- **WHEN** the operator runs `cassandra build --java 17`
+- **THEN** the build proceeds
+- **AND** the operator is warned that the sha does not fully describe the build
+- **AND** the published manifest records `dirty` as true.
+
+#### Scenario: An unavailable JDK names where it was looked for
+
+- **WHEN** the operator runs `cassandra build --java <N>` for a JDK that is not installed
+- **THEN** the command fails before building
+- **AND** the message lists the locations that were searched.
+
+#### Scenario: A stale artifact is never published as a fresh one
+
+- **GIVEN** a build directory holding more than one `apache-cassandra-*-bin.tar.gz`
+- **WHEN** the tarball to publish is selected
+- **THEN** the command fails rather than choosing between them
+- **AND** the message names the candidates found.
+
+### Requirement: Build identity
+
+A build MUST be named `<version>-[<JIRA>-][<label>-]<YYYYMMDD>-<short-sha>-jdk<java>`, where
+`<version>` is the checkout's `base.version` with any `-SNAPSHOT` suffix removed.
+
+The JIRA and label segments MUST be omitted entirely — not filled with a placeholder — when absent.
+
+The ticket MUST come only from `--jira`, and MUST be normalised to upper case so one ticket yields
+one prefix. The system MUST NOT infer a ticket from the branch name. A branch naming convention is a
+habit that changes, whereas a published name is permanent, so nothing about a build's identity may
+depend on one.
+
+The system MUST accept a free-form label via `--name`, so that builds which otherwise differ only by
+sha can be told apart at a glance. The label MUST be placed after the ticket and before the date, so
+that the version remains the leading segment and a flat listing still sorts by release.
+
+A label MUST be restricted to characters usable in an S3 key segment and a node directory name, and
+one that is not MUST be refused, naming the offending characters, rather than silently rewritten —
+the name is the build's identity everywhere afterwards, so a mangled label yields a build the
+operator did not ask for.
+
+The name MUST be the build's S3 directory, the version a node installs it under, and the name
+`cassandra install` accepts.
+
+#### Scenario: A build for a ticket
+
+- **GIVEN** a checkout of `base.version` `5.1` at sha `a1b2c3d` on branch `CASSANDRA-19000-trunk`
+- **WHEN** the operator runs `cassandra build --java 17` on 2026-09-05
+- **THEN** the build is named `5.1-CASSANDRA-19000-20260905-a1b2c3d-jdk17`.
+
+#### Scenario: A build with no ticket
+
+- **GIVEN** the same checkout on a branch whose name carries no `CASSANDRA-<n>`
+- **WHEN** the operator runs `cassandra build --java 17`
+- **THEN** the build is named `5.1-20260905-a1b2c3d-jdk17`, with no empty segment where the ticket
+  would be.
+
+#### Scenario: The ticket comes only from the flag
+
+- **WHEN** the operator runs `cassandra build --java 17 --jira CASSANDRA-19000`
+- **THEN** the name carries `CASSANDRA-19000`.
+
+#### Scenario: A branch name never contributes a ticket
+
+- **GIVEN** a checkout on a branch named `CASSANDRA-19000-trunk`, `21460-cursor-bti`, or
+  `cassandra-5.0`
+- **WHEN** the operator runs `cassandra build --java 17` with no `--jira`
+- **THEN** the build carries no ticket segment in any of those cases.
+
+#### Scenario: A label distinguishes two builds of the same commit
+
+- **GIVEN** a checkout of `base.version` `5.1` at sha `a1b2c3d` on branch `CASSANDRA-19000-trunk`
+- **WHEN** the operator runs `cassandra build --java 17 --name flushfix`
+- **THEN** the build is named `5.1-CASSANDRA-19000-flushfix-20260905-a1b2c3d-jdk17`
+- **AND** the version is still the leading segment.
+
+#### Scenario: An unusable label is refused, not rewritten
+
+- **WHEN** the operator runs `cassandra build --java 17 --name "flush fix"`
+- **THEN** the command fails before building
+- **AND** the message names the characters that are not allowed.
+
+### Requirement: Published build layout
+
+A published build MUST occupy its own directory, `cassandra-builds/<name>/`, directly under the
+profile's account S3 bucket — flat, with no grouping level between the prefix and the build.
+
+That directory MUST hold exactly two objects: the binary tarball, named
+`apache-cassandra-<name>-bin.tar.gz` so a downloaded file identifies itself, and `manifest.json`
+beside it.
+
+The manifest MUST record the build name, base version, JDK version, full and short git sha, branch,
+remote, dirty flag, ticket, ant flags, build timestamp, the profile identity that produced it, and
+the tarball's name, size and SHA-256.
+
+The tarball MUST be uploaded before the manifest, so that an interrupted publish leaves a build
+that is not listed rather than one that is listed but cannot be installed.
+
+The account bucket MUST be created if it does not yet exist.
+
+#### Scenario: A published build's objects
+
+- **WHEN** `cassandra build` completes successfully for a build named `<name>`
+- **THEN** `cassandra-builds/<name>/apache-cassandra-<name>-bin.tar.gz` and
+  `cassandra-builds/<name>/manifest.json` both exist in the account bucket
+- **AND** the operator is shown the build's location and the command that installs it.
+
+#### Scenario: An interrupted publish does not advertise a broken build
+
+- **GIVEN** a publish that uploaded the tarball and then failed
+- **WHEN** the operator runs `cassandra list`
+- **THEN** that build is not listed.
+
+### Requirement: Builds are discovered from the bucket
+
+The system MUST discover published builds by listing `cassandra-builds/` in the account bucket and
+reading each `manifest.json`, and MUST NOT depend on any local record of what was built. A build
+published from one machine MUST be discoverable and installable from another using the same
+profile.
+
+There MUST be no index object listing builds; the objects in the bucket are the only record.
+
+A manifest that cannot be read MUST be skipped with a warning, and MUST NOT prevent the remaining
+builds from being listed.
+
+`cassandra list` MUST show published builds that are not installed on the queried node, marked
+distinguishably from installed versions and from declared-but-uninstalled versions, and MUST NOT
+list a build that is already installed there as available to install.
+
+#### Scenario: A build published elsewhere is installable here
+
+- **GIVEN** a build published from another machine using the same profile
+- **WHEN** the operator runs `cassandra list`
+- **THEN** that build is listed as available to install.
+
+#### Scenario: One unreadable manifest does not hide the rest
+
+- **GIVEN** two published builds, one of whose manifests is unreadable
+- **WHEN** the operator runs `cassandra list`
+- **THEN** the readable build is still listed.
+
+### Requirement: Installing a published build
+
+`cassandra install <name>` MUST install a published build when `<name>` is not a locally declared
+version, resolving its parameters from the build's manifest.
+
+The bucket MUST only be consulted when the name is not declared locally, so that installing a
+declared version costs no lookup.
+
+The tarball MUST be referenced by an `s3://` URI rather than a presigned HTTPS URL, so that nodes
+fetch it with their instance profile and the URL still ends in `.tar.gz`. The node-side fetch
+helper MUST accept an `s3://` source and fetch it directly without routing it through the download
+cache, which would store a second copy of an object already in the same bucket.
+
+The version's `java` MUST be written into the node's `/etc/cassandra_versions.yaml`, so that
+`cassandra use <name>` afterwards selects the JDK the build was produced under.
+
+#### Scenario: Installing a build by name
+
+- **GIVEN** a published build named `<name>` and a running cluster
+- **WHEN** the operator runs `cassandra install <name>`
+- **THEN** each targeted node fetches the tarball from the account bucket with its instance profile
+- **AND** the build is extracted to `/usr/local/cassandra/<name>`
+- **AND** `cassandra use <name>` afterwards selects the JDK recorded in the manifest.
+
+#### Scenario: A declared version is resolved without a bucket lookup
+
+- **GIVEN** a version declared in `cassandra_versions.yaml`
+- **WHEN** the operator runs `cassandra install <that-version>`
+- **THEN** the build catalog is not consulted.
+
+#### Scenario: An unknown name is not silently treated as a build
+
+- **WHEN** the operator runs `cassandra install <name>` for a name that is neither declared nor
+  published
+- **THEN** the command fails as it does for any undeclared version, requiring the parameters be
+  supplied as flags.

--- a/openspec/changes/cassandra-local-builds/tasks.md
+++ b/openspec/changes/cassandra-local-builds/tasks.md
@@ -1,0 +1,18 @@
+# Tasks
+
+- [x] `CassandraBuildManifest` — the manifest record, the build-name derivation, and the JIRA sniff.
+- [x] `CassandraBuildService` — validate the checkout, read `base.version`, capture git state,
+      resolve a local JDK, run `ant realclean` + `ant artifacts`, locate the tarball, digest it.
+- [x] `CassandraBuildCatalog` — publish to `cassandra-builds/<name>/`, list, find, and express a
+      manifest as an installable `CassandraVersion`.
+- [x] `CassandraBuild` command, registered under the `cassandra` group.
+- [x] `ClusterS3Path.cassandraBuildsRoot` for the account-level prefix.
+- [x] `Event.Cassandra.BuildStarting` / `BuildArtifactReady` / `BuildPublished`; `VersionList`
+      gains a `builds` field.
+- [x] `cassandra list` reports published builds not yet installed.
+- [x] `cassandra install` resolves a published build by name.
+- [x] `cached_fetch` accepts an `s3://` source.
+- [x] Unit tests for name derivation, manifest round-trip, `base.version` parsing, tarball
+      location, and digesting.
+- [x] Docs: `cassandra build` in `docs/reference/commands.md`, the build-and-install workflow in
+      `docs/user-guide/installing-cassandra.md`, and the `list`/`install` sections updated.

--- a/packer/base/install/edl-cache-lib.sh
+++ b/packer/base/install/edl-cache-lib.sh
@@ -22,6 +22,18 @@ cached_fetch() {
     local url="$1" key="$2" dest="$3"
     local s3="s3://${EDL_S3_BUCKET}/download-cache/${key}"
 
+    # An s3:// source is already an object in the account bucket the node can read with its
+    # instance profile, so it is fetched directly and never cached: copying it under
+    # download-cache/ would store a second copy of a file that is already there. This is the path
+    # a locally-built Cassandra published by `cassandra build` arrives on.
+    case "$url" in
+        s3://*)
+            echo "s3 fetch:   $url"
+            aws s3 cp "$url" "$dest" --no-progress
+            return
+            ;;
+    esac
+
     # Note: no sudo on the aws calls. Instance-profile creds come from IMDS and work as any user,
     # and running as the build user keeps the downloaded file user-owned so callers can rm it
     # (a sudo-downloaded file in a sticky dir like /tmp can't be removed by the non-root user).

--- a/packer/base/install/edl-cache-lib.test.sh
+++ b/packer/base/install/edl-cache-lib.test.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# Unit tests for cached_fetch — the fetch helper every provisioning script and
+# install-cassandra-version routes downloads through.
+#
+# The bug these exist for: cached_fetch assumed curl could fetch anything it was handed. Given an
+# s3:// url it fell through to `curl -fsSL s3://...`, which fails with
+# `curl: (1) Protocol "s3" not supported`. An error that points nowhere near its cause, and which
+# only appears on a real node. It cost a full cluster provisioning cycle to find.
+#
+# The second thing asserted here is that an s3:// source is NOT written back into the download
+# cache. It is already an object in that same bucket, so caching it stores a second copy of a file
+# that is already there.
+#
+# aws and curl are stubbed, so this needs no network, no AWS credentials and no root.
+#
+# Run directly:  ./edl-cache-lib.test.sh
+# Or via gradle: ./gradlew testCacheLib
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+tests_run=0
+tests_failed=0
+
+pass() {
+  tests_run=$((tests_run + 1))
+  echo "ok   - $1"
+}
+
+fail() {
+  tests_run=$((tests_run + 1))
+  tests_failed=$((tests_failed + 1))
+  echo "FAIL - $1"
+}
+
+# Each test runs in a fresh temp dir with stub aws/curl on PATH that log their arguments rather
+# than doing anything. CALLS is the transcript the assertions read.
+setup() {
+  TMP="$(mktemp -d)"
+  CALLS="$TMP/calls"
+  : > "$CALLS"
+  mkdir -p "$TMP/bin"
+
+  cat > "$TMP/bin/aws" <<'STUB'
+#!/usr/bin/env bash
+echo "aws $*" >> "$CALLS"
+# "cp <src> <dest>" — create the destination so callers see a successful fetch, unless the
+# test asked for a cache miss by setting AWS_CP_FAILS for cache-key reads.
+if [ "${1:-}" = "s3" ] && [ "${2:-}" = "cp" ]; then
+  case "$3" in
+    *download-cache/*) [ -n "${AWS_CACHE_MISS:-}" ] && exit 1 ;;
+  esac
+  [ "${4:-}" != "" ] && [ "${4}" != "-" ] && echo "fetched" > "$4"
+fi
+exit 0
+STUB
+
+  cat > "$TMP/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+echo "curl $*" >> "$CALLS"
+for a in "$@"; do
+  [ "$prev" = "-o" ] 2>/dev/null && echo "fetched" > "$a"
+  prev="$a"
+done
+exit 0
+STUB
+
+  chmod +x "$TMP/bin/aws" "$TMP/bin/curl"
+  PATH="$TMP/bin:$PATH"
+  export CALLS
+
+  # Source the library with a bucket configured. /etc/edl-cache.env is absent in a test
+  # environment, so the value set here survives.
+  EDL_S3_BUCKET="test-bucket"
+  # shellcheck source=/dev/null
+  source "${SCRIPT_DIR}/edl-cache-lib.sh"
+  EDL_S3_BUCKET="test-bucket"
+}
+
+teardown() { rm -rf "$TMP"; }
+
+calls_contain() { grep -qF "$1" "$CALLS"; }
+
+# --- s3:// sources ------------------------------------------------------------------------------
+
+setup
+cached_fetch "s3://my-bucket/cassandra-builds/build/x-bin.tar.gz" "cassandra-dist/build/x-bin.tar.gz" "$TMP/out.tar.gz" >/dev/null 2>&1
+if calls_contain "aws s3 cp s3://my-bucket/cassandra-builds/build/x-bin.tar.gz"; then
+  pass "an s3:// url is fetched with aws s3 cp"
+else
+  fail "an s3:// url should be fetched with aws s3 cp; calls were: $(cat "$CALLS")"
+fi
+if grep -q "^curl" "$CALLS"; then
+  fail "an s3:// url must never reach curl (curl has no s3 protocol)"
+else
+  pass "an s3:// url never reaches curl"
+fi
+if grep -q "download-cache" "$CALLS"; then
+  fail "an s3:// url must not touch the download cache; calls were: $(cat "$CALLS")"
+else
+  pass "an s3:// url is neither read from nor written to the download cache"
+fi
+teardown
+
+# --- https:// sources, cache hit ----------------------------------------------------------------
+
+setup
+cached_fetch "https://example.com/x.tar.gz" "thing/1.0/x.tar.gz" "$TMP/out.tar.gz" >/dev/null 2>&1
+if calls_contain "aws s3 cp s3://test-bucket/download-cache/thing/1.0/x.tar.gz"; then
+  pass "an https:// url is served from the download cache when present"
+else
+  fail "expected a cache read; calls were: $(cat "$CALLS")"
+fi
+if grep -q "^curl" "$CALLS"; then
+  fail "a cache hit must not also fetch from the origin"
+else
+  pass "a cache hit does not fetch from the origin"
+fi
+teardown
+
+# --- https:// sources, cache miss ---------------------------------------------------------------
+
+setup
+AWS_CACHE_MISS=1 cached_fetch "https://example.com/x.tar.gz" "thing/1.0/x.tar.gz" "$TMP/out.tar.gz" >/dev/null 2>&1
+if calls_contain "curl -fsSL --retry 3 https://example.com/x.tar.gz"; then
+  pass "an https:// url falls back to the origin on a cache miss"
+else
+  fail "expected an origin fetch; calls were: $(cat "$CALLS")"
+fi
+if [ "$(grep -c "aws s3 cp $TMP/out.tar.gz s3://test-bucket/download-cache" "$CALLS")" -eq 1 ]; then
+  pass "a cache miss populates the cache for next time"
+else
+  fail "expected the cache to be populated; calls were: $(cat "$CALLS")"
+fi
+teardown
+
+# --- no bucket configured -----------------------------------------------------------------------
+
+setup
+EDL_S3_BUCKET="" cached_fetch "https://example.com/x.tar.gz" "thing/1.0/x.tar.gz" "$TMP/out.tar.gz" >/dev/null 2>&1
+if grep -q "^aws" "$CALLS"; then
+  fail "with no bucket configured there is no cache to touch; calls were: $(cat "$CALLS")"
+else
+  pass "with no bucket configured, no aws calls are made"
+fi
+if calls_contain "curl -fsSL --retry 3 https://example.com/x.tar.gz"; then
+  pass "with no bucket configured the origin is still fetched"
+else
+  fail "expected an origin fetch; calls were: $(cat "$CALLS")"
+fi
+teardown
+
+echo
+echo "${tests_run} tests, ${tests_failed} failed"
+[ "$tests_failed" -eq 0 ]

--- a/packer/cassandra/bin/install-cassandra-version
+++ b/packer/cassandra/bin/install-cassandra-version
@@ -363,7 +363,7 @@ install_cassandra_version() {
       export PATH="$java_home/bin:$PATH"
       # Quiet: ant output is voluminous and floods packer's SSH stream
       # shellcheck disable=SC2086
-      ant realclean >"$ant_log" 2>&1 && ant -Dno-checkstyle=true $ANT_FLAGS >>"$ant_log" 2>&1 || exit 1
+      ant realclean >"$ant_log" 2>&1 && ant -Dcheck.skip=true -Dant.gen-doc.skip=true $ANT_FLAGS >>"$ant_log" 2>&1 || exit 1
       rm -rf .git
     ) || {
         echo "ERROR: Ant build failed for version $version, see $ant_log" >&2

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
@@ -180,6 +180,11 @@ object Constants {
         const val MAX_METRICS_CONFIG_ID_LENGTH = 32
     }
 
+    // Byte-size units for human-readable sizes
+    object Size {
+        const val BYTES_PER_MIB = 1024L * 1024
+    }
+
     // Configuration file paths
     object ConfigPaths {
         // Local config files

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Cassandra.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Cassandra.kt
@@ -11,6 +11,7 @@ import picocli.CommandLine.Spec
  *
  * This command groups subcommands for Cassandra cluster management and tooling including:
  * - Cluster lifecycle: start, stop, restart
+ * - Local builds: build (build a branch and publish it to S3)
  * - Configuration: use, list, download-config, write-config, update-config
  * - Stress testing: stress (with nested subcommands)
  * - Profiling: profiling (runtime async-profiler control)
@@ -23,6 +24,7 @@ import picocli.CommandLine.Spec
     description = ["Cassandra cluster management and tooling operations"],
     mixinStandardHelpOptions = true,
     subcommands = [
+        CassandraBuild::class,
         CassandraInstall::class,
         Cql::class,
         DownloadConfig::class,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/CassandraBuild.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/CassandraBuild.kt
@@ -1,0 +1,85 @@
+package com.rustyrazorblade.easydblab.commands.cassandra
+
+import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
+import com.rustyrazorblade.easydblab.configuration.User
+import com.rustyrazorblade.easydblab.events.Event
+import com.rustyrazorblade.easydblab.services.CassandraBuildCatalog
+import com.rustyrazorblade.easydblab.services.CassandraBuildService
+import org.koin.core.component.inject
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+import picocli.CommandLine.Parameters
+import java.io.File
+
+/**
+ * Builds a Cassandra branch checkout on this machine and publishes it to the profile's S3 bucket.
+ *
+ * Exists for the committer's inner loop: build what you are working on, then install it by name
+ * onto a real cluster. The build is named for what it is — base version, ticket, an optional
+ * `--name` label, date, sha and the JDK it was built under — so a bucket holding a month of builds
+ * is still readable.
+ *
+ * Needs no cluster. The account bucket belongs to the profile, so a build made today installs onto
+ * whatever cluster exists next week.
+ */
+@RequireProfileSetup
+@Command(
+    name = "build",
+    description = ["Build a Cassandra branch locally and publish it to S3"],
+)
+class CassandraBuild : PicoBaseCommand() {
+    private val buildService: CassandraBuildService by inject()
+    private val catalog: CassandraBuildCatalog by inject()
+    private val userConfig: User by inject()
+
+    @Parameters(
+        index = "0",
+        arity = "0..1",
+        defaultValue = ".",
+        description = ["Cassandra source checkout to build (default: current directory)"],
+    )
+    var sourceDir: String = "."
+
+    @Option(
+        names = ["--java", "-j"],
+        required = true,
+        description = ["JDK major version to build with, e.g. 11, 17, 21"],
+    )
+    lateinit var javaVersion: String
+
+    @Option(
+        names = ["--jira"],
+        description = ["Ticket this build is for, e.g. CASSANDRA-19000"],
+    )
+    var jira: String = ""
+
+    @Option(
+        names = ["--name"],
+        description = ["Label folded into the build's name, to tell your builds apart at a glance"],
+    )
+    var label: String = ""
+
+    @Option(
+        names = ["--ant-flags"],
+        description = ["Extra flags passed to ant"],
+    )
+    var antFlags: String = ""
+
+    override fun execute() {
+        val result =
+            buildService.build(
+                CassandraBuildService.Request(
+                    sourceDir = File(sourceDir),
+                    javaVersion = javaVersion,
+                    jira = jira.ifBlank { null },
+                    label = label.ifBlank { null },
+                    antFlags = antFlags.ifBlank { null },
+                    builtBy = userConfig.email,
+                ),
+            )
+
+        val location = catalog.publish(result.manifest, result.tarball)
+        eventBus.emit(Event.Cassandra.BuildPublished(result.manifest.name, location.toUri()))
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/CassandraInstall.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/CassandraInstall.kt
@@ -10,6 +10,7 @@ import com.rustyrazorblade.easydblab.configuration.Host
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.exceptions.CommandExecutionException
+import com.rustyrazorblade.easydblab.services.CassandraBuildCatalog
 import com.rustyrazorblade.easydblab.services.HostOperationsService
 import com.rustyrazorblade.easydblab.shellQuote
 import com.rustyrazorblade.easydblab.ssh.redactUrlCredentials
@@ -24,7 +25,8 @@ import java.io.File
  * Installs one additional Cassandra version onto an already-running cluster, without an AMI rebuild.
  *
  * The version's install parameters come from a declared `cassandra_versions.yaml` entry (the same
- * merged candidate set an AMI bake resolves), or entirely from CLI flags for a one-off test. The
+ * merged candidate set an AMI bake resolves), from a build published to the profile's S3 bucket by
+ * `cassandra build`, or entirely from CLI flags for a one-off test. The
  * resolved entry is pushed into each targeted node's `/etc/cassandra_versions.yaml` — so a later
  * `cassandra use` finds the java/python it needs — and then `install-cassandra-version` runs
  * remotely, the same script the AMI bake uses.
@@ -36,6 +38,7 @@ import java.io.File
 )
 class CassandraInstall : PicoBaseCommand() {
     private val hostOperationsService: HostOperationsService by inject()
+    private val catalog: CassandraBuildCatalog by inject()
 
     @Parameters(description = ["Cassandra version to install"], index = "0")
     lateinit var version: String
@@ -92,7 +95,7 @@ class CassandraInstall : PicoBaseCommand() {
     override fun execute() {
         check(version.isNotBlank()) { "A version to install is required, e.g. 'cassandra install 5.0'" }
 
-        val resolved = resolveVersion(declaredCassandraVersions(context))
+        val resolved = resolveVersion(candidateVersions())
         val state = clusterState
         val available = state.getHosts(ServerType.Cassandra)
         val targeted = hostOperationsService.filteredHosts(state.hosts, ServerType.Cassandra, hosts.hostList)
@@ -165,6 +168,21 @@ class CassandraInstall : PicoBaseCommand() {
         if (problems.isNotEmpty()) {
             throw CommandExecutionException(problems.joinToString("\n"))
         }
+    }
+
+    /**
+     * The versions this install could be naming: everything declared, plus the published build of
+     * that name if there is one.
+     *
+     * S3 is only consulted when the name is not declared locally. A declared version is the common
+     * case and must not pay for a bucket lookup, and a build name is unique enough — it carries a
+     * sha — that it will never collide with a declared entry.
+     */
+    private fun candidateVersions(): List<CassandraVersion> {
+        val declared = declaredCassandraVersions(context)
+        if (declared.any { it.version == version }) return declared
+        val build = catalog.find(version) ?: return declared
+        return declared + catalog.asVersion(build)
     }
 
     /**

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/ListVersions.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/ListVersions.kt
@@ -6,11 +6,13 @@ import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.configuration.CassandraVersion
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.events.Event
+import com.rustyrazorblade.easydblab.services.CassandraBuildCatalog
+import org.koin.core.component.inject
 import picocli.CommandLine.Command
 
 /**
- * Lists the Cassandra versions installed on the cluster, plus any lazily-declared version that is
- * declared but not yet installed anywhere.
+ * Lists the Cassandra versions installed on the cluster, plus anything installable that is not on
+ * it yet: lazily-declared versions, and builds published to the profile's S3 bucket.
  */
 @McpCommand
 @RequireProfileSetup
@@ -20,6 +22,8 @@ import picocli.CommandLine.Command
     description = ["List available versions"],
 )
 class ListVersions : PicoBaseCommand() {
+    private val catalog: CassandraBuildCatalog by inject()
+
     override fun execute() {
         clusterState.getHosts(ServerType.Cassandra).first().let {
             val response = remoteOps.executeRemotely(it, "ls /usr/local/cassandra", output = false)
@@ -28,20 +32,28 @@ class ListVersions : PicoBaseCommand() {
                     .split("\n")
                     .map { line -> line.trim() }
                     .filter { line -> line.isNotEmpty() && line != "current" }
-            eventBus.emit(buildVersionList(installed, declaredCassandraVersions(context)))
+            eventBus.emit(
+                buildVersionList(
+                    installed,
+                    declaredCassandraVersions(context),
+                    catalog.list().map { build -> build.name },
+                ),
+            )
         }
     }
 
     /**
-     * A lazily-declared version is not baked into the AMI, so it only shows up here — as
-     * installable — until someone actually installs it.
+     * A lazily-declared version is not baked into the AMI, and a published build was never in one
+     * at all, so both only show up here — as installable — until someone actually installs them.
      */
     internal fun buildVersionList(
         installed: List<String>,
         declared: List<CassandraVersion>,
+        builds: List<String> = emptyList(),
     ): Event.Cassandra.VersionList =
         Event.Cassandra.VersionList(
             installed,
             declared.filter { it.lazy && it.version !in installed }.map { it.version },
+            builds.filter { it !in installed },
         )
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/CassandraBuildManifest.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/CassandraBuildManifest.kt
@@ -1,0 +1,120 @@
+package com.rustyrazorblade.easydblab.configuration
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+/**
+ * The record of one locally-produced Cassandra build, stored beside its tarball in S3.
+ *
+ * A build is identified by its [name] alone — that name is the S3 directory, the version a node
+ * installs it under, and the handle `cassandra install` takes. Everything else here exists so a
+ * build found in S3 weeks later can still be traced back to the tree it came from, which the name
+ * on its own cannot do: a short sha does not say which repository it came from, and says nothing
+ * at all when the tree was dirty.
+ */
+@Serializable
+data class CassandraBuildManifest(
+    /** The build's identity: `<version>-[JIRA-]<date>-<sha>-jdk<java>`. */
+    val name: String,
+    /** `base.version` as declared by the branch's build.xml, e.g. `5.1`. */
+    val baseVersion: String,
+    /** JDK major version the build ran under, e.g. `17`. */
+    val javaVersion: String,
+    val gitSha: String,
+    val gitShortSha: String,
+    val gitBranch: String,
+    val gitRemote: String? = null,
+    /** Whether the working tree carried uncommitted changes, making [gitSha] an incomplete record. */
+    val dirty: Boolean = false,
+    val jira: String? = null,
+    /** Free-form label from `--name`, for telling otherwise-alike builds apart at a glance. */
+    val label: String? = null,
+    val antFlags: String? = null,
+    /** ISO-8601 instant the build started. */
+    val builtAt: String,
+    /** The profile email of whoever produced it. */
+    val builtBy: String,
+    val tarball: String,
+    val tarballBytes: Long,
+    val tarballSha256: String,
+) {
+    fun encode(): String = JSON.encodeToString(this)
+
+    companion object {
+        /** Filename of the manifest within a build's S3 directory. */
+        const val FILE_NAME = "manifest.json"
+
+        /** Longest `--name` label accepted; the generated name is already long. */
+        const val MAX_LABEL_LENGTH = 40
+
+        private val JSON =
+            Json {
+                prettyPrint = true
+                ignoreUnknownKeys = true
+                encodeDefaults = true
+            }
+
+        fun parse(text: String): CassandraBuildManifest = JSON.decodeFromString(text)
+
+        /**
+         * The build's name, and so its S3 directory and the version nodes install it as.
+         *
+         * The JIRA and label segments are dropped entirely when absent, rather than filled with a
+         * placeholder, so an unticketed unlabelled build reads as `5.1-20260905-a1b2c3d-jdk17`.
+         *
+         * The label sits after the ticket and before the date: it is part of what the build *is*,
+         * not of which commit it came from, and keeping the version first means a flat bucket
+         * listing still sorts by release.
+         */
+        fun buildName(
+            baseVersion: String,
+            jira: String?,
+            date: LocalDate,
+            shortSha: String,
+            javaVersion: String,
+            label: String? = null,
+        ): String =
+            listOfNotNull(
+                stripSnapshot(baseVersion),
+                jira?.uppercase()?.ifBlank { null },
+                label?.trim()?.ifBlank { null },
+                date.format(DateTimeFormatter.BASIC_ISO_DATE),
+                shortSha,
+                "jdk$javaVersion",
+            ).joinToString("-")
+
+        /**
+         * `base.version` carries no -SNAPSHOT today, but a tree that appends one must not produce
+         * a build named `5.1-SNAPSHOT-...`.
+         */
+        internal fun stripSnapshot(version: String): String = version.removeSuffix("-SNAPSHOT")
+
+        /** The tarball name a build is stored under, so a downloaded file identifies itself. */
+        fun tarballName(name: String): String = "apache-cassandra-$name-bin.tar.gz"
+
+        /**
+         * Checks a `--name` label is usable as part of a name that becomes an S3 key segment and a
+         * directory on every node.
+         *
+         * Rejects rather than silently rewriting: a label quietly stripped of its spaces produces a
+         * build whose name is not the one the operator asked for, and the name is the build's
+         * identity everywhere afterwards. Says which characters were the problem.
+         */
+        fun validateLabel(label: String): String {
+            val trimmed = label.trim()
+            require(trimmed.isNotEmpty()) { "--name cannot be blank." }
+            require(trimmed.length <= MAX_LABEL_LENGTH) {
+                "--name is ${trimmed.length} characters; keep it to $MAX_LABEL_LENGTH or fewer."
+            }
+            val illegal = trimmed.filterNot { it.isLetterOrDigit() || it in "._-" }.toSortedSet()
+            require(illegal.isEmpty()) {
+                "--name may only contain letters, digits, '.', '_' and '-'. " +
+                    "Remove: ${illegal.joinToString(" ") { "'$it'" }}"
+            }
+            return trimmed
+        }
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterS3Path.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterS3Path.kt
@@ -50,6 +50,7 @@ data class ClusterS3Path(
         internal const val VICTORIA_METRICS_DIR = "victoriametrics"
         internal const val VICTORIA_LOGS_DIR = "victorialogs"
         internal const val CLICKHOUSE_BACKUPS_DIR = "clickhouse-backups"
+        internal const val CASSANDRA_BUILDS_DIR = "cassandra-builds"
 
         /**
          * Create a ClusterS3Path from ClusterState.
@@ -109,6 +110,14 @@ data class ClusterS3Path(
 
         /** Root path for ClickHouse backups in the account bucket, decoupled from any cluster lifecycle. */
         fun clickhouseBackupsRoot(accountBucket: String): ClusterS3Path = root(accountBucket).resolve(CLICKHOUSE_BACKUPS_DIR)
+
+        /**
+         * Root path for locally-produced Cassandra builds in the account bucket.
+         *
+         * Account-level rather than per-cluster: a build is made before any cluster exists, and is
+         * installed onto whichever clusters the profile later brings up.
+         */
+        fun cassandraBuildsRoot(accountBucket: String): ClusterS3Path = root(accountBucket).resolve(CASSANDRA_BUILDS_DIR)
     }
 
     // Core Path-like methods

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
@@ -1,5 +1,6 @@
 package com.rustyrazorblade.easydblab.events
 
+import com.rustyrazorblade.easydblab.Constants
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -338,12 +339,66 @@ sealed interface Event {
         data class VersionList(
             val versions: List<String>,
             val declaredNotInstalled: List<String> = emptyList(),
+            val builds: List<String> = emptyList(),
         ) : Cassandra {
             override fun toDisplayString(): String =
                 (
                     versions +
-                        declaredNotInstalled.map { "$it (declared, not installed - run: cassandra install $it)" }
+                        declaredNotInstalled.map { "$it (declared, not installed - run: cassandra install $it)" } +
+                        builds.map { "$it (build, not installed - run: cassandra install $it)" }
                 ).joinToString("\n")
+        }
+
+        @Serializable
+        @SerialName("Cassandra.BuildStarting")
+        data class BuildStarting(
+            val name: String,
+            val sourceDir: String,
+            val baseVersion: String,
+            val branch: String,
+            val shortSha: String,
+            val dirty: Boolean,
+            val javaVersion: String,
+            val javaHome: String,
+        ) : Cassandra {
+            override fun toDisplayString(): String =
+                buildString {
+                    appendLine("Building $name")
+                    appendLine("  source     $sourceDir")
+                    appendLine("  version    $baseVersion (from build.xml)")
+                    appendLine("  branch     $branch @ $shortSha${if (dirty) " (dirty)" else ""}")
+                    append("  java       $javaVersion at $javaHome")
+                    if (dirty) {
+                        append(
+                            "\n\nWARNING: the working tree has uncommitted changes, so $shortSha does not " +
+                                "fully describe this build. It is recorded as dirty in the manifest.",
+                        )
+                    }
+                }
+        }
+
+        @Serializable
+        @SerialName("Cassandra.BuildArtifactReady")
+        data class BuildArtifactReady(
+            val name: String,
+            val sizeBytes: Long,
+        ) : Cassandra {
+            override fun toDisplayString(): String = "Built $name (${sizeBytes / Constants.Size.BYTES_PER_MIB} MiB)"
+        }
+
+        @Serializable
+        @SerialName("Cassandra.BuildPublished")
+        data class BuildPublished(
+            val name: String,
+            val location: String,
+        ) : Cassandra {
+            override fun toDisplayString(): String =
+                """
+                Published $name
+                  $location
+
+                Install it with: easy-db-lab cassandra install $name
+                """.trimIndent()
         }
 
         @Serializable

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/CassandraBuildCatalog.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/CassandraBuildCatalog.kt
@@ -1,0 +1,88 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.configuration.CassandraBuildManifest
+import com.rustyrazorblade.easydblab.configuration.CassandraVersion
+import com.rustyrazorblade.easydblab.configuration.ClusterS3Path
+import com.rustyrazorblade.easydblab.configuration.User
+import com.rustyrazorblade.easydblab.services.aws.AwsS3BucketService
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.io.File
+
+/**
+ * The set of locally-produced Cassandra builds published to the profile's account bucket.
+ *
+ * Builds live in S3 rather than in a local yaml so they belong to the profile, not to the laptop
+ * that produced them: a build made on a desktop installs from a laptop, and survives a machine
+ * being wiped. The bucket is the only record — there is no index object to drift out of sync with
+ * what is actually stored, so a half-finished upload shows up as a missing build rather than a
+ * listed build that cannot be installed.
+ */
+class CassandraBuildCatalog(
+    private val objectStore: ObjectStore,
+    private val bucketService: AwsS3BucketService,
+    private val userConfig: User,
+) {
+    private val log = KotlinLogging.logger {}
+
+    /** Uploads the tarball and its manifest, and returns the build's S3 directory. */
+    fun publish(
+        manifest: CassandraBuildManifest,
+        tarball: File,
+    ): ClusterS3Path {
+        val dir = buildDir(manifest.name)
+
+        // The tarball goes up first. A manifest with no tarball beside it would list a build that
+        // cannot be installed; a tarball with no manifest is simply not listed.
+        objectStore.uploadFile(tarball, dir.resolve(manifest.tarball), showProgress = true)
+        objectStore.uploadContent(manifest.encode(), dir.resolve(CassandraBuildManifest.FILE_NAME))
+        return dir
+    }
+
+    /** Every published build, newest first. */
+    fun list(): List<CassandraBuildManifest> =
+        objectStore
+            .listFiles(root(), recursive = true)
+            .filter { it.path.getFileName() == CassandraBuildManifest.FILE_NAME }
+            .mapNotNull { info ->
+                // One unreadable manifest must not blind the whole listing — a build half-written
+                // by an interrupted upload would otherwise make every other build invisible.
+                runCatching { CassandraBuildManifest.parse(objectStore.readContent(info.path)) }
+                    .onFailure { log.warn(it) { "Ignoring unreadable build manifest at ${info.path}" } }
+                    .getOrNull()
+            }.sortedByDescending { it.builtAt }
+
+    fun find(name: String): CassandraBuildManifest? {
+        val path = buildDir(name).resolve(CassandraBuildManifest.FILE_NAME)
+        if (!objectStore.fileExists(path)) return null
+        return CassandraBuildManifest.parse(objectStore.readContent(path))
+    }
+
+    /**
+     * The build expressed as an installable version.
+     *
+     * The url is an `s3://` URI, not a presigned https one: nodes reach the account bucket with
+     * their instance profile, and a presigned URL's query string would stop
+     * `install-cassandra-version` recognising the tarball at all — it selects that mode on the URL
+     * ending in `.tar.gz`.
+     */
+    fun asVersion(manifest: CassandraBuildManifest): CassandraVersion =
+        CassandraVersion(
+            version = manifest.name,
+            java = manifest.javaVersion,
+            python = Constants.Cassandra.DEFAULT_PYTHON_VERSION,
+            jvmOptions = null,
+            antFlags = null,
+            url = tarballUri(manifest),
+        )
+
+    fun tarballUri(manifest: CassandraBuildManifest): String = buildDir(manifest.name).resolve(manifest.tarball).toUri()
+
+    private fun buildDir(name: String): ClusterS3Path = root().resolve(name)
+
+    /**
+     * Ensures the account bucket exists before handing back its builds prefix, so `cassandra build`
+     * works on a profile that has never provisioned a cluster.
+     */
+    private fun root(): ClusterS3Path = ClusterS3Path.cassandraBuildsRoot(bucketService.ensureAccountBucket(userConfig))
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/CassandraBuildService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/CassandraBuildService.kt
@@ -93,7 +93,7 @@ class CassandraBuildService(
         )
 
         runAnt(sourceDir, javaHome, listOf("realclean"))
-        runAnt(sourceDir, javaHome, listOf("artifacts", "-Dno-checkstyle=true") + antFlagList(request.antFlags))
+        runAnt(sourceDir, javaHome, listOf("artifacts", "-Dcheck.skip=true", "-Dant.gen-doc.skip=true") + antFlagList(request.antFlags))
 
         val tarball = locateTarball(File(sourceDir, BUILD_DIR))
         val manifest =

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/CassandraBuildService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/CassandraBuildService.kt
@@ -1,0 +1,377 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.configuration.CassandraBuildManifest
+import com.rustyrazorblade.easydblab.events.Event
+import com.rustyrazorblade.easydblab.events.EventBus
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.io.File
+import java.security.MessageDigest
+import java.time.Instant
+import java.time.LocalDate
+
+/**
+ * Builds a Cassandra branch checkout on this machine and describes what came out.
+ *
+ * This is the committer's inner loop: point at the tree you are already working in, get a tarball
+ * plus a manifest that identifies it. It deliberately builds in place with the ant you already
+ * have rather than in a container — the tree is warm, and reproducibility is the CI pipeline's
+ * job, not this one's.
+ *
+ * A dirty tree is allowed and recorded, never rejected. Refusing to build one would make the
+ * command useless for the case it exists to serve.
+ */
+class CassandraBuildService(
+    private val eventBus: EventBus,
+) {
+    private val log = KotlinLogging.logger {}
+
+    /**
+     * What to build.
+     *
+     * @property sourceDir a Cassandra git checkout
+     * @property javaVersion JDK major version to build under; part of the resulting name
+     * @property jira the ticket this build is for; never inferred, a branch name is not evidence
+     * @property label free-form `--name` text folded into the build's name
+     * @property today injected so naming is testable
+     */
+    data class Request(
+        val sourceDir: File,
+        val javaVersion: String,
+        val jira: String? = null,
+        val label: String? = null,
+        val antFlags: String? = null,
+        val builtBy: String,
+        val today: LocalDate = LocalDate.now(),
+    )
+
+    /** The tarball and the manifest describing it, both still local. */
+    data class Result(
+        val manifest: CassandraBuildManifest,
+        val tarball: File,
+    )
+
+    /** Git facts about the tree at the moment the build started. */
+    internal data class GitState(
+        val sha: String,
+        val shortSha: String,
+        val branch: String,
+        val remote: String?,
+        val dirty: Boolean,
+    )
+
+    fun build(request: Request): Result {
+        val sourceDir = request.sourceDir.absoluteFile
+        val buildXml = validateCheckout(sourceDir)
+
+        val baseVersion = readBaseVersion(buildXml.readText(), buildXml.path)
+        val git = gitState(sourceDir)
+        val jira = request.jira?.uppercase()?.ifBlank { null }
+        val label = request.label?.let { CassandraBuildManifest.validateLabel(it) }
+        val name =
+            CassandraBuildManifest.buildName(
+                baseVersion = baseVersion,
+                jira = jira,
+                date = request.today,
+                shortSha = git.shortSha,
+                javaVersion = request.javaVersion,
+                label = label,
+            )
+        val javaHome = resolveJavaHome(request.javaVersion)
+        val startedAt = Instant.now()
+
+        eventBus.emit(
+            Event.Cassandra.BuildStarting(
+                name = name,
+                sourceDir = sourceDir.path,
+                baseVersion = baseVersion,
+                branch = git.branch,
+                shortSha = git.shortSha,
+                dirty = git.dirty,
+                javaVersion = request.javaVersion,
+                javaHome = javaHome.path,
+            ),
+        )
+
+        runAnt(sourceDir, javaHome, listOf("realclean"))
+        runAnt(sourceDir, javaHome, listOf("artifacts", "-Dno-checkstyle=true") + antFlagList(request.antFlags))
+
+        val tarball = locateTarball(File(sourceDir, BUILD_DIR))
+        val manifest =
+            CassandraBuildManifest(
+                name = name,
+                baseVersion = CassandraBuildManifest.stripSnapshot(baseVersion),
+                javaVersion = request.javaVersion,
+                gitSha = git.sha,
+                gitShortSha = git.shortSha,
+                gitBranch = git.branch,
+                gitRemote = git.remote,
+                dirty = git.dirty,
+                jira = jira,
+                label = label,
+                antFlags = request.antFlags?.ifBlank { null },
+                builtAt = startedAt.toString(),
+                builtBy = request.builtBy,
+                tarball = CassandraBuildManifest.tarballName(name),
+                tarballBytes = tarball.length(),
+                tarballSha256 = sha256(tarball),
+            )
+
+        eventBus.emit(Event.Cassandra.BuildArtifactReady(name, tarball.length()))
+        return Result(manifest, tarball)
+    }
+
+    /**
+     * Checks the directory is something this can build, and returns its build.xml.
+     *
+     * Every check runs before any work starts, so pointing at the wrong directory costs a message
+     * rather than a clean and a failed compile.
+     */
+    internal fun validateCheckout(sourceDir: File): File {
+        val buildXml = File(sourceDir, BUILD_XML)
+        require(sourceDir.isDirectory) { "Not a directory: $sourceDir" }
+        require(buildXml.isFile) {
+            "$sourceDir is not a Cassandra checkout: no $BUILD_XML. Point at the root of a Cassandra source tree."
+        }
+        require(File(sourceDir, ".git").exists()) {
+            "$sourceDir is not a git checkout, so there is no sha to name the build after."
+        }
+        return buildXml
+    }
+
+    /**
+     * Runs one ant target, streaming output so a build that stalls is visibly stalled.
+     *
+     * JAVA_HOME is set for the child only. Changing the caller's JDK would be a side effect well
+     * outside what a build command should reach for, and PATH is left alone so the ant on the
+     * user's PATH is the ant that runs.
+     */
+    private fun runAnt(
+        sourceDir: File,
+        javaHome: File,
+        args: List<String>,
+    ) {
+        val command = listOf(ANT) + args
+        log.info { "Running ${command.joinToString(" ")} in $sourceDir with JAVA_HOME=$javaHome" }
+
+        val process =
+            ProcessBuilder(command)
+                .directory(sourceDir)
+                .redirectErrorStream(true)
+                .also { it.environment()["JAVA_HOME"] = javaHome.path }
+                .start()
+
+        process.inputStream.bufferedReader().useLines { lines -> lines.forEach { println(it) } }
+
+        val exit = process.waitFor()
+        check(exit == 0) { "${command.joinToString(" ")} failed with exit code $exit in $sourceDir" }
+    }
+
+    private fun gitState(sourceDir: File): GitState {
+        val sha = git(sourceDir, "rev-parse", "HEAD")
+        return GitState(
+            sha = sha,
+            shortSha = sha.take(SHORT_SHA_LENGTH),
+            branch = git(sourceDir, "rev-parse", "--abbrev-ref", "HEAD"),
+            remote = runCatching { git(sourceDir, "config", "--get", "remote.origin.url") }.getOrNull()?.ifBlank { null },
+            // --porcelain lists untracked files too, which is what "dirty" has to mean here: a new
+            // unstaged source file is compiled into the artifact exactly like a modified one.
+            dirty = git(sourceDir, "status", "--porcelain").isNotBlank(),
+        )
+    }
+
+    private fun git(
+        sourceDir: File,
+        vararg args: String,
+    ): String {
+        val process =
+            ProcessBuilder(listOf(GIT) + args)
+                .directory(sourceDir)
+                .redirectErrorStream(true)
+                .start()
+        val output =
+            process.inputStream
+                .bufferedReader()
+                .readText()
+                .trim()
+        val exit = process.waitFor()
+        check(exit == 0) { "git ${args.joinToString(" ")} failed in $sourceDir: $output" }
+        return output
+    }
+
+    /**
+     * The JDK to build under, searched across the layouts a developer machine actually uses.
+     *
+     * Fails naming every location it looked in: "JDK 17 not found" with no list is a dead end for
+     * whoever hits it.
+     */
+    internal fun resolveJavaHome(javaVersion: String): File {
+        // The JDK the operator has already selected wins when it is the one they asked for. A
+        // SDKMAN or jenv user means "the 21 I am using", not whichever 21 sorts first on disk.
+        selectedJavaHome()?.takeIf { javaMajorOf(it) == javaVersion }?.let { return it }
+
+        macOsJavaHome(javaVersion)?.let { return it }
+
+        val candidates = javaHomeCandidates(javaVersion)
+        candidates.firstOrNull { File(it, "bin/javac").canExecute() }?.let { return it }
+
+        error(
+            "No JDK $javaVersion found. Looked at JAVA_HOME, /usr/libexec/java_home -v $javaVersion, and:\n" +
+                candidates.joinToString("\n") { "  $it" },
+        )
+    }
+
+    /** Whatever JDK the shell is currently pointed at, if any. */
+    private fun selectedJavaHome(): File? =
+        System
+            .getenv("JAVA_HOME")
+            ?.ifBlank { null }
+            ?.let(::File)
+            ?.takeIf { it.isDirectory }
+
+    /**
+     * The major version a JDK install actually is, read from its own `release` file rather than
+     * guessed from a directory name — `current` and other symlinks carry no version in their name.
+     */
+    internal fun javaMajorOf(javaHome: File): String? {
+        val version = javaVersionOf(javaHome) ?: return null
+        // 1.8.0_452 is Java 8; everything since is majored on the leading number.
+        return if (version.startsWith("1.")) version.split(".").getOrNull(1) else version.substringBefore(".")
+    }
+
+    /** The `JAVA_VERSION` a JDK install declares, or null when this is not a JDK. */
+    private fun javaVersionOf(javaHome: File): String? =
+        File(javaHome, "release")
+            .takeIf { it.isFile }
+            ?.readLines()
+            ?.firstOrNull { it.startsWith(JAVA_VERSION_KEY) }
+            ?.substringAfter('=')
+            ?.trim('"', ' ')
+            ?.ifBlank { null }
+
+    /** macOS keeps its JDKs behind a helper rather than a predictable path. */
+    private fun macOsJavaHome(javaVersion: String): File? {
+        val helper = File(MAC_JAVA_HOME_TOOL)
+        if (!helper.canExecute()) return null
+        return runCatching {
+            val process = ProcessBuilder(MAC_JAVA_HOME_TOOL, "-v", javaVersion).start()
+            val path =
+                process.inputStream
+                    .bufferedReader()
+                    .readText()
+                    .trim()
+            if (process.waitFor() == 0 && path.isNotBlank()) File(path) else null
+        }.getOrNull()
+    }
+
+    /**
+     * Every JDK install found on this machine that reports the requested major, newest first.
+     *
+     * Candidates are identified by what each install says about itself in its own `release` file,
+     * never by its directory name. A layout like `21.0.10-amzn` is SDKMAN's convention, not a
+     * contract, and reading a version out of it breaks the moment a distribution names things
+     * differently.
+     */
+    private fun javaHomeCandidates(javaVersion: String): List<File> {
+        val sdkmanRoot =
+            File(
+                System.getenv("SDKMAN_DIR") ?: File(System.getProperty("user.home"), ".sdkman").path,
+                "candidates/java",
+            )
+
+        return listOf(sdkmanRoot, File(LINUX_JVM_DIR))
+            .flatMap { root -> root.listFiles()?.toList() ?: emptyList() }
+            .filter { it.isDirectory && javaMajorOf(it) == javaVersion }
+            .sortedByDescending { javaVersionKey(it) }
+    }
+
+    /**
+     * A JDK's full version as a single comparable number, so 21.0.10 sorts above 21.0.8 — which
+     * comparing the strings does not.
+     */
+    private fun javaVersionKey(javaHome: File): Long =
+        javaVersionOf(javaHome)
+            ?.split('.', '_', '-')
+            ?.mapNotNull { it.toIntOrNull() }
+            .orEmpty()
+            .let { parts -> List(VERSION_PARTS) { parts.getOrElse(it) { 0 } } }
+            .fold(0L) { acc, part -> acc * VERSION_RADIX + part }
+
+    /**
+     * The binary tarball `ant artifacts` produced.
+     *
+     * Its name carries the tree's own version, not the build name, so it is found by shape and
+     * renamed on upload.
+     */
+    internal fun locateTarball(buildDir: File): File {
+        val matches =
+            (buildDir.listFiles()?.toList() ?: emptyList())
+                .filter { it.isFile && it.name.startsWith(TARBALL_PREFIX) && it.name.endsWith(TARBALL_SUFFIX) }
+
+        check(matches.isNotEmpty()) {
+            "ant artifacts produced no $TARBALL_PREFIX*$TARBALL_SUFFIX in $buildDir"
+        }
+        check(matches.size == 1) {
+            "Expected one binary tarball in $buildDir, found ${matches.size}: " +
+                matches.joinToString(", ") { it.name } +
+                ". Run 'ant realclean' in the source tree and try again."
+        }
+        return matches.single()
+    }
+
+    companion object {
+        private const val BUILD_XML = "build.xml"
+        private const val BUILD_DIR = "build"
+        private const val ANT = "ant"
+        private const val GIT = "git"
+        private const val SHORT_SHA_LENGTH = 7
+        private const val TARBALL_PREFIX = "apache-cassandra-"
+        private const val TARBALL_SUFFIX = "-bin.tar.gz"
+        private const val MAC_JAVA_HOME_TOOL = "/usr/libexec/java_home"
+        private const val LINUX_JVM_DIR = "/usr/lib/jvm"
+        private const val JAVA_VERSION_KEY = "JAVA_VERSION="
+        private const val SHA256_BUFFER_BYTES = 8192
+
+        /** Version components compared when ordering JDKs (major, minor, patch, build). */
+        private const val VERSION_PARTS = 4
+
+        /** Wide enough that a patch number never carries into the next component. */
+        private const val VERSION_RADIX = 100_000L
+
+        private val BASE_VERSION_PATTERN =
+            Regex("""property\s+name="base\.version"\s+value="([^"]+)"""")
+
+        /**
+         * The version the branch declares for itself.
+         *
+         * build.xml is authoritative here; deriving a version from the branch name guesses at
+         * something the tree already states exactly.
+         */
+        internal fun readBaseVersion(
+            buildXml: String,
+            path: String,
+        ): String =
+            BASE_VERSION_PATTERN
+                .find(buildXml)
+                ?.groupValues
+                ?.get(1)
+                ?.trim()
+                ?.ifBlank { null }
+                ?: error("Could not read the base.version property from $path")
+
+        internal fun antFlagList(antFlags: String?): List<String> =
+            antFlags?.trim()?.takeIf { it.isNotEmpty() }?.split(Regex("\\s+")) ?: emptyList()
+
+        internal fun sha256(file: File): String {
+            val digest = MessageDigest.getInstance("SHA-256")
+            file.inputStream().use { stream ->
+                val buffer = ByteArray(SHA256_BUFFER_BYTES)
+                while (true) {
+                    val read = stream.read(buffer)
+                    if (read <= 0) break
+                    digest.update(buffer, 0, read)
+                }
+            }
+            return digest.digest().joinToString("") { "%02x".format(it) }
+        }
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/EcrPullSecretService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/EcrPullSecretService.kt
@@ -1,0 +1,101 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import io.fabric8.kubernetes.api.model.SecretBuilder
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import software.amazon.awssdk.services.ecr.EcrClient
+import java.util.Base64
+
+@Serializable
+private data class DockerConfigAuth(
+    val username: String,
+    val password: String,
+    val auth: String,
+)
+
+@Serializable
+private data class DockerConfig(
+    val auths: Map<String, DockerConfigAuth>,
+)
+
+/**
+ * Grants a workload permission to pull an image from the account's ECR.
+ *
+ * The nodes' instance profile already carries the ECR read permissions, but containerd cannot use
+ * an IAM role directly — it needs registry credentials. This turns the role into exactly that: a
+ * short-lived ECR authorization token, published as a `kubernetes.io/dockerconfigjson` secret the
+ * pod spec references.
+ *
+ * Shared by every workload that may run a custom image, rather than reimplemented per workload.
+ * Credential handling that exists in two places drifts in one of them, and the failure — an image
+ * that will not pull — surfaces far from the code that caused it.
+ */
+class EcrPullSecretService(
+    private val k8sService: K8sService,
+    private val ecrClient: EcrClient,
+) {
+    private val log = KotlinLogging.logger {}
+
+    /**
+     * Whether this image comes from ECR and therefore needs a pull secret. A public image, or one
+     * on a registry the node can already read, needs nothing.
+     */
+    fun isEcrImage(image: String): Boolean = ".dkr.ecr." in image && ".amazonaws.com" in image
+
+    /**
+     * Ensures a usable pull secret exists in [namespace] for [image], returning the secret's name,
+     * or an empty string when the image needs none.
+     *
+     * The secret is rewritten on every call rather than created once: an ECR token expires after
+     * twelve hours, so a secret left from an earlier run is as good as absent, and the failure it
+     * produces looks like a missing image rather than an expired credential.
+     *
+     * @return the secret name to attach to the pod's `imagePullSecrets`, or "" when not applicable
+     */
+    fun ensureFor(
+        controlHost: ClusterHost,
+        image: String,
+        namespace: String,
+    ): String {
+        if (!isEcrImage(image)) return ""
+
+        log.info { "Getting ECR authorization token for image=$image" }
+        val registry = image.substringBefore("/")
+        val authToken =
+            ecrClient
+                .getAuthorizationToken()
+                .authorizationData()
+                .first()
+                .authorizationToken()
+        val password = String(Base64.getDecoder().decode(authToken)).substringAfter(":")
+
+        val dockerConfigJson =
+            Json.encodeToString(
+                DockerConfig(
+                    auths = mapOf(registry to DockerConfigAuth(username = "AWS", password = password, auth = authToken)),
+                ),
+            )
+
+        val secret =
+            SecretBuilder()
+                .withNewMetadata()
+                .withName(SECRET_NAME)
+                .withNamespace(namespace)
+                .endMetadata()
+                .withType("kubernetes.io/dockerconfigjson")
+                .addToData(".dockerconfigjson", Base64.getEncoder().encodeToString(dockerConfigJson.toByteArray()))
+                .build()
+
+        k8sService.applyResource(controlHost, secret).getOrThrow()
+        log.info { "ECR pull secret ready in namespace=$namespace" }
+        return SECRET_NAME
+    }
+
+    companion object {
+        /** Name of the secret in whichever namespace it is written to. */
+        const val SECRET_NAME = "ecr-pull-secret"
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
@@ -105,9 +105,12 @@ val servicesModule =
         singleOf(::DefaultVictoriaLogsService) bind VictoriaLogsService::class
         factoryOf(::SidecarManifestBuilder)
         factoryOf(::DefaultSidecarService) bind SidecarService::class
+
+        // Turns the nodes' ECR IAM permission into registry credentials a pod can use
+        singleOf(::EcrPullSecretService)
         // Explicit single (not singleOf) so the jobPollInterval constructor default applies
         // instead of Koin trying to resolve a Duration binding.
-        single<StressJobService> { DefaultStressJobService(get(), get(), get(), get()) }
+        single<StressJobService> { DefaultStressJobService(get(), get(), get(), get(), get()) }
         singleOf(::HostOperationsService)
 
         // Builds a Cassandra branch checkout on this machine

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
@@ -28,6 +28,7 @@ import com.rustyrazorblade.easydblab.providers.docker.DockerClientProvider
 import com.rustyrazorblade.easydblab.proxy.HttpClientFactory
 import com.rustyrazorblade.easydblab.proxy.ProxyAvailability
 import com.rustyrazorblade.easydblab.proxy.SocksProxyService
+import com.rustyrazorblade.easydblab.services.aws.AwsS3BucketService
 import com.rustyrazorblade.easydblab.services.aws.EC2InstanceService
 import com.rustyrazorblade.easydblab.services.aws.EMRService
 import com.rustyrazorblade.easydblab.services.aws.OpenSearchService
@@ -108,6 +109,18 @@ val servicesModule =
         // instead of Koin trying to resolve a Duration binding.
         single<StressJobService> { DefaultStressJobService(get(), get(), get(), get()) }
         singleOf(::HostOperationsService)
+
+        // Builds a Cassandra branch checkout on this machine
+        singleOf(::CassandraBuildService)
+
+        // The profile's published Cassandra builds, stored in the account bucket
+        single {
+            CassandraBuildCatalog(
+                get<ObjectStore>(),
+                get<AwsS3BucketService>(),
+                get<User>(),
+            )
+        }
 
         // Kit command scanner — discovers @KitCommand-annotated classes across all JARs
         singleOf(::DefaultKitCommandScanner) bind KitCommandScanner::class

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/SidecarService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/SidecarService.kt
@@ -4,25 +4,7 @@ import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.sidecar.SidecarManifestBuilder
-import io.fabric8.kubernetes.api.model.SecretBuilder
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
-import software.amazon.awssdk.services.ecr.EcrClient
-import java.util.Base64
-
-@Serializable
-private data class DockerConfigAuth(
-    val username: String,
-    val password: String,
-    val auth: String,
-)
-
-@Serializable
-private data class DockerConfig(
-    val auths: Map<String, DockerConfigAuth>,
-)
 
 /**
  * Service for managing the Cassandra sidecar as a K3s DaemonSet.
@@ -63,19 +45,18 @@ interface SidecarService {
  * @property k8sService Service for K8s operations
  * @property manifestBuilder Builder for sidecar K8s resources
  * @property clusterStateManager Provides cluster name for Pyroscope labels
- * @property ecrClient AWS ECR client for fetching registry auth tokens
+ * @property ecrPullSecrets Grants the DaemonSet permission to pull a custom image from ECR
  */
 class DefaultSidecarService(
     private val k8sService: K8sService,
     private val manifestBuilder: SidecarManifestBuilder,
     private val clusterStateManager: ClusterStateManager,
-    private val ecrClient: EcrClient,
+    private val ecrPullSecrets: EcrPullSecretService,
 ) : SidecarService {
     private val log = KotlinLogging.logger {}
 
     companion object {
         private const val APP_LABEL_KEY = "app.kubernetes.io/name"
-        private const val ECR_PULL_SECRET_NAME = "ecr-pull-secret"
     }
 
     override fun deploy(
@@ -85,13 +66,7 @@ class DefaultSidecarService(
         runCatching {
             val clusterName = clusterStateManager.load().name
 
-            val pullSecretName =
-                if (isEcrImage(image)) {
-                    createEcrPullSecret(controlHost, image)
-                    ECR_PULL_SECRET_NAME
-                } else {
-                    ""
-                }
+            val pullSecretName = ecrPullSecrets.ensureFor(controlHost, image, Constants.K8s.NAMESPACE)
 
             log.info { "Deploying sidecar DaemonSet image=$image to K3s" }
             val resources =
@@ -128,45 +103,4 @@ class DefaultSidecarService(
                 .getOrThrow()
             log.info { "Sidecar DaemonSet rolling restart triggered" }
         }
-
-    private fun isEcrImage(image: String): Boolean = ".dkr.ecr." in image && ".amazonaws.com" in image
-
-    private fun createEcrPullSecret(
-        controlHost: ClusterHost,
-        image: String,
-    ) {
-        log.info { "Getting ECR authorization token for image=$image" }
-        val registry = image.substringBefore("/")
-        val authToken =
-            ecrClient
-                .getAuthorizationToken()
-                .authorizationData()
-                .first()
-                .authorizationToken()
-        val password = String(Base64.getDecoder().decode(authToken)).substringAfter(":")
-
-        val dockerConfigJson =
-            Json.encodeToString(
-                DockerConfig(
-                    auths =
-                        mapOf(
-                            registry to DockerConfigAuth(username = "AWS", password = password, auth = authToken),
-                        ),
-                ),
-            )
-        val encodedConfig = Base64.getEncoder().encodeToString(dockerConfigJson.toByteArray())
-
-        val secret =
-            SecretBuilder()
-                .withNewMetadata()
-                .withName(ECR_PULL_SECRET_NAME)
-                .withNamespace(Constants.K8s.NAMESPACE)
-                .endMetadata()
-                .withType("kubernetes.io/dockerconfigjson")
-                .addToData(".dockerconfigjson", encodedConfig)
-                .build()
-
-        k8sService.applyResource(controlHost, secret).getOrThrow()
-        log.info { "ECR pull secret created" }
-    }
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/StressJobService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/StressJobService.kt
@@ -11,6 +11,7 @@ import com.rustyrazorblade.easydblab.kubernetes.KubernetesPod
 import io.fabric8.kubernetes.api.model.Container
 import io.fabric8.kubernetes.api.model.ContainerBuilder
 import io.fabric8.kubernetes.api.model.EnvVarBuilder
+import io.fabric8.kubernetes.api.model.LocalObjectReferenceBuilder
 import io.fabric8.kubernetes.api.model.VolumeBuilder
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder
 import io.fabric8.kubernetes.api.model.batch.v1.Job
@@ -134,6 +135,7 @@ class DefaultStressJobService(
     private val clusterStateManager: ClusterStateManager,
     private val eventBus: EventBus,
     private val templateService: TemplateService,
+    private val ecrPullSecrets: EcrPullSecretService,
     private val jobPollInterval: Duration = Duration.ofMillis(JOB_POLL_INTERVAL_MS),
 ) : StressJobService {
     private val log = KotlinLogging.logger {}
@@ -367,12 +369,21 @@ class DefaultStressJobService(
             clusterState.getControlHost()?.privateIp
                 ?: error("No control node found. Re-provision the cluster to fix this.")
 
+        // A custom stress image may live in the account's ECR, which containerd cannot read from
+        // the node's IAM role alone. Same treatment the sidecar already gets.
+        val pullSecretName =
+            clusterState
+                .getControlHost()
+                ?.let { control ->
+                    ecrPullSecrets.ensureFor(control, config.image, Constants.Stress.NAMESPACE)
+                }.orEmpty()
+
         val stressContainer =
             buildStressContainer(config, region, controlNodeIp, clusterState.name)
         val otelSidecar =
             buildOtelSidecarContainer(config.jobName, config.tags, config.promPort, clusterState.clusterLabelName())
 
-        return assembleJob(config.jobName, labels, stressContainer, otelSidecar)
+        return assembleJob(config.jobName, labels, stressContainer, otelSidecar, pullSecretName)
     }
 
     private fun buildStressContainer(
@@ -497,6 +508,7 @@ class DefaultStressJobService(
         labels: Map<String, String>,
         stressContainer: Container,
         otelSidecar: Container,
+        pullSecretName: String = "",
     ): Job =
         JobBuilder()
             .withNewMetadata()
@@ -516,7 +528,11 @@ class DefaultStressJobService(
             .withDnsPolicy("ClusterFirstWithHostNet")
             .withRestartPolicy("Never")
             .withNodeSelector<String, String>(mapOf("type" to ServerType.Stress.serverType))
-            .withInitContainers(otelSidecar)
+            .apply {
+                if (pullSecretName.isNotEmpty()) {
+                    withImagePullSecrets(LocalObjectReferenceBuilder().withName(pullSecretName).build())
+                }
+            }.withInitContainers(otelSidecar)
             .withContainers(stressContainer)
             .withVolumes(
                 VolumeBuilder()

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/TestModules.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/TestModules.kt
@@ -17,6 +17,7 @@ import com.rustyrazorblade.easydblab.providers.ssh.DefaultSSHConfiguration
 import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
 import com.rustyrazorblade.easydblab.providers.ssh.SSHConfiguration
 import com.rustyrazorblade.easydblab.providers.ssh.SSHConnectionProvider
+import com.rustyrazorblade.easydblab.services.CassandraBuildCatalog
 import com.rustyrazorblade.easydblab.services.CommandExecutor
 import com.rustyrazorblade.easydblab.services.ExternalIpService
 import com.rustyrazorblade.easydblab.services.aws.AMIValidator
@@ -179,6 +180,11 @@ object TestModules {
 
             // AwsS3BucketService using mocked AWS
             single { AwsS3BucketService(get<AWS>()) }
+
+            // Published Cassandra builds. Mocked rather than real: resolving it for real would
+            // create the account bucket. Its defaults (no builds, no match) are what a profile
+            // that has never run `cassandra build` actually looks like.
+            single { mock<CassandraBuildCatalog>() }
 
             // Fake external IP resolver so tests never make a network call
             single<ExternalIpService> {

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/TestModules.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/TestModules.kt
@@ -19,6 +19,7 @@ import com.rustyrazorblade.easydblab.providers.ssh.SSHConfiguration
 import com.rustyrazorblade.easydblab.providers.ssh.SSHConnectionProvider
 import com.rustyrazorblade.easydblab.services.CassandraBuildCatalog
 import com.rustyrazorblade.easydblab.services.CommandExecutor
+import com.rustyrazorblade.easydblab.services.EcrPullSecretService
 import com.rustyrazorblade.easydblab.services.ExternalIpService
 import com.rustyrazorblade.easydblab.services.aws.AMIValidator
 import com.rustyrazorblade.easydblab.services.aws.AwsS3BucketService
@@ -30,6 +31,7 @@ import org.koin.dsl.module
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import software.amazon.awssdk.services.ecr.EcrClient
 import software.amazon.awssdk.services.iam.IamClient
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sts.StsClient
@@ -185,6 +187,11 @@ object TestModules {
             // create the account bucket. Its defaults (no builds, no match) are what a profile
             // that has never run `cassandra build` actually looks like.
             single { mock<CassandraBuildCatalog>() }
+
+            // Real, over a mocked ECR client and K8s service: tests that exercise a custom image
+            // assert on the secret this actually builds, so a mock here would verify nothing.
+            single { mock<EcrClient>() }
+            single { EcrPullSecretService(get(), get()) }
 
             // Fake external IP resolver so tests never make a network call
             single<ExternalIpService> {

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/ListVersionsTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/ListVersionsTest.kt
@@ -9,6 +9,7 @@ import com.rustyrazorblade.easydblab.configuration.InitConfig
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
 import com.rustyrazorblade.easydblab.output.OutputHandler
+import com.rustyrazorblade.easydblab.services.CassandraBuildCatalog
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -19,6 +20,7 @@ import org.mockito.kotlin.whenever
 
 class ListVersionsTest : BaseKoinTest() {
     private lateinit var mockClusterStateManager: ClusterStateManager
+    private lateinit var mockCatalog: CassandraBuildCatalog
     private lateinit var outputHandler: BufferedOutputHandler
 
     private val testCassandraHost =
@@ -45,15 +47,18 @@ class ListVersionsTest : BaseKoinTest() {
         listOf(
             module {
                 single<ClusterStateManager> { mockClusterStateManager }
+                single<CassandraBuildCatalog> { mockCatalog }
             },
         )
 
     @BeforeEach
     fun setupMocks() {
         mockClusterStateManager = mock()
+        mockCatalog = mock()
         outputHandler = getKoin().get<OutputHandler>() as BufferedOutputHandler
 
         whenever(mockClusterStateManager.load()).thenReturn(testClusterState)
+        whenever(mockCatalog.list()).thenReturn(emptyList())
     }
 
     @Test
@@ -78,6 +83,38 @@ class ListVersionsTest : BaseKoinTest() {
 
         assertThat(event.declaredNotInstalled).isEmpty()
         assertThat(event.toDisplayString()).isEqualTo("5.0")
+    }
+
+    @Test
+    fun `buildVersionList offers a published build that is not installed yet`() {
+        val event =
+            ListVersions().buildVersionList(
+                installed = listOf("5.0"),
+                declared = emptyList(),
+                builds = listOf("5.1-CASSANDRA-19000-20260905-a1b2c3d-jdk17"),
+            )
+
+        assertThat(event.builds).containsExactly("5.1-CASSANDRA-19000-20260905-a1b2c3d-jdk17")
+        assertThat(event.toDisplayString())
+            .contains("5.1-CASSANDRA-19000-20260905-a1b2c3d-jdk17 (build, not installed")
+            .contains("cassandra install 5.1-CASSANDRA-19000-20260905-a1b2c3d-jdk17")
+    }
+
+    @Test
+    fun `a build already installed on the cluster is not offered a second time`() {
+        val build = "5.1-CASSANDRA-19000-20260905-a1b2c3d-jdk17"
+
+        val event =
+            ListVersions().buildVersionList(
+                installed = listOf("5.0", build),
+                declared = emptyList(),
+                builds = listOf(build),
+            )
+
+        assertThat(event.builds).isEmpty()
+        assertThat(event.toDisplayString()).doesNotContain("(build, not installed")
+        // ...but it is still listed as installed, which is what the node actually has.
+        assertThat(event.versions).contains(build)
     }
 
     private fun lazyVersion(version: String) =

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/CassandraBuildManifestTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/CassandraBuildManifestTest.kt
@@ -1,0 +1,153 @@
+package com.rustyrazorblade.easydblab.configuration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class CassandraBuildManifestTest {
+    private val date = LocalDate.of(2026, 9, 5)
+
+    @Test
+    fun `build name carries version, ticket, date, sha and jdk`() {
+        val name = CassandraBuildManifest.buildName("5.1", "CASSANDRA-19000", date, "a1b2c3d", "17")
+
+        assertThat(name).isEqualTo("5.1-CASSANDRA-19000-20260905-a1b2c3d-jdk17")
+    }
+
+    @Test
+    fun `build name drops the ticket segment entirely when there is no ticket`() {
+        val name = CassandraBuildManifest.buildName("5.0", null, date, "9876abc", "17")
+
+        assertThat(name).isEqualTo("5.0-20260905-9876abc-jdk17")
+    }
+
+    @Test
+    fun `a blank ticket is treated as no ticket rather than an empty segment`() {
+        val name = CassandraBuildManifest.buildName("5.0", "   ", date, "9876abc", "17")
+
+        assertThat(name).isEqualTo("5.0-20260905-9876abc-jdk17")
+    }
+
+    @Test
+    fun `a lowercase ticket is normalised so one ticket yields one prefix`() {
+        val name = CassandraBuildManifest.buildName("trunk", "cassandra-20111", date, "1122def", "21")
+
+        assertThat(name).isEqualTo("trunk-CASSANDRA-20111-20260905-1122def-jdk21")
+    }
+
+    @Test
+    fun `a SNAPSHOT suffix never reaches the name`() {
+        val name = CassandraBuildManifest.buildName("5.1-SNAPSHOT", null, date, "a1b2c3d", "17")
+
+        assertThat(name).startsWith("5.1-2026")
+    }
+
+    @Test
+    fun `a label sits between the ticket and the date`() {
+        val name = CassandraBuildManifest.buildName("5.1", "CASSANDRA-19000", date, "a1b2c3d", "17", "flushfix")
+
+        assertThat(name).isEqualTo("5.1-CASSANDRA-19000-flushfix-20260905-a1b2c3d-jdk17")
+    }
+
+    @Test
+    fun `a label without a ticket still follows the version`() {
+        val name = CassandraBuildManifest.buildName("5.1", null, date, "a1b2c3d", "17", "flushfix")
+
+        assertThat(name).isEqualTo("5.1-flushfix-20260905-a1b2c3d-jdk17")
+    }
+
+    @Test
+    fun `every name keeps the version first so a flat listing sorts by release`() {
+        val labelled = CassandraBuildManifest.buildName("5.1", "CASSANDRA-19000", date, "a1b2c3d", "17", "flushfix")
+        val unlabelled = CassandraBuildManifest.buildName("5.1", null, date, "a1b2c3d", "17")
+
+        assertThat(labelled).startsWith("5.1-")
+        assertThat(unlabelled).startsWith("5.1-")
+    }
+
+    @Test
+    fun `an absent or blank label adds no segment`() {
+        assertThat(CassandraBuildManifest.buildName("5.1", null, date, "a1b2c3d", "17", null))
+            .isEqualTo("5.1-20260905-a1b2c3d-jdk17")
+        assertThat(CassandraBuildManifest.buildName("5.1", null, date, "a1b2c3d", "17", "   "))
+            .isEqualTo("5.1-20260905-a1b2c3d-jdk17")
+    }
+
+    @Test
+    fun `a usable label is accepted and trimmed`() {
+        assertThat(CassandraBuildManifest.validateLabel("  flush-fix_2.1  ")).isEqualTo("flush-fix_2.1")
+    }
+
+    @Test
+    fun `a label with a space is refused rather than silently rewritten`() {
+        // The name is the build's identity in S3 and on every node, so a quietly mangled label
+        // would produce a build the operator did not ask for.
+        assertThatThrownBy { CassandraBuildManifest.validateLabel("flush fix") }
+            .hasMessageContaining("' '")
+    }
+
+    @Test
+    fun `a label naming characters that would break an S3 key is refused, listing them`() {
+        assertThatThrownBy { CassandraBuildManifest.validateLabel("flush/fix?v=1") }
+            .hasMessageContaining("'/'")
+            .hasMessageContaining("'?'")
+            .hasMessageContaining("'='")
+    }
+
+    @Test
+    fun `a blank label is refused`() {
+        assertThatThrownBy { CassandraBuildManifest.validateLabel("   ") }
+            .hasMessageContaining("cannot be blank")
+    }
+
+    @Test
+    fun `an over-long label is refused with its length`() {
+        assertThatThrownBy { CassandraBuildManifest.validateLabel("x".repeat(41)) }
+            .hasMessageContaining("41")
+    }
+
+    @Test
+    fun `tarball name is derived from the build name so a downloaded file identifies itself`() {
+        assertThat(CassandraBuildManifest.tarballName("5.1-20260905-a1b2c3d-jdk17"))
+            .isEqualTo("apache-cassandra-5.1-20260905-a1b2c3d-jdk17-bin.tar.gz")
+    }
+
+    @Test
+    fun `a manifest survives a round trip through S3`() {
+        val manifest = sampleManifest()
+
+        val decoded = CassandraBuildManifest.parse(manifest.encode())
+
+        assertThat(decoded).isEqualTo(manifest)
+    }
+
+    @Test
+    fun `a manifest written by a newer version still parses`() {
+        val withUnknownField =
+            sampleManifest().encode().replaceFirst("{", """{ "somethingAddedLater": "value",""")
+
+        val decoded = CassandraBuildManifest.parse(withUnknownField)
+
+        assertThat(decoded.name).isEqualTo("5.1-CASSANDRA-19000-20260905-a1b2c3d-jdk17")
+    }
+
+    private fun sampleManifest() =
+        CassandraBuildManifest(
+            name = "5.1-CASSANDRA-19000-20260905-a1b2c3d-jdk17",
+            baseVersion = "5.1",
+            javaVersion = "17",
+            gitSha = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678",
+            gitShortSha = "a1b2c3d",
+            gitBranch = "CASSANDRA-19000-trunk",
+            gitRemote = "https://github.com/apache/cassandra.git",
+            dirty = true,
+            jira = "CASSANDRA-19000",
+            antFlags = "-Duse.jdk11=true",
+            builtAt = "2026-09-05T12:00:00Z",
+            builtBy = "jon@rustyrazorblade.com",
+            tarball = "apache-cassandra-5.1-CASSANDRA-19000-20260905-a1b2c3d-jdk17-bin.tar.gz",
+            tarballBytes = 78_123_456L,
+            tarballSha256 = "abc123",
+        )
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/CassandraBuildServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/CassandraBuildServiceTest.kt
@@ -1,0 +1,207 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.events.EventBus
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.createDirectory
+import kotlin.io.path.writeText
+
+class CassandraBuildServiceTest {
+    @Test
+    fun `base version is read from the build xml property`() {
+        val buildXml =
+            """
+            <project basedir="." default="jar" name="apache-cassandra">
+                <property name="debuglevel" value="source,lines,vars"/>
+                <property name="base.version" value="5.1"/>
+                <property name="scm.connection" value="scm:https://gitbox.apache.org/repos/asf/cassandra.git"/>
+            </project>
+            """.trimIndent()
+
+        assertThat(CassandraBuildService.readBaseVersion(buildXml, "build.xml")).isEqualTo("5.1")
+    }
+
+    @Test
+    fun `a build xml with no base version names the file it could not read`() {
+        assertThatThrownBy {
+            CassandraBuildService.readBaseVersion("<project/>", "/src/cassandra/build.xml")
+        }.hasMessageContaining("/src/cassandra/build.xml")
+    }
+
+    @Test
+    fun `a similarly named property is not mistaken for the base version`() {
+        val buildXml = """<property name="base.version.extra" value="wrong"/>"""
+
+        assertThatThrownBy {
+            CassandraBuildService.readBaseVersion(buildXml, "build.xml")
+        }.hasMessageContaining("base.version")
+    }
+
+    @Test
+    fun `a directory with no build xml is refused, naming what is missing`(
+        @TempDir tmp: Path,
+    ) {
+        val notACheckout = tmp.resolve("src").also { it.createDirectory() }
+        notACheckout.resolve(".git").createDirectory()
+
+        assertThatThrownBy { service().validateCheckout(notACheckout.toFile()) }
+            .hasMessageContaining("build.xml")
+    }
+
+    @Test
+    fun `a source tree that is not a git checkout is refused, because there is no sha to name it`(
+        @TempDir tmp: Path,
+    ) {
+        val noGit = tmp.resolve("src").also { it.createDirectory() }
+        noGit.resolve("build.xml").writeText("<project/>")
+
+        assertThatThrownBy { service().validateCheckout(noGit.toFile()) }
+            .hasMessageContaining("not a git checkout")
+    }
+
+    @Test
+    fun `a path that is not a directory at all is refused`(
+        @TempDir tmp: Path,
+    ) {
+        val file = tmp.resolve("build.xml").also { it.writeText("<project/>") }
+
+        assertThatThrownBy { service().validateCheckout(file.toFile()) }
+            .hasMessageContaining("Not a directory")
+    }
+
+    @Test
+    fun `a real checkout passes and yields its build xml`(
+        @TempDir tmp: Path,
+    ) {
+        val checkout = tmp.resolve("cassandra").also { it.createDirectory() }
+        checkout.resolve("build.xml").writeText("""<property name="base.version" value="5.1"/>""")
+        checkout.resolve(".git").createDirectory()
+
+        val buildXml = service().validateCheckout(checkout.toFile())
+
+        assertThat(CassandraBuildService.readBaseVersion(buildXml.readText(), buildXml.path)).isEqualTo("5.1")
+    }
+
+    @Test
+    fun `ant flags are split into separate arguments`() {
+        assertThat(CassandraBuildService.antFlagList("-Duse.jdk11=true -Dsomething=2"))
+            .containsExactly("-Duse.jdk11=true", "-Dsomething=2")
+    }
+
+    @Test
+    fun `absent or blank ant flags contribute no arguments`() {
+        assertThat(CassandraBuildService.antFlagList(null)).isEmpty()
+        assertThat(CassandraBuildService.antFlagList("   ")).isEmpty()
+    }
+
+    @Test
+    fun `the binary tarball is found by shape, whatever version the tree names it`(
+        @TempDir tmp: Path,
+    ) {
+        val buildDir = tmp.resolve("build").also { it.createDirectory() }
+        buildDir.resolve("apache-cassandra-5.1-SNAPSHOT-bin.tar.gz").writeText("tarball")
+        // The source tarball and the jars sit in the same directory and must not be picked up.
+        buildDir.resolve("apache-cassandra-5.1-SNAPSHOT-src.tar.gz").writeText("source")
+        buildDir.resolve("apache-cassandra-5.1-SNAPSHOT.jar").writeText("jar")
+
+        val found = service().locateTarball(buildDir.toFile())
+
+        assertThat(found.name).isEqualTo("apache-cassandra-5.1-SNAPSHOT-bin.tar.gz")
+    }
+
+    @Test
+    fun `a build directory with no tarball fails rather than publishing nothing`(
+        @TempDir tmp: Path,
+    ) {
+        val buildDir = tmp.resolve("build").also { it.createDirectory() }
+
+        assertThatThrownBy { service().locateTarball(buildDir.toFile()) }
+            .hasMessageContaining("produced no")
+    }
+
+    @Test
+    fun `a stale tarball beside a fresh one is refused rather than guessed between`(
+        @TempDir tmp: Path,
+    ) {
+        val buildDir = tmp.resolve("build").also { it.createDirectory() }
+        buildDir.resolve("apache-cassandra-5.0-SNAPSHOT-bin.tar.gz").writeText("stale")
+        buildDir.resolve("apache-cassandra-5.1-SNAPSHOT-bin.tar.gz").writeText("fresh")
+
+        assertThatThrownBy { service().locateTarball(buildDir.toFile()) }
+            .hasMessageContaining("found 2")
+            .hasMessageContaining("realclean")
+    }
+
+    @Test
+    fun `a missing build directory is reported, not treated as an empty one`(
+        @TempDir tmp: Path,
+    ) {
+        assertThatThrownBy { service().locateTarball(tmp.resolve("build").toFile()) }
+            .hasMessageContaining("produced no")
+    }
+
+    @Test
+    fun `the tarball digest is the file's real sha256`(
+        @TempDir tmp: Path,
+    ) {
+        val empty = tmp.resolve("empty.tar.gz").toFile().also { it.writeBytes(ByteArray(0)) }
+
+        assertThat(CassandraBuildService.sha256(empty))
+            .isEqualTo("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+    }
+
+    @Test
+    fun `the digest reads the whole file, not just its first buffer`(
+        @TempDir tmp: Path,
+    ) {
+        // Larger than the 8 KiB read buffer: a digest that stopped after one read would collide.
+        val a = tmp.resolve("a.bin").toFile().also { it.writeBytes(ByteArray(20_000) { 1 }) }
+        val b =
+            tmp.resolve("b.bin").toFile().also {
+                it.writeBytes(ByteArray(20_000) { i -> if (i < 19_999) 1 else 2 })
+            }
+
+        assertThat(CassandraBuildService.sha256(a)).isNotEqualTo(CassandraBuildService.sha256(b))
+    }
+
+    @Test
+    fun `a jdk's major version is read from its release file, not its directory name`(
+        @TempDir tmp: Path,
+    ) {
+        // SDKMAN's "current" is a symlink whose name carries no version at all.
+        val current = tmp.resolve("current").also { it.createDirectory() }
+        current.resolve("release").writeText("""JAVA_VERSION="21.0.10"\nJAVA_VENDOR="Amazon"""")
+
+        assertThat(service().javaMajorOf(current.toFile())).isEqualTo("21")
+    }
+
+    @Test
+    fun `an old-style 1 dot 8 version reads as java 8`(
+        @TempDir tmp: Path,
+    ) {
+        val jdk = tmp.resolve("jdk8").also { it.createDirectory() }
+        jdk.resolve("release").writeText("""JAVA_VERSION="1.8.0_452"""")
+
+        assertThat(service().javaMajorOf(jdk.toFile())).isEqualTo("8")
+    }
+
+    @Test
+    fun `a directory that is not a jdk yields no version rather than a wrong one`(
+        @TempDir tmp: Path,
+    ) {
+        val notAJdk = tmp.resolve("nope").also { it.createDirectory() }
+
+        assertThat(service().javaMajorOf(notAJdk.toFile())).isNull()
+    }
+
+    @Test
+    fun `an unavailable jdk is refused with the places that were searched`() {
+        assertThatThrownBy { service().resolveJavaHome("3") }
+            .hasMessageContaining("No JDK 3 found")
+    }
+
+    private fun service() = CassandraBuildService(EventBus())
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/DefaultStressJobServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/DefaultStressJobServiceTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.koin.core.module.Module
 import org.koin.dsl.module
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -24,6 +25,7 @@ import org.mockito.kotlin.whenever
 class DefaultStressJobServiceTest : BaseKoinTest() {
     private lateinit var service: DefaultStressJobService
     private lateinit var mockK8sService: K8sService
+    private lateinit var mockEcrPullSecrets: EcrPullSecretService
 
     override fun additionalTestModules(): List<Module> =
         listOf(
@@ -64,6 +66,9 @@ class DefaultStressJobServiceTest : BaseKoinTest() {
     @BeforeEach
     fun setup() {
         mockK8sService = getKoin().get()
+        // The default stress image is public, so no pull secret is involved.
+        mockEcrPullSecrets = mock()
+        whenever(mockEcrPullSecrets.ensureFor(any(), any(), any())).thenReturn("")
         val clusterStateManager: ClusterStateManager = getKoin().get()
         service =
             DefaultStressJobService(
@@ -72,6 +77,7 @@ class DefaultStressJobServiceTest : BaseKoinTest() {
                 com.rustyrazorblade.easydblab.events
                     .EventBus(),
                 getKoin().get(),
+                mockEcrPullSecrets,
             )
     }
 

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/EcrPullSecretServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/EcrPullSecretServiceTest.kt
@@ -1,0 +1,135 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import io.fabric8.kubernetes.api.model.Secret
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import software.amazon.awssdk.services.ecr.EcrClient
+import software.amazon.awssdk.services.ecr.model.AuthorizationData
+import software.amazon.awssdk.services.ecr.model.GetAuthorizationTokenResponse
+import java.util.Base64
+
+class EcrPullSecretServiceTest {
+    private val controlHost =
+        ClusterHost(
+            publicIp = "54.1.2.3",
+            privateIp = "10.0.1.1",
+            alias = "control0",
+            availabilityZone = "us-west-2a",
+            instanceId = "i-control0",
+        )
+
+    private val ecrImage = "102382809497.dkr.ecr.us-west-2.amazonaws.com/rustyrazorblade/cassandra-easy-stress:mybranch"
+
+    @Test
+    fun `an ECR image is recognised`() {
+        assertThat(service().isEcrImage(ecrImage)).isTrue()
+    }
+
+    @Test
+    fun `images on other registries are not mistaken for ECR`() {
+        val svc = service()
+
+        assertThat(svc.isEcrImage("ghcr.io/apache/cassandra-easy-stress:latest")).isFalse()
+        assertThat(svc.isEcrImage("otel/opentelemetry-collector-contrib:latest")).isFalse()
+        // Looks ECR-ish but is not: a registry named to resemble one must not get AWS credentials.
+        assertThat(svc.isEcrImage("dkr.ecr.example.com/thing:1")).isFalse()
+        assertThat(svc.isEcrImage("myrepo.amazonaws.com.evil.test/thing:1")).isFalse()
+    }
+
+    @Test
+    fun `a non-ECR image needs no secret and costs no AWS call`() {
+        val ecr = mock<EcrClient>()
+        val k8s = mock<K8sService>()
+
+        val name = EcrPullSecretService(k8s, ecr).ensureFor(controlHost, "ghcr.io/apache/x:latest", "default")
+
+        assertThat(name).isEmpty()
+        verify(ecr, never()).getAuthorizationToken()
+        verify(k8s, never()).applyResource(any(), any())
+    }
+
+    @Test
+    fun `an ECR image yields a dockerconfigjson secret the pod can use`() {
+        val k8s = mock<K8sService>()
+        whenever(k8s.applyResource(any(), any())).thenReturn(Result.success(Unit))
+        val captor = argumentCaptor<Secret>()
+
+        val name = EcrPullSecretService(k8s, ecrClientReturning("AWS:s3cr3t")).ensureFor(controlHost, ecrImage, "default")
+
+        assertThat(name).isEqualTo(EcrPullSecretService.SECRET_NAME)
+        verify(k8s).applyResource(eq(controlHost), captor.capture())
+
+        val secret = captor.firstValue
+        assertThat(secret.type).isEqualTo("kubernetes.io/dockerconfigjson")
+        assertThat(secret.metadata.namespace).isEqualTo("default")
+
+        val config =
+            Json
+                .parseToJsonElement(String(Base64.getDecoder().decode(secret.data[".dockerconfigjson"])))
+                .jsonObject["auths"]!!
+                .jsonObject
+        // Keyed by registry host only: a key carrying the image path would not match on pull.
+        val registry = "102382809497.dkr.ecr.us-west-2.amazonaws.com"
+        assertThat(config.keys).containsExactly(registry)
+        assertThat(config[registry]!!.jsonObject["username"]!!.jsonPrimitive.content).isEqualTo("AWS")
+        // The password is the half after the colon, not the whole decoded token.
+        assertThat(config[registry]!!.jsonObject["password"]!!.jsonPrimitive.content).isEqualTo("s3cr3t")
+    }
+
+    @Test
+    fun `a password containing a colon survives intact`() {
+        val k8s = mock<K8sService>()
+        whenever(k8s.applyResource(any(), any())).thenReturn(Result.success(Unit))
+        val captor = argumentCaptor<Secret>()
+
+        EcrPullSecretService(k8s, ecrClientReturning("AWS:pa:ss:word")).ensureFor(controlHost, ecrImage, "default")
+
+        verify(k8s).applyResource(any(), captor.capture())
+        val config =
+            Json
+                .parseToJsonElement(String(Base64.getDecoder().decode(captor.firstValue.data[".dockerconfigjson"])))
+                .jsonObject["auths"]!!
+                .jsonObject
+                .values
+                .first()
+                .jsonObject
+        assertThat(config["password"]!!.jsonPrimitive.content).isEqualTo("pa:ss:word")
+    }
+
+    @Test
+    fun `the secret is written to the namespace it was asked for`() {
+        val k8s = mock<K8sService>()
+        whenever(k8s.applyResource(any(), any())).thenReturn(Result.success(Unit))
+        val captor = argumentCaptor<Secret>()
+
+        EcrPullSecretService(k8s, ecrClientReturning("AWS:x")).ensureFor(controlHost, ecrImage, "observability")
+
+        verify(k8s).applyResource(any(), captor.capture())
+        assertThat(captor.firstValue.metadata.namespace).isEqualTo("observability")
+    }
+
+    private fun service() = EcrPullSecretService(mock(), mock())
+
+    private fun ecrClientReturning(decodedToken: String): EcrClient {
+        val encoded = Base64.getEncoder().encodeToString(decodedToken.toByteArray())
+        val ecr = mock<EcrClient>()
+        whenever(ecr.getAuthorizationToken()).thenReturn(
+            GetAuthorizationTokenResponse
+                .builder()
+                .authorizationData(AuthorizationData.builder().authorizationToken(encoded).build())
+                .build(),
+        )
+        return ecr
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/ServicesModuleTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/ServicesModuleTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module
 import org.mockito.kotlin.mock
+import software.amazon.awssdk.services.ecr.EcrClient
 
 /**
  * Verifies the Koin wiring declared in [servicesModule] can actually construct services whose
@@ -34,6 +35,7 @@ class ServicesModuleTest {
             single<ClusterStateManager> { mock() }
             single { EventBus() }
             single<User> { mock() }
+            single<EcrClient> { mock() }
         }
 
     @Test

--- a/test-plans/cassandra-build-s3-ecr-stress-validation.md
+++ b/test-plans/cassandra-build-s3-ecr-stress-validation.md
@@ -1,0 +1,249 @@
+# Lab Plan: `cassandra build` S3 install + ECR stress image
+
+## Objective
+
+Prove the two seams on branch `cassandra-build-s3` that unit tests cannot reach, because both only
+execute on a real cluster node:
+
+1. **S3 install path** (commit `27d0b39c`) — a Cassandra built locally by `cassandra build` and
+   published to the account bucket is discovered by listing S3, and is fetched by each node over
+   `s3://` using its instance profile through the new `cached_fetch` branch.
+2. **ECR pull secret** (commit `bd94fa8a`) — `cassandra stress --image <ECR image>` pulls from the
+   account's ECR, which was impossible before `EcrPullSecretService` was wired into the stress path.
+
+Success is specific: the install log shows `s3 fetch:` (not `cache miss` + curl), the build lands on
+**every** db node with `java: 21` recorded, and the stress pod reaches `Running` rather than
+`ImagePullBackOff`. Anything else is a failure of the code under test.
+
+Secondary, and the reason for the custom stress image: observe whether the rate-limiter optimizer's
+rebuilt control loop converges against a 20 ms read/write latency target at 30k ops/s.
+
+## Cluster Name
+
+cassandra-build-s3-ecr
+
+## Datacenters
+
+single
+
+## Environment
+
+3 db nodes + 1 stress node, `i4i.xlarge`, us-west-2. Local NVMe, so no EBS configuration.
+`AWS_PROFILE=sandbox-admin` for any direct AWS CLI calls.
+
+**Artifact 1 — Cassandra build under test** (already published; verified present in S3):
+
+| | |
+|---|---|
+| Build name | `6.0-alpha3-cursor-bti-20260905-b8c4c07-jdk21` |
+| Location | `s3://easy-db-lab-61e80d2c-634a-49d3-8333-3d2758000d9d/cassandra-builds/<build name>/` |
+| base.version | 6.0-alpha3 |
+| Git sha | `b8c4c0766b` on `21460-cursor-bti`, **dirty tree (14 modified files)** |
+| Build JDK | 21 |
+| Size | 70 MiB |
+
+**Artifact 2 — stress image under test** (already published; verified present in ECR):
+
+```
+102382809497.dkr.ecr.us-west-2.amazonaws.com/rustyrazorblade/cassandra-easy-stress:optimizer-latency-signal
+```
+
+From `rustyrazorblade/cassandra-easy-stress` commit `970d58c`, *"Fix the rate limiter optimizer's
+control loop"*.
+
+## Steps
+
+### 1. Provision
+
+3 db + 1 stress node. Nothing else is installed; the AMI's baked Cassandra versions are irrelevant
+here beyond giving `cassandra list` something to contrast against.
+
+```bash
+$EDB init --db.count 3 --app.count 1 --db.instance-type i4i.xlarge --app.instance-type i4i.xlarge --up cassandra-build-s3-ecr
+```
+
+### 2. The published build is discovered by listing S3
+
+This is the catalog-discovery check. The build was never declared in any local yaml — if it appears,
+it can only have come from listing the bucket.
+
+```bash
+$EDB cassandra list
+```
+
+**Pass:** `6.0-alpha3-cursor-bti-20260905-b8c4c07-jdk21` is listed, marked `(build, not installed)`.
+**Fail:** absent, or listed without the marker (which would mean it was mistaken for an installed
+version).
+
+### 3. Install it by name, and prove the fetch came from S3
+
+No `--url` and no `--java`: every parameter comes from the manifest in S3. Passing either flag would
+defeat the point of the step.
+
+```bash
+$EDB cassandra install 6.0-alpha3-cursor-bti-20260905-b8c4c07-jdk21
+```
+
+**Pass:** the per-host output contains `s3 fetch: s3://easy-db-lab-.../cassandra-builds/...tar.gz`,
+and the command reports success on all three hosts.
+**Fail:** a `cache miss:` line followed by a curl download (the `s3://` branch was not taken), any
+`403`/`AccessDenied` (the instance profile was not used), or a host-level failure.
+
+Capture the install output verbatim into the journal — the `s3 fetch:` line is the single most
+important piece of evidence in this plan.
+
+### 4. The bits and the declaration landed on every node
+
+Checked on **all three** db nodes, not just the first — the install runs per host in parallel and a
+partial success is exactly the failure worth catching.
+
+```bash
+CLUSTER_DIR=$(dirname "$EDB")
+BUILD=6.0-alpha3-cursor-bti-20260905-b8c4c07-jdk21
+for h in db0 db1 db2; do
+  echo "--- $h ---"
+  ssh -F "$CLUSTER_DIR/sshConfig" $h \
+    "ls -d /usr/local/cassandra/$BUILD && grep -A3 'cursor-bti' /etc/cassandra_versions.yaml"
+done
+```
+
+**Pass:** the directory exists on all three, and each node's entry carries `java: "21"`.
+**Fail:** a missing directory on any node, or a `java` value other than 21 — the latter means the
+manifest's JDK did not propagate, and `cassandra use` would then select the wrong JDK.
+
+### 5. Activate the version
+
+```bash
+$EDB cassandra use 6.0-alpha3-cursor-bti-20260905-b8c4c07-jdk21
+
+CLUSTER_DIR=$(dirname "$EDB")
+for h in db0 db1 db2; do
+  echo -n "$h: "; ssh -F "$CLUSTER_DIR/sshConfig" $h "java -version 2>&1 | head -1"
+done
+```
+
+**Pass:** `use` succeeds on all hosts and the selected JDK reports 21.
+**Fail:** `use` errors on a missing `java`/`python` field, or a JDK other than 21 is selected.
+
+Steps 2–5 are what prove the install mechanism. They are complete on their own.
+
+### 6. Start Cassandra
+
+```bash
+$EDB cassandra start
+$EDB cassandra nt status
+```
+
+**Pass:** all three nodes UP/NORMAL.
+
+**Read a failure here carefully.** This build came off an active development branch with a dirty
+tree. A node that will not start is at least as likely to be a defect in `21460-cursor-bti` as a
+problem with the install path, and steps 3–5 have already proven the install path independently.
+Record a startup failure as a finding against the *branch*, capture
+`/var/log/cassandra/system.log`, and do not retroactively mark steps 3–5 failed. If Cassandra will
+not start, stop here and report — step 7 cannot run without a live cluster.
+
+### 7. Stress with the ECR image — the pull-secret check
+
+First a **2-minute smoke run with the identical image and flags**. It costs 2 minutes and catches
+an argument-parse failure, a driver/protocol mismatch against a 6.0 trunk build, a schema failure,
+or missing metrics — any of which would otherwise waste the full hour:
+
+```bash
+IMG=102382809497.dkr.ecr.us-west-2.amazonaws.com/rustyrazorblade/cassandra-easy-stress:optimizer-latency-signal
+
+$EDB cassandra stress start --image $IMG -- RandomPartitionAccess \
+  -d 2m -p 100k --workload.rows=10 --populate 250k --threads 4 \
+  --rate 30k --readrate 0.2 --cl LOCAL_QUORUM \
+  --maxrlat 20 --maxwlat 20
+```
+
+Only if the smoke run reaches `Running`, creates its schema, and reports traffic, start the real run:
+
+```bash
+$EDB cassandra stress start --image $IMG -- RandomPartitionAccess \
+  -d 60m -p 100k --workload.rows=10 --populate 250k --threads 4 \
+  --rate 30k --readrate 0.2 --cl LOCAL_QUORUM \
+  --maxrlat 20 --maxwlat 20
+```
+
+Immediately confirm the secret exists and is actually referenced, before waiting on the run:
+
+```bash
+$EDB cassandra stress status
+
+CLUSTER_DIR=$(dirname "$EDB")
+ssh -F "$CLUSTER_DIR/sshConfig" control0 \
+  "sudo k3s kubectl get secret ecr-pull-secret -n default"
+ssh -F "$CLUSTER_DIR/sshConfig" control0 \
+  "sudo k3s kubectl get pod -n default -l app.kubernetes.io/name=cassandra-easy-stress \
+     -o jsonpath='{.items[*].spec.imagePullSecrets[*].name}'"
+```
+
+**Pass:** the pod reaches `Running`, `ecr-pull-secret` exists in `default`, and the pod's
+`imagePullSecrets` names it.
+**Fail:** `ImagePullBackOff` or `ErrImagePull` — a hard failure of commit `bd94fa8a`. Capture
+`kubectl describe pod` for the pull error verbatim; a 401 means the secret was wrong, an absent
+secret means it was never created.
+
+**Every flag above is load-bearing. Do not simplify this command.**
+
+| Flag | Why |
+|---|---|
+| `--threads 4` | Default is 1. One generator thread cannot sustain 30k ops/s, so utilization stays below `MIN_UTILIZATION = 0.90` and the optimizer never takes its increase path — a client ceiling that is indistinguishable from a broken control loop. |
+| `-p 100k --workload.rows=10` | Shrinks the key space from 100M rows to 1M, so it is covered in about a minute. |
+| `--populate 250k` | Per thread, so 1M rows total — the whole space. Without it, reads are mostly bloom-filter misses and read p99 climbs monotonically for the entire hour. |
+| `--readrate 0.2` | `RandomPartitionAccess` inherits `getDefaultReadRate() = .01`. At the default, `--maxrlat` would be steering on 1% of operations. |
+| `--cl LOCAL_QUORUM` | Default `LOCAL_ONE` acks as soon as one replica responds, so the optimizer would happily converge on a rate at which the other two are dropping mutations and accumulating hints. |
+| `--rate 30k` | One shared `RateLimiter`, so this is the **global** total, not per-thread. |
+
+**Why populate matters more than it looks:** with both `--maxrlat` and `--maxwlat` set,
+`determineCriticalLatency()` steers on whichever of read/write is nearer its target. Against an
+uncovered key space it starts write-driven and flips to read-driven partway through the hour. That
+flip renders as oscillation in the graphs and is easily misread as a defect in the control loop
+under test.
+
+### 8. Observe the rate-limiter optimizer
+
+The optimizer is only constructed when a latency target is set (`Run.kt:476`), so `--maxrlat` /
+`--maxwlat` above are what put the code under test on the execution path.
+
+Over the 60-minute run, record from Grafana and `cassandra stress logs`:
+
+- whether the achieved rate converges, or oscillates without settling
+- how achieved read/write p99 track the 20 ms targets
+- whether the optimizer backs off when latency exceeds target, and recovers when it drops
+
+Render the relevant dashboards to `docs/images/` at roughly 15-minute intervals so the convergence
+behaviour over the full hour is visible in the report, not just its endpoint.
+
+### 9. Tear down
+
+```bash
+$EDB down --auto-approve
+```
+
+## Notes
+
+- **Steps 2–5 and step 7 are independent verdicts.** The first group validates commit `27d0b39c`,
+  step 7 validates `bd94fa8a`. Either can pass while the other fails; report them separately.
+- **The branch under test is probably not exercised by this run.** `21460-cursor-bti` is BTI /
+  cursor-compaction work, but BTI needs `storage_compatibility_mode: NONE` and
+  `sstable: selected_format: bti`, and the generated `cassandra.patch.yaml` sets neither — so this
+  runs stock 6.0-alpha3 BIG format. That is fine for validating the install seam, which is the
+  point of steps 2-5, but do not read the stress numbers as saying anything about the cursor work.
+- **Heap and GC are whatever the tarball ships.** `CassandraBuildCatalog` sets `jvmOptions = null`
+  for S3 builds and `patch-config` only merges `cassandra.yaml`, so the JVM options come entirely
+  from the build's own `conf/jvm*-server.options`. At a 20 ms p99 target on 4 vCPU, GC pauses are a
+  large fraction of what the optimizer is measuring — record the resolved flags before the run.
+- **20 ms is well past the knee** — healthy p99 here is 1-3 ms, so the loop spends the hour hunting
+  around saturation rather than converging cleanly. Deliberate, since saturation is where the fix
+  matters, but a 10 ms target would show convergence more legibly if this run is ambiguous.
+- **`:latest` in the ECR repo currently points at this branch build**, because the jib block in
+  `build.gradle.kts` hardcodes `tags = setOf("latest")`. Pin the explicit tag in every command; do
+  not rely on `:latest` meaning anything stable there.
+- The ECR authorization token expires after 12 hours. `EcrPullSecretService` rewrites the secret on
+  every submission, so a fresh run always re-mints it — but a pod restarting late in a much longer
+  soak could still hit an expired credential. Not a risk within this 60-minute run.
+- Total expected cluster time is roughly 2 hours: ~15 min provisioning, ~15 min steps 2-6, 60 min
+  stress, ~10 min teardown.


### PR DESCRIPTION
## What this adds

**`cassandra build [<dir>] --java <N>`** — builds a Cassandra checkout on your own machine and
publishes it to the profile's S3 bucket, where `cassandra install` finds it by name.

```
$ easy-db-lab cassandra build ~/dev/cassandra/21460-cursor-bti --java 21 --name cursor-bti
  built 6.0-alpha3-cursor-bti-20260905-b8c4c07-jdk21
  s3://easy-db-lab-<uuid>/cassandra-builds/<name>/

$ easy-db-lab cassandra install 6.0-alpha3-cursor-bti-20260905-b8c4c07-jdk21
```

This is the committer's inner loop, which had no supported path. `cassandra install --url --branch`
builds on every node in place, produces no artifact, and cannot build a branch that only exists
locally. The CI pipeline builds a *pushed* ref, so uncommitted work — the normal state of a branch
under development — could not be tested at all.

Also: **`cassandra stress --image` can now pull from the account's ECR**, which was impossible
before. `DefaultSidecarService` had ECR pull-secret handling; the stress path had none, so a custom
image there failed with `ImagePullBackOff`.

## Design notes

**Naming.** `<version>-[JIRA-][label-]<date>-<sha>-jdk<N>`. The version comes from `build.xml`'s
`base.version`. Nothing is inferred from the branch name — a branch convention is a habit that
changes, while a published name is permanent, so `--jira` and `--name` are the only ways anything
else enters it.

**One copy, one location.** `cassandra-builds/<name>/` holds the tarball and `manifest.json`,
nothing else. The tarball uploads before the manifest, so an interrupted publish leaves a build
that is not *listed* rather than one that is listed but cannot be installed.

**Discovery is by listing the bucket**, not a local file, so a build belongs to the profile rather
than the machine that produced it, and there is no index object to drift out of sync.

**`s3://` is handled in `cached_fetch`**, not worked around in Kotlin. curl has no `s3` protocol;
the node fetches with its instance profile and returns before the cache-population step, so no
duplicate copy is written.

**Build flags.** `-Dno-checkstyle=true` never existed in Cassandra's build.xml and has always been
a no-op. Replaced with the real `check.skip` and `ant.gen-doc.skip` at both call sites.

## Validation — real AWS cluster, 3x i4i.xlarge, us-west-2a

Every step below was run on hardware, not asserted:

| Step | Evidence |
|---|---|
| Build + publish | 70 MiB tarball + manifest in `cassandra-builds/`, manifest read back intact |
| Discovery from S3 | `cassandra list` shows it as `(build, not installed)` with no local declaration |
| Install by name | `s3 fetch: s3://.../cassandra-builds/...` on every node — no `cache miss`, no curl |
| One copy only | verified no write under `download-cache/` |
| JDK propagation | `java: "21"` in `/etc/cassandra_versions.yaml` on all three nodes |
| Activation | `cassandra use` selects JDK 21.0.12 on all three |
| Cluster health | UN/UN/UN on the custom build |
| ECR stress pull | `ecr-pull-secret` minted, pod `Running`, `pullSecrets=ecr-pull-secret` |

Two defects were found this way and could not have been found by unit tests:

1. The first implementation put the `s3://` handling in a packer script, which is baked into the
   AMI — so it worked only on a freshly-baked image and failed on every existing cluster. Surfaced
   as `curl: (1) Protocol "s3" not supported`, an error that points nowhere near its cause.
2. `build-image` bakes from `build/install/easy-db-lab/packer/`, not the working tree, so a packer
   change does not reach an AMI until `installDist` has run. Documented in CLAUDE.md.

## Tests

`cached_fetch` had no tests at all, which is why (1) reached a cluster. Nine added, stubbing `aws`
and `curl` — no network, no credentials, no node — registered as `testCacheLib`. They pin the two
behaviours that broke: an `s3://` url never reaches curl, and never touches the download cache.

Full suite green: 2612 passed, 0 failed. ktlint clean, no new detekt findings.
