### PR TITLE
fix(dashboards): declare Cassandra latency panels in ms, not µs

### DIFF
--- a/dashboards/cassandra-overview.json
+++ b/dashboards/cassandra-overview.json
@@ -278,7 +278,7 @@
               }
             ]
           },
-          "unit": "\u00b5s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -377,7 +377,7 @@
               }
             ]
           },
-          "unit": "\u00b5s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -1228,7 +1228,7 @@
               }
             ]
           },
-          "unit": "\u00b5s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -1319,7 +1319,7 @@
               }
             ]
           },
-          "unit": "\u00b5s"
+          "unit": "ms"
         },
         "overrides": []
       },

--- a/dashboards/cluster-comparison.json
+++ b/dashboards/cluster-comparison.json
@@ -32,8 +32,8 @@
             "mode": "absolute",
             "steps": [
               {"color": "green", "value": null},
-              {"color": "yellow", "value": 5000},
-              {"color": "red", "value": 20000}
+              {"color": "yellow", "value": 5},
+              {"color": "red", "value": 20}
             ]
           }
         },
@@ -49,16 +49,16 @@
           {
             "matcher": {"id": "byName", "options": "Write p99"},
             "properties": [
-              {"id": "unit", "value": "µs"},
-              {"id": "thresholds", "value": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 5000}, {"color": "red", "value": 20000}]}},
+              {"id": "unit", "value": "ms"},
+              {"id": "thresholds", "value": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 5}, {"color": "red", "value": 20}]}},
               {"id": "custom.cellOptions", "value": {"type": "color-background"}}
             ]
           },
           {
             "matcher": {"id": "byName", "options": "Read p99"},
             "properties": [
-              {"id": "unit", "value": "µs"},
-              {"id": "thresholds", "value": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 5000}, {"color": "red", "value": 20000}]}},
+              {"id": "unit", "value": "ms"},
+              {"id": "thresholds", "value": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 5}, {"color": "red", "value": 20}]}},
               {"id": "custom.cellOptions", "value": {"type": "color-background"}}
             ]
           },
@@ -455,11 +455,11 @@
             "mode": "absolute",
             "steps": [
               {"color": "green", "value": null},
-              {"color": "yellow", "value": 5000},
-              {"color": "red", "value": 20000}
+              {"color": "yellow", "value": 5},
+              {"color": "red", "value": 20}
             ]
           },
-          "unit": "µs"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -507,7 +507,7 @@
           },
           "mappings": [],
           "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
-          "unit": "µs"
+          "unit": "ms"
         },
         "overrides": [
           {
@@ -566,7 +566,7 @@
           },
           "mappings": [],
           "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
-          "unit": "µs"
+          "unit": "ms"
         },
         "overrides": [
           {
@@ -610,7 +610,7 @@
     },
     {
       "datasource": {"type": "prometheus", "uid": "${datasource}"},
-      "description": "Latency distribution shape per cluster. Y axis = latency bucket boundary (µs). Color intensity = request density. GC pauses appear as transient high-latency bands. One panel per selected cluster.",
+      "description": "Latency distribution shape per cluster. Y axis = latency bucket boundary (ms). Color intensity = request density. GC pauses appear as transient high-latency bands. One panel per selected cluster.",
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
@@ -643,7 +643,7 @@
         "legend": {"show": true},
         "rowsFrame": {"layout": "auto"},
         "tooltip": {"mode": "single", "showColorScale": false, "yHistogram": false},
-        "yAxis": {"axisPlacement": "left", "reverse": false, "unit": "µs"}
+        "yAxis": {"axisPlacement": "left", "reverse": false, "unit": "ms"}
       },
       "targets": [
         {
@@ -767,11 +767,11 @@
             "mode": "absolute",
             "steps": [
               {"color": "green", "value": null},
-              {"color": "yellow", "value": 5000},
-              {"color": "red", "value": 20000}
+              {"color": "yellow", "value": 5},
+              {"color": "red", "value": 20}
             ]
           },
-          "unit": "µs"
+          "unit": "ms"
         },
         "overrides": [
           {

--- a/openspec/changes/issue-908/proposal.md
+++ b/openspec/changes/issue-908/proposal.md
@@ -1,0 +1,35 @@
+# issue-908: Cassandra latency panels declare µs but the pipeline emits ms
+
+## Why
+
+The client-request latency panels on **Cassandra Overview** and **Cluster Comparison** declare
+their unit as microseconds (`µs`), but the values arriving from the metrics collector are
+milliseconds. Latency reads 1000x smaller than reality on the two flagship Cassandra dashboards.
+
+The owner has observed the rendered dashboards directly and confirmed the displayed values are
+impossible under a `µs` label — a client-request p99 in the tens of microseconds is below a
+single network round trip.
+
+The threshold-colored cells are broken by the same mismatch. Grafana compares thresholds against
+the raw value, so breakpoints of `5000` and `20000` — written to mean 5 ms and 20 ms under a µs
+unit — never fire at real millisecond-scale latencies.
+
+The cause is settled as collector behavior and is out of scope. The collector is being replaced
+with the OTel agent later; a pipeline-side workaround would have to be unwound as part of that
+work.
+
+## What Changes
+
+- `dashboards/cassandra-overview.json` — `fieldConfig.defaults.unit` from `µs` to `ms` on the
+  four client-request latency panels (ids 4, 5, 28, 29). No thresholds, no `min`/`max` on any of
+  them, so the unit is the whole edit.
+- `dashboards/cluster-comparison.json` — the same unit correction on all six latency panels
+  (including the heatmap Y axis and the `(µs)` in its own description prose), plus a rescale of
+  the latency thresholds by 1000 on the three panels that carry them, so yellow fires at 5 ms and
+  red at 20 ms as originally intended.
+- No PromQL expression changes. No collector, relabeling, agent-config or `packer/` changes. No
+  new panels, no restructuring, no `GrafanaDashboard` enum changes, no kit dashboard changes.
+
+User-visible effect: latency panels report true magnitudes, and threshold coloring on the Cluster
+Summary table, the Latency Percentile Ladder table and the Write p99 per Cluster timeseries
+becomes live again at its intended breakpoints.

--- a/openspec/changes/issue-908/specs/cassandra-dashboards/spec.md
+++ b/openspec/changes/issue-908/specs/cassandra-dashboards/spec.md
@@ -1,0 +1,74 @@
+# cassandra-dashboards
+
+## ADDED Requirements
+
+### Requirement: Cassandra client-request latency panels declare milliseconds
+
+The Cassandra Overview and Cluster Comparison dashboards SHALL declare their client-request latency panel units as `ms`, matching the millisecond values the metrics collector emits.
+
+#### Scenario: Cassandra Overview latency panels render in milliseconds
+
+- **WHEN** the Cassandra Overview dashboard is opened against a cluster under load
+- **THEN** Read Latency (p99 / p999), Write Latency (p99 / p999), Read p99 per Node and Write p99
+  per Node each render axis and tooltip values in `ms`
+- **AND** a p99 confirmed as roughly 4 ms via `nodetool proxyhistograms` reads as roughly 4 ms,
+  not 4 µs and not 4000 ms
+
+#### Scenario: Cluster Comparison latency panels render in milliseconds
+
+- **WHEN** the Cluster Comparison dashboard is opened
+- **THEN** the Cluster Summary table, Write p99 per Cluster, Write p50 + p99 per Cluster, Write
+  p99 Range, the Write Latency Distribution heatmap Y axis, and the Latency Percentile Ladder all
+  render in `ms`
+- **AND** no latency panel on either dashboard is left declaring microseconds
+
+#### Scenario: No microsecond unit remains in either dashboard file
+
+- **WHEN** either dashboard file is searched for a microsecond unit
+- **THEN** none is found, in either the raw UTF-8 form or the escaped form
+- **AND** this includes the microsecond reference inside the heatmap panel's own description prose
+
+### Requirement: Latency threshold breakpoints fire at their intended millisecond values
+
+Latency thresholds SHALL be expressed in the panel's declared unit so that Grafana, which
+compares thresholds against the raw value, colors cells at the intended breakpoints of 5 ms and
+20 ms.
+
+#### Scenario: Table cells color by threshold at real latencies
+
+- **WHEN** a cluster write p99 sits between 5 ms and 20 ms
+- **THEN** the Cluster Summary `Write p99` cell and the Latency Percentile Ladder cells are yellow
+- **WHEN** the write p99 exceeds 20 ms
+- **THEN** those same cells are red
+
+#### Scenario: Threshold lines on the per-cluster timeseries sit at their intended values
+
+- **WHEN** the Write p99 per Cluster timeseries is rendered
+- **THEN** its threshold lines, drawn because the panel sets `thresholdsStyle.mode` to `line`,
+  sit at 5 ms and 20 ms rather than below every real data point
+
+### Requirement: The correction is confined to the display layer
+
+The change SHALL alter only unit declarations, threshold values and the one description string,
+leaving the metrics pipeline untouched.
+
+#### Scenario: No query or pipeline change accompanies the fix
+
+- **WHEN** the resulting diff is reviewed
+- **THEN** no `targets[].expr` string has changed
+- **AND** no file under `packer/`, no OTel collector configuration and no collector builder
+  appears in it
+
+#### Scenario: The edit preserves file encoding and formatting
+
+- **WHEN** the diff is inspected
+- **THEN** only the two dashboard JSON files are modified, both still parse as JSON, and the
+  changed-line count matches the enumerated edits with no whole-file reindent
+- **AND** every remaining non-ASCII character, including the em dash in the heatmap panel title,
+  is byte-identical to before
+
+#### Scenario: The deployed dashboard is verified from Grafana
+
+- **WHEN** the change is deployed with `./gradlew installDist` followed by `grafana update-config`
+- **THEN** reading the dashboard back from the Grafana API shows the `ms` unit, confirmed from
+  Grafana itself rather than from the deploy command's success message

--- a/openspec/changes/issue-908/tasks.md
+++ b/openspec/changes/issue-908/tasks.md
@@ -1,0 +1,30 @@
+# Tasks — issue-908
+
+1. `dashboards/cassandra-overview.json` — replace the four `"unit": "\u00b5s"` declarations
+   (panel ids 4, 5, 28, 29) with `"unit": "ms"`. Byte-preserving edit only.
+2. `dashboards/cluster-comparison.json` — replace all eight raw-UTF-8 `µs` occurrences with `ms`.
+   Seven are unit declarations; the eighth is the `(µs)` inside `panels[14]`'s description prose.
+3. `dashboards/cluster-comparison.json` — rescale the latency thresholds by 1000: `5000` to `5`
+   and `20000` to `20`. Five pairs, all latency: `panels[1]` defaults plus its `Write p99` and
+   `Read p99` byName overrides, `panels[11]` defaults, and `panels[19]` defaults.
+4. Verify the diff: only these two files touched, both still parse (`jq empty`), no
+   `targets[].expr` changed, changed-line count as enumerated with no whole-file reindent, and
+   every non-ASCII byte outside the edits unchanged.
+5. Deploy to the shared `dashboard-dev` cluster — `./gradlew installDist`, then
+   `grafana update-config` from inside `clusters/dashboard-dev/` — and read the unit back from the
+   Grafana API to prove it landed. Never take that cluster down or recreate it.
+6. Capture the read-back output as PR evidence, as the `requires-aws` label requires.
+
+## Editing hazard
+
+`dashboards/CLAUDE.md` prescribes `perl -0pi -e` with `\Q...\E`. **That idiom silently no-ops on
+`cassandra-overview.json`** — Perl reads the `\u` in `\u00b5` as its titlecase escape during
+interpolation, before `\Q` applies, so the pattern degrades and matches nothing. Exit code 0, no
+error, file unchanged. Reproduced during activation. Use a literal byte replacement (the `Edit`
+tool), or escape the backslash: `s/"unit": "\\u00b5s"/"unit": "ms"/g`.
+
+Never edit these files with `jq` — it round-trips the whole document, which previously produced a
+1,644-line reindent and mangled `µ` and `—`.
+
+`git diff --stat` reports 20 changed lines as `40 +-` (insertions and deletions counted
+separately). Use `git diff --numstat` and expect `20 20`.


### PR DESCRIPTION
Closes #908

The client-request latency panels on **Cassandra Overview** and **Cluster Comparison** declared their unit as microseconds, but the values arriving from the metrics collector are milliseconds. Latency read 1000x smaller than reality on both dashboards.

Grafana compares thresholds against the **raw** value, so the `5000`/`20000` breakpoints — written to mean 5 ms and 20 ms under a microsecond unit — never fired at real latencies. Rescaling them by 1000 preserves their original meaning: yellow at 5 ms, red at 20 ms.

Display layer only. No PromQL expression changed; no collector, relabeling, agent-config or `packer/` change accompanies it.

## Changes — 20 lines across two files

**`dashboards/cassandra-overview.json`** (4 lines) — unit on panel ids 4, 5, 28, 29. No thresholds or `min`/`max` on any of them.

**`dashboards/cluster-comparison.json`** (16 lines) — unit on the Cluster Summary `Write p99` and `Read p99` overrides, Write p99 per Cluster, Write p50 + p99 per Cluster, Write p99 Range, the heatmap Y axis, and the Latency Percentile Ladder; thresholds rescaled on the three panels that carry them.

Two items were added to scope during activation, after checking the files against the issue:

- `panels[11]` was filed as "unit only" but carries `thresholdsStyle.mode: "line"`, so its `5000`/`20000` draw visible threshold lines. Left unrescaled they would have sat below every real data point.
- `panels[14]`'s own description prose named its axis in microseconds. Acceptance criterion 4 forbids any remaining microsecond reference, so it is corrected with the axis it describes.

## Verification

Diff scope — exactly the enumerated edits, no reindent:

```
$ git diff --numstat
4	4	dashboards/cassandra-overview.json
16	16	dashboards/cluster-comparison.json
```

No query touched: `git diff -U0 | grep -c 'expr'` returns `0`. No file outside these two.

Encoding intact:

```
$ grep -c 'µ' dashboards/cassandra-overview.json dashboards/cluster-comparison.json
dashboards/cassandra-overview.json:0
dashboards/cluster-comparison.json:0
$ grep -c 'u00b5' ...        -> 0, 0
$ LC_ALL=C grep -c '[^ -~]' dashboards/cassandra-overview.json   -> 0   (still pure ASCII)
$ grep -c '—' dashboards/cluster-comparison.json                 -> 21  (em dashes intact)
$ jq empty <both>                                                -> both parse
```

## AWS verification (`requires-aws`)

Deployed to the shared `dashboard-dev` cluster via `./gradlew installDist` then `grafana update-config`, and read back **from the Grafana API**, not from the deploy message.

Build picked up the edit before deploy — source and build copies byte-identical (`cmp`).

Served by Grafana after deploy:

```
Cassandra Overview
id=4   Read Latency (p99 / p999)     unit=ms
id=5   Write Latency (p99 / p999)    unit=ms
id=28  Read p99 per Node             unit=ms
id=29  Write p99 per Node            unit=ms

Cassandra Cluster Comparison
id=9   Write p99 per Cluster         unit=ms  steps=green:null,yellow:5,red:20
id=10  Write p50 + p99 per Cluster   unit=ms
id=11  Write p99 Range               unit=ms
id=16  Latency Percentile Ladder     unit=ms  steps=green:null,yellow:5,red:20
       heatmap yAxis.unit=ms
       description="... Y axis = latency bucket boundary (ms) ..."

Cluster Summary overrides
field=Write p99   unit=ms     thresholds=green:null,yellow:5,red:20
field=Read p99    unit=ms     thresholds=green:null,yellow:5,red:20
field=Error rate  unit=reqps  thresholds=green:null,red:0.001   (untouched)
```

Zero `µs` and zero `u00b5` remain in either payload Grafana returns.

Read-back provenance checked — `provisioned: false` here reflects `allowUiUpdates: true` (dashboards unlocked rather than locked), not a hand-edited copy: `provisionedExternalId` points at the provisioned file, `updatedBy` is `Anonymous` rather than a person, and `version` went 1 to 2 at the deploy timestamp.

## Notes for the reviewer

Two defects in `dashboards/CLAUDE.md` surfaced during this work. Neither is fixed here, since acceptance criteria 5 and 6 confine the diff to the two dashboard files:

- Its prescribed byte-preserving edit recipe, `perl -0pi -e` with `\Q...\E`, **silently no-ops** on escaped-unicode content such as `µ`. Perl reads the `\u` as its titlecase escape during interpolation, before `\Q` applies, so the pattern degrades and matches nothing — exit code 0, no error, file unchanged. Reproduced. The working form escapes the backslash.
- Its line 93 — "Panel units for latency must be `ms` … since the histogram buckets are in milliseconds" — sits under **Spanmetrics Metric Names** and describes `traces_spanmetrics_duration_milliseconds_bucket`, a different metric family. It reads as a general latency-unit convention and is easily mistaken for one.
