### PR TITLE
939: grafana annotate, annotations-only backup, backup-first teardown

### DIFF
--- a/dashboards/ab-comparison.json
+++ b/dashboards/ab-comparison.json
@@ -28,6 +28,25 @@
         "textFormat": "{{host_name}} restarted on build {{cassandra_build}}",
         "titleFormat": "Database restart",
         "useValueForTime": false
+      },
+      {
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": false,
+        "iconColor": "green",
+        "name": "easy-db-lab markers",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [
+            "easydblab"
+          ],
+          "type": "tags"
+        },
+        "type": "tags"
       }
     ]
   },

--- a/dashboards/cassandra-overview.json
+++ b/dashboards/cassandra-overview.json
@@ -1,6 +1,26 @@
 {
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": false,
+        "iconColor": "green",
+        "name": "easy-db-lab markers",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [
+            "easydblab"
+          ],
+          "type": "tags"
+        },
+        "type": "tags"
+      }
+    ]
   },
   "editable": true,
   "fiscalYearStartMonth": 0,

--- a/dashboards/cluster-comparison.json
+++ b/dashboards/cluster-comparison.json
@@ -1,6 +1,26 @@
 {
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": false,
+        "iconColor": "green",
+        "name": "easy-db-lab markers",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [
+            "easydblab"
+          ],
+          "type": "tags"
+        },
+        "type": "tags"
+      }
+    ]
   },
   "description": "Compare Cassandra cluster throughput, latency, and health side by side. Latency comes from the OpenTelemetry JMX agent as pre-aggregated per-node percentiles, so cluster-level latency panels report the slowest node rather than a re-aggregated quantile.",
   "editable": true,

--- a/dashboards/node-divergence.json
+++ b/dashboards/node-divergence.json
@@ -12,6 +12,25 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": false,
+        "iconColor": "green",
+        "name": "easy-db-lab markers",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [
+            "easydblab"
+          ],
+          "type": "tags"
+        },
+        "type": "tags"
       }
     ]
   },

--- a/dashboards/system-ab-comparison.json
+++ b/dashboards/system-ab-comparison.json
@@ -28,6 +28,25 @@
         "textFormat": "{{host_name}} rebooted",
         "titleFormat": "Host reboot",
         "useValueForTime": false
+      },
+      {
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": false,
+        "iconColor": "green",
+        "name": "easy-db-lab markers",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [
+            "easydblab"
+          ],
+          "type": "tags"
+        },
+        "type": "tags"
       }
     ]
   },

--- a/dashboards/system-overview.json
+++ b/dashboards/system-overview.json
@@ -1,6 +1,26 @@
 {
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": false,
+        "iconColor": "green",
+        "name": "easy-db-lab markers",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [
+            "easydblab"
+          ],
+          "type": "tags"
+        },
+        "type": "tags"
+      }
+    ]
   },
   "editable": true,
   "fiscalYearStartMonth": 0,

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -750,7 +750,7 @@ easy-db-lab dashboards upload
 
 Create a Grafana annotation on the running cluster. Use it to drop an A/B config-change marker on the dashboards' timeline; for example, before and after a Cassandra setting change.
 
-A global marker (no `--dashboard`/`--panel` scope) that carries the agreed tag renders on the core dashboards through their provisioned annotation query. The command reaches Grafana over the SOCKS proxy. If the Grafana API is unreachable, the command exits non-zero and names the endpoint.
+A plain global marker (no `--dashboard` and no `--panel` scope) is automatically tagged `easydblab`, in addition to any `--tags` you pass, so it renders on the core dashboards through their tag-filtered annotation query. A scoped marker (`--dashboard` or `--panel`) is not auto-tagged; it renders on its target dashboard. The command reaches Grafana over the SOCKS proxy. If the Grafana API is unreachable, the command exits non-zero and names the endpoint.
 
 ```bash
 easy-db-lab grafana annotate --text "raised concurrent_writes to 128" --tags config

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -173,6 +173,13 @@ easy-db-lab down [vpc-id] [options]
 | `--all` | Tear down all VPCs tagged with easy_cass_lab |
 | `--packer` | Tear down the packer infrastructure VPC |
 | `--retention-days N` | Days to retain S3 data after teardown (default: 1) |
+| `--force` | Skip the pre-teardown backup and tear down anyway |
+
+**Automatic backup before teardown.** When you tear down the current cluster, `down` first backs up the VictoriaMetrics metrics and the Grafana annotations. The metrics land in the cluster's S3 prefix; the annotations land in an account-level location that teardown does not expire. Both backups always run together, and each is retried on a transient failure. This runs before any infrastructure is removed.
+
+**Abort on backup failure.** If the backup fails, `down` aborts and removes no infrastructure. It reports the failure and leaves the cluster intact so you can fix the backup and retry. This is deliberate: the annotations and metrics are worth more than a fast teardown.
+
+**`--force` skips the backup.** Pass `--force` to skip the pre-teardown backup and tear down anyway. Use it only when the backup source is already gone, or when you do not need the data. `--force` is the sole escape from the abort-on-failure behavior.
 
 ### clean
 
@@ -734,6 +741,41 @@ Apply all Grafana dashboard manifests and the datasource ConfigMap to the K8s cl
 ```bash
 easy-db-lab dashboards upload
 ```
+
+---
+
+## Grafana Commands
+
+### grafana annotate
+
+Create a Grafana annotation on the running cluster. Use it to drop an A/B config-change marker on the dashboards' timeline; for example, before and after a Cassandra setting change.
+
+A global marker (no `--dashboard`/`--panel` scope) that carries the agreed tag renders on the core dashboards through their provisioned annotation query. The command reaches Grafana over the SOCKS proxy. If the Grafana API is unreachable, the command exits non-zero and names the endpoint.
+
+```bash
+easy-db-lab grafana annotate --text "raised concurrent_writes to 128" --tags config
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--text` | The annotation body text (required) | - |
+| `--tags` | Tags to attach; repeat the flag or comma-separate | none |
+| `--time` | Start time: `now`, a relative offset like `-30m`/`-2h`/`-1d`, an ISO-8601 instant, or epoch millis | `now` |
+| `--time-end` | Optional end time; produces a region annotation (same formats as `--time`) | none |
+| `--dashboard` | Optional dashboard UID to scope the annotation to one dashboard | all dashboards |
+| `--panel` | Optional panel id to scope the annotation to one panel | all panels |
+
+### grafana backup
+
+Back up the cluster's Grafana annotations to an account-level S3 location.
+
+The annotations are the A/B config-change markers worth keeping after the ephemeral cluster is torn down, so the artifact lands outside the per-cluster prefix that teardown expires. The command reports the resulting S3 URI on success. If no S3 bucket is configured, it fails fast with the standard "run `up` first" message.
+
+```bash
+easy-db-lab grafana backup
+```
+
+This backup also runs automatically before teardown; see [`down`](#down).
 
 ---
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -771,6 +771,8 @@ Back up the cluster's Grafana annotations to an account-level S3 location.
 
 The annotations are the A/B config-change markers worth keeping after the ephemeral cluster is torn down, so the artifact lands outside the per-cluster prefix that teardown expires. The command reports the resulting S3 URI on success. If no S3 bucket is configured, it fails fast with the standard "run `up` first" message.
 
+The backup captures up to 5000 annotations in one call. If the cluster has 5000 or more, the command fails and backs up nothing, rather than persisting the first 5000 as a complete backup. This makes a truncated backup impossible to mistake for a full one.
+
 ```bash
 easy-db-lab grafana backup
 ```

--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -116,6 +116,32 @@ Latency arrives as pre-aggregated percentile gauges read from Cassandra's own `E
 the same reservoir `nodetool proxyhistograms` prints. `histogram_quantile()` does not apply to them,
 and they cannot be re-aggregated into a cluster-wide percentile.
 
+## Annotations
+
+Annotations mark a moment on the dashboards' timeline. Use them as A/B config-change markers; for example, drop one before and one after you change a Cassandra setting, so a latency shift lines up with the change that caused it.
+
+Create an annotation with `grafana annotate`:
+
+```bash
+# A point marker at the current time
+easy-db-lab grafana annotate --text "raised concurrent_writes to 128" --tags config
+
+# A region marker spanning a window
+easy-db-lab grafana annotate --text "load test" --tags test --time -30m --time-end now
+```
+
+A global marker (no `--dashboard`/`--panel` scope) that carries the agreed tag renders on the core dashboards through their provisioned annotation query. See [Command Reference](../reference/commands.md#grafana-annotate) for all options.
+
+### Backing up annotations
+
+The cluster is ephemeral, but the annotations are worth keeping. Back them up to an account-level S3 location that teardown does not expire:
+
+```bash
+easy-db-lab grafana backup
+```
+
+This backup also runs automatically before teardown. When you run `easy-db-lab down`, the tool backs up the metrics and the annotations first, before it removes any infrastructure. If that backup fails, `down` aborts and removes nothing, so you can fix the problem and retry. Pass `--force` to skip the backup and tear down anyway. See [`down`](../reference/commands.md#down) for details.
+
 ## eBPF Observability
 
 The cluster deploys eBPF-based agents on all nodes for deep system observability:

--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -130,7 +130,7 @@ easy-db-lab grafana annotate --text "raised concurrent_writes to 128" --tags con
 easy-db-lab grafana annotate --text "load test" --tags test --time -30m --time-end now
 ```
 
-A global marker (no `--dashboard`/`--panel` scope) that carries the agreed tag renders on the core dashboards through their provisioned annotation query. See [Command Reference](../reference/commands.md#grafana-annotate) for all options.
+A plain global marker (no `--dashboard` and no `--panel` scope) is automatically tagged `easydblab`, in addition to any `--tags` you pass, so it renders on the core dashboards through their tag-filtered annotation query. A scoped marker (`--dashboard` or `--panel`) is not auto-tagged; it renders on its target dashboard. See [Command Reference](../reference/commands.md#grafana-annotate) for all options.
 
 ### Backing up annotations
 

--- a/openspec/changes/issue-939/.openspec.yaml
+++ b/openspec/changes/issue-939/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-11

--- a/openspec/changes/issue-939/ac-coverage.md
+++ b/openspec/changes/issue-939/ac-coverage.md
@@ -1,0 +1,20 @@
+# Acceptance-criteria coverage
+
+| Source | Requirement | Covering scenario(s) | Status |
+|--------|-------------|----------------------|--------|
+| AC | annotate with no --time creates an annotation at now, with confirmation identifying it | `grafana-annotations: Annotate at the current time with no explicit time` | ✅ Covered |
+| AC | annotate with explicit time + tags (and other fields) creates it at that time carrying them | `grafana-annotations: Annotate with an explicit time and tags` | ✅ Covered |
+| AC | a global tagged annotation renders on the core dashboards | `grafana-annotations: A tagged global annotation appears on a core dashboard` | ✅ Covered |
+| AC | annotate against a supported scope (global vs dashboard/panel) lands in that scope | `grafana-annotations: Annotate a specific dashboard or panel scope` | ✅ Covered |
+| AC | unreachable Grafana → clear error naming the endpoint, non-zero exit, no silent success | `grafana-annotations: Unreachable Grafana produces a non-zero exit` | ✅ Covered |
+| AC | grafana backup on UP + S3 → annotations captured to an account-level location, URI reported | `grafana-annotations: Backup uploads annotations and reports the URI` | ✅ Covered |
+| AC | grafana backup with no S3 bucket → fails fast with the "run up first" message | `grafana-annotations: Backup fails fast with no S3 bucket` | ✅ Covered |
+| AC | down auto-backup runs before any teardown; metrics + annotations always together | `cluster-lifecycle: Automatic backup runs before any infrastructure is torn down` | ✅ Covered |
+| AC | on backup failure, down aborts and removes no infrastructure, reporting the failure | `cluster-lifecycle: Backup failure aborts teardown with no infrastructure removed` | ✅ Covered |
+| AC | down --force skips the backup and tears down anyway | `cluster-lifecycle: --force skips the backup and tears down anyway` | ✅ Covered |
+| Risk | down can now fail on purpose, leaving a still-billing cluster up | `cluster-lifecycle: Backup failure aborts teardown with no infrastructure removed` (intended behavior; `--force` is the escape) | ✅ Covered |
+| Risk | global annotations do not render without a provisioned query (critic H2) | `grafana-annotations: A tagged global annotation appears on a core dashboard` (D6 provisions the query; dashboard-editor read-back guards it) | ✅ Covered |
+| Risk | backup lost to per-cluster teardown expiration (critic C1) | `grafana-annotations: Backup uploads annotations and reports the URI` (account-level location, D2) | ✅ Covered |
+| Risk | annotate silently returns 0 on failure like MetricsImport (critic H3) | `grafana-annotations: Unreachable Grafana produces a non-zero exit` (D5) | ✅ Covered |
+| Risk | teardown-path backup Job hangs on the 600s default, delaying the abort/--force decision (critic H1) | tasks.md 5.2 (short teardown-path timeout) | ⚠️ Excluded — an implementation constraint (Job timeout tuning), not an externally observable behavior; captured as a task, not a scenario |
+| Excluded | AC8 (fresh cluster + restore → annotations present) | — | ⚠️ Excluded — import/restore deferred to a follow-up issue per the owner's activate decision |

--- a/openspec/changes/issue-939/design.md
+++ b/openspec/changes/issue-939/design.md
@@ -1,0 +1,65 @@
+## Context
+
+Issue 939 adds three things that serve one goal: make A/B config-change markers survive an ephemeral cluster's teardown. The design was decided with the owner during activate; this section records the choices and, importantly, the reversal from the original grooming.
+
+The original grooming scoped a whole-`grafana.db` backup with import/restore. The owner reversed that during the design stop. The whole DB carries dashboards, datasources, and Grafana's own accounts table; the owner needs none of them, because dashboards and datasources regenerate from code on every fresh cluster. Annotations are the only work product worth preserving. So the backup captures annotations only, over the Grafana HTTP API, and import/restore is deferred to a follow-up issue.
+
+## Goals / Non-Goals
+
+Goals:
+- A `grafana annotate` command that drops a human-readable, tagged, optionally scoped marker on the timeline.
+- Global markers that actually render on the core dashboards.
+- An annotations backup that is never lost and never blocks nothing important.
+- An automatic backup at `down` that protects metrics and annotations as critical work product.
+
+Non-Goals:
+- Import / restore of annotations (fresh cluster or central Grafana). Deferred.
+- Whole-`grafana.db` backup.
+- Logs and Tempo at teardown.
+- In-CLI event-driven auto-annotation (issue 918).
+
+## Decisions
+
+### D1 — Annotations only, over HTTP (not the whole DB)
+
+Back up annotations with `GET /api/annotations`, restore-side with `POST /api/annotations` (the restore side is deferred). This is symmetric with `grafana annotate` and reuses `GrafanaDashboardService`'s injected `OkHttpClient`. It removes every hazard of a whole-DB backup at once: live-SQLite consistency, WAL sidecar handling, an `sqlite3` Job image, scale-to-0 restore choreography, and org/UID drift on a wholesale DB replace.
+
+### D2 — Account-level backup location
+
+All backups go to an account-level S3 location, keyed by cluster name and timestamp, outside the per-cluster prefix that `Down.setClusterLifecycleRule()` expires (default 1 day). This guarantees a backup is never lost to teardown expiration and is findable after the cluster is gone. This is a hard requirement, not a preference: backups are critical work product.
+
+### D3 — Backup runs first at `down`; a failure aborts teardown
+
+At `down`, the coupled metrics + annotations backup runs first, before any infrastructure is torn down. If it fails after retry, `down` aborts and removes no infrastructure. Because the backup runs before any destruction, a failure leaves the whole cluster intact — there is no partial-teardown trap on the normal path. The `--force` flag skips the backup and proceeds. This deliberately overrides the usual "never block teardown" instinct: the owner prefers a still-billing cluster over lost data.
+
+### D4 — Coupling is atomic in attempt, not in artifact
+
+The metrics and annotations backups are always attempted together — never one without the other invoked. Each is retried. The coupling lives at one call site (a `TeardownBackupService`), which keeps `Down` thin and gives the coupling one testable home.
+
+### D5 — `annotate` fails non-zero when Grafana is unreachable
+
+`grafana annotate` throws (non-zero exit) on an unreachable API, rather than following the `MetricsImport` pattern of emitting a failure event and returning 0. This is a deliberate deviation from that sibling, required by the acceptance criterion.
+
+### D6 — Provision a tag-based annotation query on the core dashboards
+
+Grafana renders an annotation on a dashboard only where the dashboard has a matching annotation query. Global tag-based annotations therefore need a provisioned, tag-filtered annotation query on the core dashboards. This change is applied through the `dashboard-editor` agent (edit → deploy → read back from Grafana), per repo rules.
+
+## Alternatives Considered
+
+- **Whole-`grafana.db` backup (original grooming, recommended by the architect).** Rejected by the owner: it drags in dashboards, datasources, and the accounts table that regenerate from code or are unneeded, and it carries live-SQLite consistency, WAL, `sqlite3`-image, and scale-to-0 restore hazards (design-critic M1/M2/M3). This was an explicit owner override of the architect's recommendation, made after seeing what the whole DB contains.
+- **`VACUUM INTO` vs SQLite online-backup vs scale-to-0 (architect's D1 options).** All moot under the annotations-only decision; there is no SQLite file to snapshot.
+- **Best-effort coupling at `down` — keep whatever backup succeeds (architect's D3 recommendation).** Rejected: the design-critic showed it contradicts "never one without the other", and the owner requires a failed backup to block teardown outright, not to proceed with a partial set.
+- **Never block teardown / exception-isolate the backup (design-critic C3).** Deliberately overridden by the owner: a failed backup must block `down`. The `--force` flag is the sole escape.
+- **Import into a central Grafana as part of 939.** Deferred to a follow-up issue at the owner's direction; the annotations-only artifact makes a later merge/append import natural.
+
+## Risks / Trade-offs
+
+- **`down` can now fail on purpose.** A backup failure leaves a still-billing cluster up. This is intended; `--force` is the documented escape. The teardown-path metrics backup Job SHOULD use a short timeout so a stuck backup does not delay the abort/`--force` decision (the standalone path may keep the longer default).
+- **Global-annotation rendering depends on the provisioned query.** If the tag-filtered query is missing or misconfigured, markers exist but do not render. The `dashboard-editor` read-back step guards this.
+- **Account-level S3 growth.** Annotations JSON is tiny, but the account-level location is never expired by cluster teardown. Acceptable; annotations are small and are the work product the owner wants kept.
+
+## Follow-up (separate issues)
+
+- Import / restore of annotations — into a fresh ephemeral cluster and, by merge/append, into a central long-lived Grafana (default local target, `--target <url>` for central, dedup on re-import). Deferred from 939.
+- `VictoriaBackupService.waitForJobCompletion` hand-rolls a `while` + `Thread.sleep` loop; the house rule is resilience4j. Not folded in — refactoring it is not small. Recommend a separate issue (design-critic / architect flag).
+- `ClusterStateManager` uses Jackson vs the kotlinx.serialization rule. Untouched here. Separate issue.

--- a/openspec/changes/issue-939/overrides.md
+++ b/openspec/changes/issue-939/overrides.md
@@ -1,0 +1,13 @@
+# Overrides and conflicts
+
+## Overrides existing behavior
+
+### cluster-lifecycle: Cluster Teardown
+
+**Currently:** "The system MUST clean up all AWS resources on cluster teardown. Data bucket cleanup MUST use lifecycle expiration rather than individual object deletion." Teardown has no backup step; it proceeds straight to resource cleanup after confirmation.
+
+**This change:** Adds a mandatory automatic backup (VictoriaMetrics + Grafana annotations, coupled) that runs BEFORE any infrastructure is torn down. A backup failure (after retry) aborts teardown with no infrastructure removed and reports the failure. A new `--force` flag skips the backup and proceeds. The existing resource-cleanup and lifecycle-expiration behavior is unchanged; the backup gate is added ahead of it.
+
+## Conflicts with other in-flight changes
+
+None found. The other open changes touch `cassandra-local-builds`, `kit-install-command`, `workload-runner`, `profile-command-group`, `setup`, and `cli-help-topics`. None touches `cluster-lifecycle` or the new `grafana-annotations` capability.

--- a/openspec/changes/issue-939/proposal.md
+++ b/openspec/changes/issue-939/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+During A/B config testing, an operator changes a database setting (say `concurrent_reads` from 64 to 128) and wants the Grafana timeline to show when and what changed. Today there is no way to mark that; a dashboard variable or a remembered time window cannot show the actual setting values. Operators need to drop a human-readable marker ("concurrent_reads 64->128") onto the time axis at the moment of the change.
+
+Grafana annotations live only in Grafana's own database on the ephemeral control node. At teardown they are lost with the node, so the marks that make an A/B comparison legible do not survive the run they describe. Backups, observations, and metrics are critical work product; the tool must never lose them to teardown. There is also no automatic metrics backup today — only config files are auto-backed-up — so metrics are lost at `down` too unless the operator remembers to act.
+
+## What Changes
+
+- Add a `grafana annotate` command under the `Grafana` parent. It POSTs an annotation to the running Grafana HTTP API (`POST /api/annotations`) on the control node, over the proxied HTTP client, exactly like `metrics backup`. It carries `@RequiresProxy` and reuses `GrafanaDashboardService`'s injected `OkHttpClient`.
+- `grafana annotate` exposes `--text`, `--tags`, `--time` (a human string converted to epoch milliseconds, defaulting to now), `--time-end` (a region annotation), and `--dashboard`/`--panel` scoping. Global annotations (no dashboard) are the primary path. On success it emits `Event.Grafana.AnnotationCreated` identifying the created annotation.
+- `grafana annotate` exits non-zero with a clear error naming the unreachable Grafana endpoint when the API cannot be reached. It does not emit a failure event and return 0.
+- Provision a tag-based annotation query on the core dashboards (via `GrafanaManifestBuilder` / the dashboard JSONs) so a global annotation carrying the agreed tag renders on the dashboards' timelines.
+- Add a `grafana backup` command that captures the Grafana annotations (`GET /api/annotations`) as a JSON artifact and uploads it to an account-level S3 location, never under a per-cluster prefix that `down` sets to expire. It reports the resulting S3 URI, and fails fast with the standard "run up first" message when no S3 bucket is configured.
+- Add an automatic backup at `down` that captures VictoriaMetrics and the Grafana annotations as one coupled operation, running before any infrastructure is torn down. The two backups are always attempted together — never one without the other. If the backup fails, `down` retries; if it still fails, `down` aborts and tears down no infrastructure, reporting the failure. `down --force` skips the backup and proceeds with teardown.
+- Update the user documentation for the new commands and the `down --force` flag.
+
+## Capabilities
+
+### New Capabilities
+- `grafana-annotations`: A `grafana annotate` command that POSTs a human-readable, optionally scoped, tagged annotation to the running Grafana API over the proxied HTTP client and exits non-zero when the API is unreachable; a `grafana backup` command that captures the annotations as JSON to an account-level S3 location; and a tag-based annotation query provisioned on the core dashboards so global annotations render on their timelines.
+
+### Modified Capabilities
+- `cluster-lifecycle`: Cluster Teardown gains an automatic metrics + annotations backup that runs before any infrastructure is torn down. A backup failure aborts teardown with no infrastructure removed; the `--force` flag skips the backup and proceeds.
+
+## Impact
+
+- New command: `commands/grafana/GrafanaAnnotate.kt` (`@RequiresProxy`, `@McpCommand`, `@RequireProfileSetup`), registered in the `Grafana` parent's `subcommands` list and the Koin commands module.
+- New command: `commands/grafana/GrafanaBackup.kt` (same annotations), delegating to a new backup service.
+- New annotation call on `services/GrafanaDashboardService.kt` (`createAnnotation`, `fetchAnnotations`), reusing its injected `OkHttpClient` and kotlinx.serialization types.
+- New `services/GrafanaAnnotationBackupService.kt` (interface + default impl) for the annotations GET → JSON → account-level S3 upload.
+- New serialization types: `GrafanaAnnotationRequest`, and the annotation response shape returned by the API.
+- New account-level S3 path helper (a sibling of the per-cluster helpers in `configuration/ClusterS3Path.kt`, but outside the prefix `Down.setClusterLifecycleRule()` expires).
+- New events: `Event.Grafana.AnnotationCreated`/`AnnotationFailed`, `Event.Backup.GrafanaAnnotationsBackupStarting`/`Complete`. Domain-typed, structured fields, no `Event.Message`/`Event.Error`.
+- New teardown wiring in `commands/Down.kt`: run the coupled backup first, add the `--force` flag, abort on backup failure. A new `TeardownBackupService` orchestrates the metrics + annotations coupling in one testable home.
+- Dashboard change (the tag-based annotation query) goes through the `dashboard-editor` agent per repo rules.
+- A PicoCLI converter for `--time` (human string to epoch millis) under `commands/converters/`.
+- Documentation: the Grafana commands reference and the teardown docs.
+- Retry uses resilience4j (`RetryUtil`), not a hand-rolled loop. K8s config uses fabric8. No SOCKS JVM globals are touched.

--- a/openspec/changes/issue-939/specs/cluster-lifecycle/spec.md
+++ b/openspec/changes/issue-939/specs/cluster-lifecycle/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Cluster Teardown
+
+The system MUST clean up all AWS resources on cluster teardown. Data bucket cleanup MUST use lifecycle expiration rather than individual object deletion.
+
+Before any infrastructure is torn down, the system MUST run an automatic backup that captures VictoriaMetrics and the Grafana annotations as one coupled operation. The two backups MUST always be attempted together — never one without the other. IF the backup fails, the system MUST retry it; IF it still fails, teardown MUST abort with no infrastructure removed, and the failure MUST be reported. The `--force` flag MUST skip the automatic backup and proceed with teardown regardless.
+
+#### Scenario: Teardown removes AWS resources
+
+- **GIVEN** a running cluster
+- **WHEN** the user tears it down with confirmation
+- **THEN** all AWS resources (EC2, NAT gateways, security groups, route tables, subnets, internet gateways, VPC) are terminated.
+
+#### Scenario: Data bucket expires via lifecycle rule
+
+- **GIVEN** a running cluster with a data bucket
+- **WHEN** the user tears it down
+- **THEN** a lifecycle expiration rule is set on the data bucket to expire all objects after the retention period.
+
+#### Scenario: Teardown of all clusters
+
+- **GIVEN** multiple clusters
+- **WHEN** the user tears down all clusters
+- **THEN** every tagged VPC and its resources are removed, and all per-cluster data buckets are deleted.
+
+#### Scenario: Teardown requires confirmation
+
+- **GIVEN** a teardown request without confirmation
+- **WHEN** the command runs
+- **THEN** the user is prompted for approval before proceeding.
+
+#### Scenario: Automatic backup runs before any infrastructure is torn down
+
+- **GIVEN** a running cluster with an S3 bucket configured
+- **WHEN** the user tears it down
+- **THEN** the metrics and annotations backup runs before any infrastructure is torn down
+- **AND** the metrics backup and the annotations backup are attempted together, never one without the other
+
+#### Scenario: Backup failure aborts teardown with no infrastructure removed
+
+- **GIVEN** a teardown in progress whose automatic backup fails after retry
+- **WHEN** the command runs without `--force`
+- **THEN** teardown aborts and no infrastructure is torn down
+- **AND** the failure is reported to the operator
+
+#### Scenario: --force skips the backup and tears down anyway
+
+- **GIVEN** a teardown request with `--force`
+- **WHEN** the command runs
+- **THEN** the automatic backup is skipped
+- **AND** teardown proceeds regardless

--- a/openspec/changes/issue-939/specs/grafana-annotations/spec.md
+++ b/openspec/changes/issue-939/specs/grafana-annotations/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Create a Grafana annotation from the CLI
+
+The system SHALL provide a `grafana annotate` command under the `Grafana` parent that POSTs an annotation to the running Grafana HTTP API (`POST /api/annotations`) on the control node, over the proxied HTTP client. The command SHALL carry `@RequiresProxy` and reuse the existing injected Grafana HTTP client. It SHALL accept `--text` (the annotation body), `--tags` (zero or more tags), `--time` (an optional time defaulting to the current time), `--time-end` (an optional end time producing a region annotation), and `--dashboard`/`--panel` scoping options. On success it SHALL emit `Event.Grafana.AnnotationCreated` identifying the created annotation.
+
+#### Scenario: Annotate at the current time with no explicit time
+
+- **WHEN** a user runs `grafana annotate --text "concurrent_reads 64->128"` against a provisioned, UP cluster with no `--time`
+- **THEN** an annotation is created at the current time
+- **AND** the operator sees confirmation identifying the created annotation
+
+#### Scenario: Annotate with an explicit time and tags
+
+- **WHEN** a user runs `grafana annotate` with an explicit `--time` and one or more `--tags` (and any other supported fields)
+- **THEN** the annotation is created at that time carrying those tags and fields
+
+#### Scenario: Annotate a specific dashboard or panel scope
+
+- **WHEN** a user runs `grafana annotate` with a supported scope (global, or a specific `--dashboard`/`--panel`)
+- **THEN** the annotation lands in that scope
+
+### Requirement: Fail non-zero when Grafana is unreachable
+
+WHEN the Grafana API cannot be reached (the control node is down, Grafana is not ready, or the proxy is not established), the `grafana annotate` command SHALL fail with a clear error naming the unreachable Grafana endpoint and SHALL exit with a non-zero status. It SHALL NOT emit a failure event and return 0, and it SHALL NOT silently succeed.
+
+#### Scenario: Unreachable Grafana produces a non-zero exit
+
+- **WHEN** a user runs `grafana annotate` and the Grafana endpoint is unreachable
+- **THEN** the command prints an error naming the unreachable Grafana endpoint
+- **AND** the command exits with a non-zero status
+- **AND** no annotation is reported as created
+
+### Requirement: Global annotations render on the core dashboards
+
+The system SHALL provision a tag-based annotation query on the core dashboards so that a global annotation (no dashboard scope) carrying the agreed tag renders on those dashboards' timelines. A global A/B marker SHALL be visible on the core dashboards without the operator manually adding an annotation query.
+
+#### Scenario: A tagged global annotation appears on a core dashboard
+
+- **WHEN** a global annotation carrying the agreed tag exists
+- **AND** a user opens a core dashboard
+- **THEN** the annotation renders on that dashboard's timeline via the provisioned tag-based annotation query
+
+### Requirement: Back up Grafana annotations to an account-level S3 location
+
+The system SHALL provide a `grafana backup` command that captures the Grafana annotations (`GET /api/annotations`) as a JSON artifact and uploads it to an account-level S3 location. The artifact SHALL NOT be written under a per-cluster prefix that cluster teardown sets to expire. On success the command SHALL report the resulting S3 URI. The command SHALL carry `@RequiresProxy` and reach the API over the proxied HTTP client.
+
+#### Scenario: Backup uploads annotations and reports the URI
+
+- **WHEN** a user runs `grafana backup` against an UP cluster with an S3 bucket configured
+- **THEN** the Grafana annotations are captured as a JSON artifact
+- **AND** the artifact is uploaded to an account-level Grafana backup location, not a per-cluster prefix subject to teardown expiration
+- **AND** the resulting S3 URI is reported
+
+#### Scenario: Backup fails fast with no S3 bucket
+
+- **WHEN** a user runs `grafana backup` with no S3 bucket configured
+- **THEN** the command fails fast with the same "run up first" message the other backups use

--- a/openspec/changes/issue-939/tasks.md
+++ b/openspec/changes/issue-939/tasks.md
@@ -20,10 +20,10 @@
 
 ## 4. `grafana backup` (annotations) to account-level S3
 
-- [ ] 4.1 Add an account-level S3 path helper (sibling of the per-cluster helpers in `configuration/ClusterS3Path.kt`, but outside the prefix `Down.setClusterLifecycleRule()` expires), keyed by cluster name + timestamp.
-- [ ] 4.2 Add `services/GrafanaAnnotationBackupService.kt` (interface + default impl): `GET /api/annotations` over the proxied client, serialize to JSON, upload to the account-level location, emit `Event.Backup.GrafanaAnnotationsBackup*`.
-- [ ] 4.3 Add `commands/grafana/GrafanaBackup.kt` (`@RequiresProxy`) delegating to the service; report the S3 URI; fail fast with the standard "run up first" message when no bucket is configured. Register it.
-- [ ] 4.4 Tests: backup uploads to the account-level location and reports the URI; no-bucket fails fast with the "run up first" message.
+- [x] 4.1 Add an account-level S3 path helper (sibling of the per-cluster helpers in `configuration/ClusterS3Path.kt`, but outside the prefix `Down.setClusterLifecycleRule()` expires), keyed by cluster name + timestamp.
+- [x] 4.2 Add `services/GrafanaAnnotationBackupService.kt` (interface + default impl): `GET /api/annotations` over the proxied client, serialize to JSON, upload to the account-level location, emit `Event.Backup.GrafanaAnnotationsBackup*`.
+- [x] 4.3 Add `commands/grafana/GrafanaBackup.kt` (`@RequiresProxy`) delegating to the service; report the S3 URI; fail fast with the standard "run up first" message when no bucket is configured. Register it.
+- [x] 4.4 Tests: backup uploads to the account-level location and reports the URI; no-bucket fails fast with the "run up first" message.
 
 ## 5. Automatic backup at `down`
 

--- a/openspec/changes/issue-939/tasks.md
+++ b/openspec/changes/issue-939/tasks.md
@@ -2,16 +2,16 @@
 
 ## 1. Grafana HTTP annotation types and service methods
 
-- [ ] 1.1 Add kotlinx.serialization types: `GrafanaAnnotationRequest` (text, tags, time?, timeEnd?, dashboardUID?, panelId?) and the annotation response shape returned by `GET`/`POST /api/annotations`.
-- [ ] 1.2 Add `createAnnotation(...)` and `fetchAnnotations(...)` to `GrafanaDashboardService`, reusing its injected `OkHttpClient`. `createAnnotation` throws on a non-2xx or unreachable endpoint with a message naming the endpoint.
-- [ ] 1.3 Add a PicoCLI converter under `commands/converters/` that parses a human `--time` string to epoch milliseconds, defaulting to now.
+- [x] 1.1 Add kotlinx.serialization types: `GrafanaAnnotationRequest` (text, tags, time?, timeEnd?, dashboardUID?, panelId?) and the annotation response shape returned by `GET`/`POST /api/annotations`.
+- [x] 1.2 Add `createAnnotation(...)` and `fetchAnnotations(...)` to `GrafanaDashboardService`, reusing its injected `OkHttpClient`. `createAnnotation` throws on a non-2xx or unreachable endpoint with a message naming the endpoint.
+- [x] 1.3 Add a PicoCLI converter under `commands/converters/` that parses a human `--time` string to epoch milliseconds, defaulting to now.
 
 ## 2. `grafana annotate` command
 
-- [ ] 2.1 Add `commands/grafana/GrafanaAnnotate.kt` (`@RequiresProxy`, `@McpCommand`, `@RequireProfileSetup`) with `--text`, `--tags`, `--time`, `--time-end`, `--dashboard`, `--panel`. Named options only.
-- [ ] 2.2 Register the command in the `Grafana` parent `subcommands` list and the Koin commands module.
-- [ ] 2.3 Emit `Event.Grafana.AnnotationCreated` (structured fields, identifying the annotation) on success; ensure a non-zero exit on an unreachable API (no failure-event-and-return-0).
-- [ ] 2.4 Tests: annotate with defaults, with explicit time + tags, with a dashboard/panel scope, and the unreachable-endpoint non-zero-exit path.
+- [x] 2.1 Add `commands/grafana/GrafanaAnnotate.kt` (`@RequiresProxy`, `@McpCommand`, `@RequireProfileSetup`) with `--text`, `--tags`, `--time`, `--time-end`, `--dashboard`, `--panel`. Named options only.
+- [x] 2.2 Register the command in the `Grafana` parent `subcommands` list and the Koin commands module.
+- [x] 2.3 Emit `Event.Grafana.AnnotationCreated` (structured fields, identifying the annotation) on success; ensure a non-zero exit on an unreachable API (no failure-event-and-return-0).
+- [x] 2.4 Tests: annotate with defaults, with explicit time + tags, with a dashboard/panel scope, and the unreachable-endpoint non-zero-exit path.
 
 ## 3. Tag-based annotation query on core dashboards
 

--- a/openspec/changes/issue-939/tasks.md
+++ b/openspec/changes/issue-939/tasks.md
@@ -35,11 +35,11 @@
 
 ## 6. Documentation
 
-- [ ] 6.1 Document `grafana annotate` and `grafana backup` in the Grafana commands reference.
-- [ ] 6.2 Document the automatic backup at `down`, the abort-on-failure behavior, and `down --force`.
+- [x] 6.1 Document `grafana annotate` and `grafana backup` in the Grafana commands reference.
+- [x] 6.2 Document the automatic backup at `down`, the abort-on-failure behavior, and `down --force`.
 
 ## 7. Validation
 
-- [ ] 7.1 `./gradlew ktlintFormat detekt` clean (detekt on JDK 21).
-- [ ] 7.2 `./gradlew test` green; `./gradlew integrationTest` green for the new K3s-backed tests.
-- [ ] 7.3 Confirm no SOCKS JVM globals are touched; the proxied client uses the per-client SOCKS path.
+- [x] 7.1 `./gradlew ktlintFormat detekt` clean (detekt on JDK 21).
+- [x] 7.2 `./gradlew test` green; `./gradlew integrationTest` green for the new K3s-backed tests.
+- [x] 7.3 Confirm no SOCKS JVM globals are touched; the proxied client uses the per-client SOCKS path.

--- a/openspec/changes/issue-939/tasks.md
+++ b/openspec/changes/issue-939/tasks.md
@@ -27,11 +27,11 @@
 
 ## 5. Automatic backup at `down`
 
-- [ ] 5.1 Add `services/TeardownBackupService.kt` that runs the metrics backup and the annotations backup as one coupled operation, retried via resilience4j (`RetryUtil`). Both always attempted together.
-- [ ] 5.2 Give the teardown-path metrics backup Job a short timeout so a stuck backup does not delay the abort/`--force` decision.
-- [ ] 5.3 Wire `commands/Down.kt`: run the coupled backup FIRST, before any infrastructure teardown and before the proxy is torn down (establish the tunnel with `SocksProxyService.ensureRunning`). On backup failure, abort with no infrastructure removed and report the failure.
-- [ ] 5.4 Add the `--force` flag to `Down` to skip the backup and proceed.
-- [ ] 5.5 Integration tests (K3s TestContainer where K8s is involved): backup runs before teardown; a failed backup aborts `down` with no infra removed; `--force` skips the backup and tears down.
+- [x] 5.1 Add `services/TeardownBackupService.kt` that runs the metrics backup and the annotations backup as one coupled operation, retried via resilience4j (`RetryUtil`). Both always attempted together.
+- [x] 5.2 Give the teardown-path metrics backup Job a short timeout so a stuck backup does not delay the abort/`--force` decision.
+- [x] 5.3 Wire `commands/Down.kt`: run the coupled backup FIRST, before any infrastructure teardown and before the proxy is torn down (establish the tunnel with `SocksProxyService.ensureRunning`). On backup failure, abort with no infrastructure removed and report the failure.
+- [x] 5.4 Add the `--force` flag to `Down` to skip the backup and proceed.
+- [x] 5.5 Integration tests (K3s TestContainer where K8s is involved): backup runs before teardown; a failed backup aborts `down` with no infra removed; `--force` skips the backup and tears down.
 
 ## 6. Documentation
 

--- a/openspec/changes/issue-939/tasks.md
+++ b/openspec/changes/issue-939/tasks.md
@@ -1,0 +1,45 @@
+# Tasks
+
+## 1. Grafana HTTP annotation types and service methods
+
+- [ ] 1.1 Add kotlinx.serialization types: `GrafanaAnnotationRequest` (text, tags, time?, timeEnd?, dashboardUID?, panelId?) and the annotation response shape returned by `GET`/`POST /api/annotations`.
+- [ ] 1.2 Add `createAnnotation(...)` and `fetchAnnotations(...)` to `GrafanaDashboardService`, reusing its injected `OkHttpClient`. `createAnnotation` throws on a non-2xx or unreachable endpoint with a message naming the endpoint.
+- [ ] 1.3 Add a PicoCLI converter under `commands/converters/` that parses a human `--time` string to epoch milliseconds, defaulting to now.
+
+## 2. `grafana annotate` command
+
+- [ ] 2.1 Add `commands/grafana/GrafanaAnnotate.kt` (`@RequiresProxy`, `@McpCommand`, `@RequireProfileSetup`) with `--text`, `--tags`, `--time`, `--time-end`, `--dashboard`, `--panel`. Named options only.
+- [ ] 2.2 Register the command in the `Grafana` parent `subcommands` list and the Koin commands module.
+- [ ] 2.3 Emit `Event.Grafana.AnnotationCreated` (structured fields, identifying the annotation) on success; ensure a non-zero exit on an unreachable API (no failure-event-and-return-0).
+- [ ] 2.4 Tests: annotate with defaults, with explicit time + tags, with a dashboard/panel scope, and the unreachable-endpoint non-zero-exit path.
+
+## 3. Tag-based annotation query on core dashboards
+
+- [ ] 3.1 Via the `dashboard-editor` agent: add a tag-filtered annotation query to the core dashboards so global annotations carrying the agreed tag render on their timelines. Follow the edit → deploy → read-back-from-Grafana sequence.
+- [ ] 3.2 Confirm a tagged global annotation renders on a core dashboard (read-back).
+
+## 4. `grafana backup` (annotations) to account-level S3
+
+- [ ] 4.1 Add an account-level S3 path helper (sibling of the per-cluster helpers in `configuration/ClusterS3Path.kt`, but outside the prefix `Down.setClusterLifecycleRule()` expires), keyed by cluster name + timestamp.
+- [ ] 4.2 Add `services/GrafanaAnnotationBackupService.kt` (interface + default impl): `GET /api/annotations` over the proxied client, serialize to JSON, upload to the account-level location, emit `Event.Backup.GrafanaAnnotationsBackup*`.
+- [ ] 4.3 Add `commands/grafana/GrafanaBackup.kt` (`@RequiresProxy`) delegating to the service; report the S3 URI; fail fast with the standard "run up first" message when no bucket is configured. Register it.
+- [ ] 4.4 Tests: backup uploads to the account-level location and reports the URI; no-bucket fails fast with the "run up first" message.
+
+## 5. Automatic backup at `down`
+
+- [ ] 5.1 Add `services/TeardownBackupService.kt` that runs the metrics backup and the annotations backup as one coupled operation, retried via resilience4j (`RetryUtil`). Both always attempted together.
+- [ ] 5.2 Give the teardown-path metrics backup Job a short timeout so a stuck backup does not delay the abort/`--force` decision.
+- [ ] 5.3 Wire `commands/Down.kt`: run the coupled backup FIRST, before any infrastructure teardown and before the proxy is torn down (establish the tunnel with `SocksProxyService.ensureRunning`). On backup failure, abort with no infrastructure removed and report the failure.
+- [ ] 5.4 Add the `--force` flag to `Down` to skip the backup and proceed.
+- [ ] 5.5 Integration tests (K3s TestContainer where K8s is involved): backup runs before teardown; a failed backup aborts `down` with no infra removed; `--force` skips the backup and tears down.
+
+## 6. Documentation
+
+- [ ] 6.1 Document `grafana annotate` and `grafana backup` in the Grafana commands reference.
+- [ ] 6.2 Document the automatic backup at `down`, the abort-on-failure behavior, and `down --force`.
+
+## 7. Validation
+
+- [ ] 7.1 `./gradlew ktlintFormat detekt` clean (detekt on JDK 21).
+- [ ] 7.2 `./gradlew test` green; `./gradlew integrationTest` green for the new K3s-backed tests.
+- [ ] 7.3 Confirm no SOCKS JVM globals are touched; the proxied client uses the per-client SOCKS path.

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaAnnotateTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaAnnotateTest.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.commands.grafana
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
@@ -142,7 +143,7 @@ class GrafanaAnnotateTest : BaseKoinTest() {
     }
 
     @Test
-    fun `annotate with explicit time and tags posts both`() {
+    fun `annotate with explicit time and tags posts both plus the global tag`() {
         mockWebServer.enqueue(MockResponse(code = 200, body = """{"id":7,"message":"Annotation added"}"""))
 
         val command = GrafanaAnnotate()
@@ -153,17 +154,37 @@ class GrafanaAnnotateTest : BaseKoinTest() {
 
         val body = Json.parseToJsonElement(requireNotNull(mockWebServer.takeRequest().body).utf8()).jsonObject
         assertThat(body["time"]?.jsonPrimitive?.content).isEqualTo("1767225600000")
+        // This annotation is global (no dashboard/panel scope), so the fixed global tag is appended
+        // to the operator's tags, preserving their order.
         val postedTags = body["tags"]?.jsonArray?.map { it.jsonPrimitive.content }
-        assertThat(postedTags).containsExactly("ab-marker", "cassandra")
+        assertThat(postedTags).containsExactly("ab-marker", "cassandra", Constants.Grafana.GLOBAL_ANNOTATION_TAG)
     }
 
     @Test
-    fun `annotate with dashboard and panel scope posts the scope fields`() {
+    fun `a global annotate auto-applies the global tag and de-dupes when the user passed it`() {
+        mockWebServer.enqueue(MockResponse(code = 200, body = """{"id":11,"message":"Annotation added"}"""))
+
+        val command = GrafanaAnnotate()
+        command.text = "global"
+        command.time = 1767225600000L
+        // The operator already passed the global tag; it must appear exactly once, not twice.
+        command.tags = listOf(Constants.Grafana.GLOBAL_ANNOTATION_TAG, "cassandra")
+        command.execute()
+
+        val body = Json.parseToJsonElement(requireNotNull(mockWebServer.takeRequest().body).utf8()).jsonObject
+        val postedTags = body["tags"]?.jsonArray?.map { it.jsonPrimitive.content }
+        assertThat(postedTags).containsExactly(Constants.Grafana.GLOBAL_ANNOTATION_TAG, "cassandra")
+        assertThat(postedTags?.count { it == Constants.Grafana.GLOBAL_ANNOTATION_TAG }).isEqualTo(1)
+    }
+
+    @Test
+    fun `annotate with dashboard and panel scope posts the scope fields and does not auto-add the global tag`() {
         mockWebServer.enqueue(MockResponse(code = 200, body = """{"id":9,"message":"Annotation added"}"""))
 
         val command = GrafanaAnnotate()
         command.text = "scoped"
         command.time = 1767225600000L
+        command.tags = listOf("cassandra")
         command.dashboardUid = "abc123"
         command.panelId = 5
         command.execute()
@@ -171,6 +192,11 @@ class GrafanaAnnotateTest : BaseKoinTest() {
         val body = Json.parseToJsonElement(requireNotNull(mockWebServer.takeRequest().body).utf8()).jsonObject
         assertThat(body["dashboardUID"]?.jsonPrimitive?.content).isEqualTo("abc123")
         assertThat(body["panelId"]?.jsonPrimitive?.content).isEqualTo("5")
+        // A scoped annotation renders on its target dashboard, so the global tag is NOT auto-added;
+        // only the operator's own tags are sent.
+        val postedTags = body["tags"]?.jsonArray?.map { it.jsonPrimitive.content }
+        assertThat(postedTags).containsExactly("cassandra")
+        assertThat(postedTags).doesNotContain(Constants.Grafana.GLOBAL_ANNOTATION_TAG)
     }
 
     @Test

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaAnnotateTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaAnnotateTest.kt
@@ -161,6 +161,22 @@ class GrafanaAnnotateTest : BaseKoinTest() {
     }
 
     @Test
+    fun `annotate with time and time-end posts a region carrying both timestamps`() {
+        mockWebServer.enqueue(MockResponse(code = 200, body = """{"id":13,"message":"Annotation added"}"""))
+
+        val command = GrafanaAnnotate()
+        command.text = "rolling restart window"
+        command.time = 1767225600000L
+        command.timeEnd = 1767229200000L
+        command.execute()
+
+        val body = Json.parseToJsonElement(requireNotNull(mockWebServer.takeRequest().body).utf8()).jsonObject
+        // A region annotation must carry both timestamps so Grafana renders it as a span, not a point.
+        assertThat(body["time"]?.jsonPrimitive?.content).isEqualTo("1767225600000")
+        assertThat(body["timeEnd"]?.jsonPrimitive?.content).isEqualTo("1767229200000")
+    }
+
+    @Test
     fun `a global annotate auto-applies the global tag and de-dupes when the user passed it`() {
         mockWebServer.enqueue(MockResponse(code = 200, body = """{"id":11,"message":"Annotation added"}"""))
 

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaAnnotateTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaAnnotateTest.kt
@@ -1,0 +1,192 @@
+package com.rustyrazorblade.easydblab.commands.grafana
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.configuration.InitConfig
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.configuration.grafana.GrafanaManifestBuilder
+import com.rustyrazorblade.easydblab.events.Event
+import com.rustyrazorblade.easydblab.events.EventBus
+import com.rustyrazorblade.easydblab.events.EventEnvelope
+import com.rustyrazorblade.easydblab.events.EventListener
+import com.rustyrazorblade.easydblab.services.DefaultGrafanaDashboardService
+import com.rustyrazorblade.easydblab.services.GrafanaDashboardService
+import com.rustyrazorblade.easydblab.services.K8sService
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * Integration tests for [GrafanaAnnotate].
+ *
+ * These drive the real [DefaultGrafanaDashboardService] against a [MockWebServer] that stands in for
+ * the control node's Grafana HTTP API. They verify the POST body the command sends for the default,
+ * explicit-time-and-tags, and dashboard/panel-scope cases, the success event, and the non-zero-exit
+ * behavior when the Grafana endpoint is unreachable.
+ */
+class GrafanaAnnotateTest : BaseKoinTest() {
+    private lateinit var mockClusterStateManager: ClusterStateManager
+    private lateinit var mockWebServer: MockWebServer
+    private val capturedEvents = mutableListOf<EventEnvelope>()
+
+    private val controlHost =
+        ClusterHost(
+            publicIp = "127.0.0.1",
+            privateIp = "10.0.1.1",
+            alias = "control0",
+            availabilityZone = "us-west-2a",
+            instanceId = "i-control",
+        )
+
+    private val testClusterState =
+        ClusterState(
+            name = "test-cluster",
+            versions = mutableMapOf(),
+            initConfig = InitConfig(region = "us-west-2"),
+            hosts = mapOf(ServerType.Control to listOf(controlHost)),
+        )
+
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                single<ClusterStateManager> { mockClusterStateManager }
+                single {
+                    val interceptor =
+                        Interceptor { chain ->
+                            val original = chain.request()
+                            val redirected =
+                                original.url
+                                    .newBuilder()
+                                    .host(mockWebServer.hostName)
+                                    .port(mockWebServer.port)
+                                    .build()
+                            chain.proceed(original.newBuilder().url(redirected).build())
+                        }
+                    OkHttpClient.Builder().addInterceptor(interceptor).build()
+                }
+                single<GrafanaDashboardService> {
+                    DefaultGrafanaDashboardService(
+                        k8sService = mock<K8sService>(),
+                        manifestBuilder = mock<GrafanaManifestBuilder>(),
+                        eventBus = get<EventBus>(),
+                        okHttpClient = get<OkHttpClient>(),
+                    )
+                }
+            },
+        )
+
+    @BeforeEach
+    fun setup() {
+        mockClusterStateManager = mock()
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+        whenever(mockClusterStateManager.load()).thenReturn(testClusterState)
+        capturedEvents.clear()
+        getKoin().get<EventBus>().addListener(
+            object : EventListener {
+                override fun onEvent(envelope: EventEnvelope) {
+                    capturedEvents.add(envelope)
+                }
+
+                override fun close() = Unit
+            },
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mockWebServer.close()
+    }
+
+    @Test
+    fun `annotate with default time posts text and current time and emits event`() {
+        mockWebServer.enqueue(MockResponse(code = 200, body = """{"id":42,"message":"Annotation added"}"""))
+
+        val before = System.currentTimeMillis()
+        val command = GrafanaAnnotate()
+        command.text = "concurrent_reads 64->128"
+        command.time = System.currentTimeMillis()
+        command.execute()
+        val after = System.currentTimeMillis()
+
+        val request = mockWebServer.takeRequest()
+        assertThat(request.url.encodedPath).isEqualTo("/api/annotations")
+        assertThat(request.method).isEqualTo("POST")
+
+        val body = Json.parseToJsonElement(requireNotNull(request.body).utf8()).jsonObject
+        assertThat(body["text"]?.jsonPrimitive?.content).isEqualTo("concurrent_reads 64->128")
+        val postedTime = body["time"]?.jsonPrimitive?.content?.toLong()
+        assertThat(postedTime).isBetween(before, after)
+        // Null-valued scope fields must be omitted from the wire payload.
+        assertThat(body.keys).doesNotContain("timeEnd", "dashboardUID", "panelId")
+
+        val created = capturedEvents.map { it.event }.filterIsInstance<Event.Grafana.AnnotationCreated>()
+        assertThat(created).singleElement()
+        assertThat(created.first().id).isEqualTo(42L)
+    }
+
+    @Test
+    fun `annotate with explicit time and tags posts both`() {
+        mockWebServer.enqueue(MockResponse(code = 200, body = """{"id":7,"message":"Annotation added"}"""))
+
+        val command = GrafanaAnnotate()
+        command.text = "restart"
+        command.time = 1767225600000L
+        command.tags = listOf("ab-marker", "cassandra")
+        command.execute()
+
+        val body = Json.parseToJsonElement(requireNotNull(mockWebServer.takeRequest().body).utf8()).jsonObject
+        assertThat(body["time"]?.jsonPrimitive?.content).isEqualTo("1767225600000")
+        val postedTags = body["tags"]?.jsonArray?.map { it.jsonPrimitive.content }
+        assertThat(postedTags).containsExactly("ab-marker", "cassandra")
+    }
+
+    @Test
+    fun `annotate with dashboard and panel scope posts the scope fields`() {
+        mockWebServer.enqueue(MockResponse(code = 200, body = """{"id":9,"message":"Annotation added"}"""))
+
+        val command = GrafanaAnnotate()
+        command.text = "scoped"
+        command.time = 1767225600000L
+        command.dashboardUid = "abc123"
+        command.panelId = 5
+        command.execute()
+
+        val body = Json.parseToJsonElement(requireNotNull(mockWebServer.takeRequest().body).utf8()).jsonObject
+        assertThat(body["dashboardUID"]?.jsonPrimitive?.content).isEqualTo("abc123")
+        assertThat(body["panelId"]?.jsonPrimitive?.content).isEqualTo("5")
+    }
+
+    @Test
+    fun `unreachable Grafana fails with a non-zero exit naming the endpoint`() {
+        // Close the server so the connection is refused, simulating an unreachable Grafana.
+        mockWebServer.close()
+
+        val command = GrafanaAnnotate()
+        command.text = "unreachable"
+        command.time = System.currentTimeMillis()
+
+        assertThatThrownBy { command.execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("/api/annotations")
+
+        val created = capturedEvents.map { it.event }.filterIsInstance<Event.Grafana.AnnotationCreated>()
+        assertThat(created).isEmpty()
+    }
+}

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/GrafanaAnnotationBackupServiceTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/GrafanaAnnotationBackupServiceTest.kt
@@ -1,0 +1,122 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterS3Path
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.InitConfig
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.configuration.grafana.GrafanaManifestBuilder
+import com.rustyrazorblade.easydblab.events.EventBus
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+/**
+ * Integration tests for [DefaultGrafanaAnnotationBackupService].
+ *
+ * The service is driven against a [MockWebServer] standing in for Grafana's `GET /api/annotations`,
+ * with a captured [ObjectStore] to assert what is uploaded and where. The tests pin the account-level
+ * destination (outside any cluster prefix), the reported URI and count, and the fail-fast behavior
+ * when no S3 bucket is configured.
+ */
+class GrafanaAnnotationBackupServiceTest : BaseKoinTest() {
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var objectStore: ObjectStore
+    private lateinit var service: DefaultGrafanaAnnotationBackupService
+
+    private val controlHost =
+        ClusterHost(
+            publicIp = "127.0.0.1",
+            privateIp = "10.0.1.1",
+            alias = "control0",
+            availabilityZone = "us-west-2a",
+            instanceId = "i-control",
+        )
+
+    private fun clusterState(bucket: String?) =
+        ClusterState(
+            name = "perf-test",
+            versions = mutableMapOf(),
+            s3Bucket = bucket,
+            initConfig = InitConfig(region = "us-west-2"),
+            hosts = mapOf(ServerType.Control to listOf(controlHost)),
+        )
+
+    @BeforeEach
+    fun setup() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+        objectStore = mock()
+
+        val interceptor =
+            Interceptor { chain ->
+                val original = chain.request()
+                val redirected =
+                    original.url
+                        .newBuilder()
+                        .host(mockWebServer.hostName)
+                        .port(mockWebServer.port)
+                        .build()
+                chain.proceed(original.newBuilder().url(redirected).build())
+            }
+        val grafanaService =
+            DefaultGrafanaDashboardService(
+                k8sService = mock(),
+                manifestBuilder = mock<GrafanaManifestBuilder>(),
+                eventBus = getKoin().get<EventBus>(),
+                okHttpClient = OkHttpClient.Builder().addInterceptor(interceptor).build(),
+            )
+        service = DefaultGrafanaAnnotationBackupService(grafanaService, objectStore, getKoin().get<EventBus>())
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mockWebServer.close()
+    }
+
+    @Test
+    fun `backup uploads annotations to the account-level location and reports the URI and count`() {
+        val annotationsJson = """[{"id":1,"text":"a"},{"id":2,"text":"b"}]"""
+        mockWebServer.enqueue(MockResponse(code = 200, body = annotationsJson))
+
+        val result = service.backup(controlHost, clusterState("acct-bucket")).getOrThrow()
+
+        val contentCaptor = argumentCaptor<String>()
+        val pathCaptor = argumentCaptor<ClusterS3Path>()
+        verify(objectStore).uploadContent(contentCaptor.capture(), pathCaptor.capture())
+
+        // The exact JSON Grafana returned is uploaded verbatim.
+        assertThat(contentCaptor.firstValue).isEqualTo(annotationsJson)
+        // Account-level destination, not a per-cluster prefix that teardown expires.
+        assertThat(pathCaptor.firstValue.getKey())
+            .startsWith("grafana-annotations/perf-test/")
+            .doesNotStartWith("clusters/")
+        assertThat(result.annotationCount).isEqualTo(2)
+        assertThat(result.s3Path.toUri()).startsWith("s3://acct-bucket/grafana-annotations/perf-test/")
+
+        val request = mockWebServer.takeRequest()
+        assertThat(request.url.encodedPath).isEqualTo("/api/annotations")
+        assertThat(request.method).isEqualTo("GET")
+    }
+
+    @Test
+    fun `backup fails fast with the run-up-first message when no bucket is configured`() {
+        val result = service.backup(controlHost, clusterState(null))
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull())
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Run 'easy-db-lab up' first")
+        verify(objectStore, never()).uploadContent(org.mockito.kotlin.any(), org.mockito.kotlin.any())
+    }
+}

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/GrafanaAnnotationBackupServiceTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/GrafanaAnnotationBackupServiceTest.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.services
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterS3Path
 import com.rustyrazorblade.easydblab.configuration.ClusterState
@@ -107,6 +108,44 @@ class GrafanaAnnotationBackupServiceTest : BaseKoinTest() {
         val request = mockWebServer.takeRequest()
         assertThat(request.url.encodedPath).isEqualTo("/api/annotations")
         assertThat(request.method).isEqualTo("GET")
+    }
+
+    @Test
+    fun `backup captures more than Grafana's default page size and requests the high limit`() {
+        // 150 annotations — more than Grafana's default limit of 100. A backup that relied on the
+        // default would capture only the first 100 and report that count as complete.
+        val annotationsJson = (1..150).joinToString(",", "[", "]") { """{"id":$it,"text":"a$it"}""" }
+        mockWebServer.enqueue(MockResponse(code = 200, body = annotationsJson))
+
+        val result = service.backup(controlHost, clusterState("acct-bucket")).getOrThrow()
+
+        // All 150 are captured, not truncated to the default 100.
+        assertThat(result.annotationCount).isEqualTo(150)
+
+        // The request must ask for the high explicit limit rather than relying on Grafana's default.
+        val request = mockWebServer.takeRequest()
+        assertThat(request.url.encodedPath).isEqualTo("/api/annotations")
+        assertThat(request.url.queryParameter("limit"))
+            .isEqualTo(Constants.Grafana.ANNOTATION_FETCH_LIMIT.toString())
+    }
+
+    @Test
+    fun `a response that fills the requested limit fails rather than reporting a truncated backup`() {
+        // Exactly the requested limit came back, so more annotations may exist that this call did not
+        // return. Reporting this as a complete backup would silently drop data.
+        val fullPage =
+            (1..Constants.Grafana.ANNOTATION_FETCH_LIMIT)
+                .joinToString(",", "[", "]") { """{"id":$it}""" }
+        mockWebServer.enqueue(MockResponse(code = 200, body = fullPage))
+
+        val result = service.backup(controlHost, clusterState("acct-bucket"))
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull())
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("truncated")
+        // Nothing is uploaded, so a truncated capture is never persisted as if it were complete.
+        verify(objectStore, never()).uploadContent(org.mockito.kotlin.any(), org.mockito.kotlin.any())
     }
 
     @Test

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
@@ -495,6 +495,13 @@ object Constants {
         const val DEFAULT_METRICS_MATCH = """{__name__!=""}"""
         const val DEFAULT_LOGS_QUERY = "*"
         const val METRICS_COLLECTION_INTERVAL_SECONDS = 5L
+
+        /**
+         * Short timeout (seconds) for the metrics-backup Job on the teardown path. A stuck backup
+         * must not delay the abort/`--force` decision at `down`, so teardown uses this instead of
+         * the longer standalone default. See design decision D4 in `openspec/changes/issue-939`.
+         */
+        const val TEARDOWN_METRICS_BACKUP_TIMEOUT_SECONDS = 120L
     }
 
     // Proxy configuration

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
@@ -504,6 +504,18 @@ object Constants {
         const val TEARDOWN_METRICS_BACKUP_TIMEOUT_SECONDS = 120L
     }
 
+    // Grafana configuration
+    object Grafana {
+        /**
+         * Tag auto-applied to every GLOBAL (unscoped) annotation created via `grafana annotate`, in
+         * addition to any operator-supplied tags. The core dashboards' annotation query filters on
+         * this tag so global markers render on their timelines. Scoped annotations
+         * (`--dashboard`/`--panel`) are NOT auto-tagged; they render on their target dashboard. See
+         * design in `openspec/changes/issue-939`.
+         */
+        const val GLOBAL_ANNOTATION_TAG = "easydblab"
+    }
+
     // Proxy configuration
     object Proxy {
         const val DEFAULT_SOCKS5_PORT = 1080

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
@@ -514,6 +514,15 @@ object Constants {
          * design in `openspec/changes/issue-939`.
          */
         const val GLOBAL_ANNOTATION_TAG = "easydblab"
+
+        /**
+         * The `limit` sent on `GET /api/annotations` when backing up annotations. Grafana defaults
+         * this to 100 and gives no pagination cursor, so a backup that relied on the default would
+         * silently capture at most 100 annotations. The fetch asks for this high explicit limit
+         * instead, and fails loudly if the response fills it exactly, rather than reporting a
+         * truncated capture as a complete backup. See design in `openspec/changes/issue-939`.
+         */
+        const val ANNOTATION_FETCH_LIMIT = 5000
     }
 
     // Proxy configuration

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Down.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Down.kt
@@ -10,7 +10,9 @@ import com.rustyrazorblade.easydblab.providers.aws.DiscoveredResources
 import com.rustyrazorblade.easydblab.providers.aws.TeardownMode
 import com.rustyrazorblade.easydblab.providers.aws.TeardownResult
 import com.rustyrazorblade.easydblab.proxy.Socks5ProxyStateFile
+import com.rustyrazorblade.easydblab.proxy.SocksProxyService
 import com.rustyrazorblade.easydblab.services.TailscaleService
+import com.rustyrazorblade.easydblab.services.TeardownBackupService
 import com.rustyrazorblade.easydblab.services.aws.AwsInfrastructureService
 import com.rustyrazorblade.easydblab.services.aws.AwsS3BucketService
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -79,16 +81,31 @@ class Down : PicoBaseCommand() {
     )
     var retentionDays: Int = 1
 
+    @CommandLine.Option(
+        names = ["--force"],
+        description = ["Skip the pre-teardown metrics + annotations backup and tear down anyway"],
+    )
+    var force = false
+
     private val teardownService: AwsInfrastructureService by inject()
     private val s3BucketService: AwsS3BucketService by inject()
     private val tailscaleService: TailscaleService by inject()
     private val user: User by inject()
+    private val teardownBackupService: TeardownBackupService by inject()
+    private val socksProxyService: SocksProxyService by inject()
     private val log = KotlinLogging.logger {}
 
     override fun execute() {
         val mode = determineTeardownMode()
 
         eventBus.emit(Event.Teardown.Starting)
+
+        // Back up metrics and annotations FIRST, before any infrastructure is touched. If the
+        // backup fails, abort with no infrastructure removed so the data is not lost to teardown.
+        // Runs before the proxy is torn down; --force skips it. See design decision D3.
+        if (!backupBeforeTeardown(mode)) {
+            return
+        }
 
         // Clear JVM SOCKS proxy settings before teardown so all AWS SDK calls go directly
         // to public AWS endpoints. The control node (and its SSH tunnel) will be terminated
@@ -108,6 +125,43 @@ class Down : PicoBaseCommand() {
 
         // Report results
         reportResult(result)
+    }
+
+    /**
+     * Runs the coupled metrics + annotations backup before any teardown, and decides whether the
+     * teardown may proceed.
+     *
+     * The backup only applies to the current-cluster teardown of a running cluster: the other modes
+     * (`--all`, `--packer`, a specific VPC id, `--dry-run`) do not map to a single reachable control
+     * node, and `--force` skips it outright. When the backup runs and fails, the teardown aborts with
+     * no infrastructure removed. See design decisions D3 and D4.
+     *
+     * @return true to proceed with teardown, false to abort with nothing removed.
+     */
+    private fun backupBeforeTeardown(mode: TeardownMode): Boolean {
+        if (force || dryRun || mode != TeardownMode.CurrentCluster || !clusterStateManager.exists()) {
+            return true
+        }
+
+        val state = clusterStateManager.load()
+        if (!state.isInfrastructureUp()) {
+            return true
+        }
+
+        val controlHost = state.getControlHost() ?: return true
+
+        // Establish the SOCKS tunnel so the backup can reach the private cluster network. This runs
+        // before clearProxySystemProperties()/cleanupSocks5Proxy() tear the tunnel down.
+        socksProxyService.ensureRunning(controlHost)
+
+        eventBus.emit(Event.Teardown.BackupStarting)
+        return teardownBackupService.backupBeforeTeardown(controlHost, state).fold(
+            onSuccess = { true },
+            onFailure = { failure ->
+                eventBus.emit(Event.Teardown.BackupFailedAbort(failure.message ?: "unknown error"))
+                false
+            },
+        )
     }
 
     /**

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Down.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Down.kt
@@ -145,17 +145,26 @@ class Down : PicoBaseCommand() {
 
         val state = clusterStateManager.load()
         if (!state.isInfrastructureUp()) {
+            eventBus.emit(Event.Teardown.BackupSkipped("cluster infrastructure is not up"))
             return true
         }
 
-        val controlHost = state.getControlHost() ?: return true
-
-        // Establish the SOCKS tunnel so the backup can reach the private cluster network. This runs
-        // before clearProxySystemProperties()/cleanupSocks5Proxy() tear the tunnel down.
-        socksProxyService.ensureRunning(controlHost)
+        val controlHost = state.getControlHost()
+        if (controlHost == null) {
+            eventBus.emit(Event.Teardown.BackupSkipped("no control node found in cluster state"))
+            return true
+        }
 
         eventBus.emit(Event.Teardown.BackupStarting)
-        return teardownBackupService.backupBeforeTeardown(controlHost, state).fold(
+        // The tunnel setup and the backup are one failure boundary: a tunnel failure is a backup
+        // failure. Both are inside the runCatching so either aborts teardown with the standard
+        // "no infrastructure removed / pass --force" guidance rather than a raw stack trace. The
+        // tunnel is established here, before clearProxySystemProperties()/cleanupSocks5Proxy() tear
+        // it down.
+        return runCatching {
+            socksProxyService.ensureRunning(controlHost)
+            teardownBackupService.backupBeforeTeardown(controlHost, state).getOrThrow()
+        }.fold(
             onSuccess = { true },
             onFailure = { failure ->
                 eventBus.emit(Event.Teardown.BackupFailedAbort(failure.message ?: "unknown error"))

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/converters/PicoEpochMillisConverter.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/converters/PicoEpochMillisConverter.kt
@@ -1,0 +1,68 @@
+package com.rustyrazorblade.easydblab.commands.converters
+
+import picocli.CommandLine.ITypeConverter
+import picocli.CommandLine.TypeConversionException
+import java.time.Duration
+import java.time.Instant
+import java.time.format.DateTimeParseException
+
+/**
+ * PicoCLI converter that parses a human `--time` string to epoch milliseconds.
+ *
+ * The `grafana annotate` command places a marker on the Grafana timeline at a point in time. Grafana
+ * annotations use epoch milliseconds. This converter turns operator-friendly input into that value.
+ *
+ * Supported forms:
+ * - "now" or an empty string: the current time.
+ * - A relative offset from now: "-30m", "-2h", "-1d" (also "+" for the future).
+ * - An ISO-8601 instant: "2026-01-01T12:00:00Z".
+ * - A raw epoch-milliseconds integer: "1767225600000".
+ *
+ * The converter is deterministic per invocation; it reads the clock once when it converts.
+ */
+class PicoEpochMillisConverter : ITypeConverter<Long> {
+    override fun convert(value: String): Long {
+        val trimmed = value.trim()
+        if (trimmed.isEmpty() || trimmed.equals("now", ignoreCase = true)) {
+            return Instant.now().toEpochMilli()
+        }
+        parseRelativeOffset(trimmed)?.let { return it }
+        parseEpochMillis(trimmed)?.let { return it }
+        return parseInstant(trimmed)
+    }
+
+    private fun parseRelativeOffset(value: String): Long? {
+        val match = RELATIVE_PATTERN.matchEntire(value) ?: return null
+        val amount = match.groupValues[1].toLong()
+        val unit = match.groupValues[2]
+        val duration =
+            when (unit) {
+                "s" -> Duration.ofSeconds(amount)
+                "m" -> Duration.ofMinutes(amount)
+                "h" -> Duration.ofHours(amount)
+                "d" -> Duration.ofDays(amount)
+                else -> return null
+            }
+        return Instant.now().plus(duration).toEpochMilli()
+    }
+
+    private fun parseEpochMillis(value: String): Long? {
+        if (!value.all { it.isDigit() }) return null
+        return value.toLongOrNull()
+    }
+
+    private fun parseInstant(value: String): Long =
+        try {
+            Instant.parse(value).toEpochMilli()
+        } catch (e: DateTimeParseException) {
+            throw TypeConversionException(
+                "Cannot parse time '$value'. Use 'now', a relative offset like '-30m'/'-2h'/'-1d', " +
+                    "an ISO-8601 instant like '2026-01-01T12:00:00Z', or epoch milliseconds.",
+            ).initCause(e)
+        }
+
+    private companion object {
+        /** A signed integer followed by a unit: s (seconds), m (minutes), h (hours), d (days). */
+        val RELATIVE_PATTERN = Regex("^([+-]\\d+)([smhd])$")
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/grafana/Grafana.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/grafana/Grafana.kt
@@ -16,6 +16,7 @@ import picocli.CommandLine.Spec
     mixinStandardHelpOptions = true,
     subcommands = [
         GrafanaAnnotate::class,
+        GrafanaBackup::class,
         GrafanaInstall::class,
         GrafanaUpdateConfig::class,
     ],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/grafana/Grafana.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/grafana/Grafana.kt
@@ -15,6 +15,7 @@ import picocli.CommandLine.Spec
     description = ["Grafana operations"],
     mixinStandardHelpOptions = true,
     subcommands = [
+        GrafanaAnnotate::class,
         GrafanaInstall::class,
         GrafanaUpdateConfig::class,
     ],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaAnnotate.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaAnnotate.kt
@@ -1,5 +1,6 @@
 package com.rustyrazorblade.easydblab.commands.grafana
 
+import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.annotations.RequiresProxy
@@ -18,7 +19,8 @@ import picocli.CommandLine.Option
  *
  * Operators use this to drop an A/B config-change marker on the dashboards' timeline, for example
  * before and after changing a Cassandra setting. A global marker (no `--dashboard`/`--panel` scope)
- * carrying the agreed tag renders on the core dashboards via their provisioned annotation query.
+ * is automatically tagged with [Constants.Grafana.GLOBAL_ANNOTATION_TAG] so it renders on the core
+ * dashboards via their tag-filtered annotation query; a scoped marker renders on its target dashboard.
  *
  * The command reaches Grafana over the proxied HTTP client, so it carries `@RequiresProxy`. If the
  * Grafana API cannot be reached, [GrafanaDashboardService.createAnnotation] throws and the command
@@ -71,10 +73,12 @@ class GrafanaAnnotate : PicoBaseCommand() {
             clusterState.hosts[ServerType.Control]?.firstOrNull()
                 ?: error("No control node found in cluster state.")
 
+        val effectiveTags = effectiveTags()
+
         val annotation =
             GrafanaAnnotationRequest(
                 text = text,
-                tags = tags,
+                tags = effectiveTags,
                 time = time,
                 timeEnd = timeEnd,
                 dashboardUID = dashboardUid,
@@ -87,9 +91,24 @@ class GrafanaAnnotate : PicoBaseCommand() {
             Event.Grafana.AnnotationCreated(
                 id = response.id,
                 text = text,
-                tags = tags,
+                tags = effectiveTags,
                 time = time,
             ),
         )
+    }
+
+    /**
+     * The tags sent to Grafana. A GLOBAL annotation (no `--dashboard` and no `--panel` scope) gets
+     * the fixed global tag appended so it renders on the core dashboards' tag-filtered annotation
+     * query; the tag is de-duplicated if the operator already passed it. A scoped annotation renders
+     * on its own dashboard, so it carries only the operator's tags.
+     */
+    private fun effectiveTags(): List<String> {
+        val isGlobal = dashboardUid == null && panelId == null
+        return if (isGlobal) {
+            (tags + Constants.Grafana.GLOBAL_ANNOTATION_TAG).distinct()
+        } else {
+            tags
+        }
     }
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaAnnotate.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaAnnotate.kt
@@ -1,0 +1,95 @@
+package com.rustyrazorblade.easydblab.commands.grafana
+
+import com.rustyrazorblade.easydblab.annotations.McpCommand
+import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
+import com.rustyrazorblade.easydblab.commands.converters.PicoEpochMillisConverter
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.events.Event
+import com.rustyrazorblade.easydblab.services.GrafanaAnnotationRequest
+import com.rustyrazorblade.easydblab.services.GrafanaDashboardService
+import org.koin.core.component.inject
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+
+/**
+ * Creates a Grafana annotation on the running cluster's Grafana instance.
+ *
+ * Operators use this to drop an A/B config-change marker on the dashboards' timeline, for example
+ * before and after changing a Cassandra setting. A global marker (no `--dashboard`/`--panel` scope)
+ * carrying the agreed tag renders on the core dashboards via their provisioned annotation query.
+ *
+ * The command reaches Grafana over the proxied HTTP client, so it carries `@RequiresProxy`. If the
+ * Grafana API cannot be reached, [GrafanaDashboardService.createAnnotation] throws and the command
+ * exits non-zero, naming the unreachable endpoint. It does NOT emit a failure event and return 0.
+ */
+@McpCommand
+@RequireProfileSetup
+@RequiresProxy
+@Command(
+    name = "annotate",
+    description = ["Create a Grafana annotation (A/B config-change marker) on the cluster's Grafana"],
+    mixinStandardHelpOptions = true,
+)
+class GrafanaAnnotate : PicoBaseCommand() {
+    @Option(names = ["--text"], description = ["The annotation body text"], required = true)
+    lateinit var text: String
+
+    @Option(
+        names = ["--tags"],
+        description = ["Tags to attach to the annotation (repeat or comma-separate)"],
+        split = ",",
+    )
+    var tags: List<String> = emptyList()
+
+    @Option(
+        names = ["--time"],
+        description = ["Start time: 'now' (default), a relative offset like '-30m'/'-2h'/'-1d', an ISO-8601 instant, or epoch millis"],
+        converter = [PicoEpochMillisConverter::class],
+        defaultValue = "now",
+    )
+    var time: Long = 0
+
+    @Option(
+        names = ["--time-end"],
+        description = ["Optional end time producing a region annotation (same formats as --time)"],
+        converter = [PicoEpochMillisConverter::class],
+    )
+    var timeEnd: Long? = null
+
+    @Option(names = ["--dashboard"], description = ["Optional dashboard UID to scope the annotation to one dashboard"])
+    var dashboardUid: String? = null
+
+    @Option(names = ["--panel"], description = ["Optional panel id to scope the annotation to one panel"])
+    var panelId: Int? = null
+
+    private val grafanaDashboardService: GrafanaDashboardService by inject()
+
+    override fun execute() {
+        val controlHost =
+            clusterState.hosts[ServerType.Control]?.firstOrNull()
+                ?: error("No control node found in cluster state.")
+
+        val annotation =
+            GrafanaAnnotationRequest(
+                text = text,
+                tags = tags,
+                time = time,
+                timeEnd = timeEnd,
+                dashboardUID = dashboardUid,
+                panelId = panelId,
+            )
+
+        val response = grafanaDashboardService.createAnnotation(controlHost, annotation)
+
+        eventBus.emit(
+            Event.Grafana.AnnotationCreated(
+                id = response.id,
+                text = text,
+                tags = tags,
+                time = time,
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaBackup.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaBackup.kt
@@ -1,0 +1,41 @@
+package com.rustyrazorblade.easydblab.commands.grafana
+
+import com.rustyrazorblade.easydblab.annotations.McpCommand
+import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.services.GrafanaAnnotationBackupService
+import org.koin.core.component.inject
+import picocli.CommandLine.Command
+
+/**
+ * Backs up the cluster's Grafana annotations to an account-level S3 location.
+ *
+ * The annotations are the A/B config-change markers worth keeping after the ephemeral cluster is
+ * torn down, so the artifact lands outside the per-cluster prefix that teardown expires. The command
+ * reaches the Grafana HTTP API over the proxied client, so it carries `@RequiresProxy`.
+ *
+ * If no S3 bucket is configured, the backup fails fast with the standard "run up first" message.
+ */
+@McpCommand
+@RequireProfileSetup
+@RequiresProxy
+@Command(
+    name = "backup",
+    description = ["Back up Grafana annotations to an account-level S3 location"],
+    mixinStandardHelpOptions = true,
+)
+class GrafanaBackup : PicoBaseCommand() {
+    private val annotationBackupService: GrafanaAnnotationBackupService by inject()
+
+    override fun execute() {
+        val controlHost =
+            clusterState.hosts[ServerType.Control]?.firstOrNull()
+                ?: error("No control node found in cluster state.")
+
+        // getOrThrow so a missing bucket or an unreachable Grafana exits non-zero; the backup service
+        // emits the start/complete events and reports the resulting S3 URI on success.
+        annotationBackupService.backup(controlHost, clusterState).getOrThrow()
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterS3Path.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterS3Path.kt
@@ -51,6 +51,7 @@ data class ClusterS3Path(
         internal const val VICTORIA_LOGS_DIR = "victorialogs"
         internal const val CLICKHOUSE_BACKUPS_DIR = "clickhouse-backups"
         internal const val CASSANDRA_BUILDS_DIR = "cassandra-builds"
+        internal const val GRAFANA_ANNOTATIONS_DIR = "grafana-annotations"
 
         /**
          * Create a ClusterS3Path from ClusterState.
@@ -118,6 +119,33 @@ data class ClusterS3Path(
          * installed onto whichever clusters the profile later brings up.
          */
         fun cassandraBuildsRoot(accountBucket: String): ClusterS3Path = root(accountBucket).resolve(CASSANDRA_BUILDS_DIR)
+
+        /**
+         * Root path for Grafana annotation backups in the account bucket.
+         *
+         * Account-level rather than per-cluster: the annotations are the work product that must
+         * outlive the ephemeral cluster, so they live outside the `clusters/<name>-<id>/` prefix
+         * that `Down.setClusterLifecycleRule()` sets to expire. Callers key an artifact under this
+         * root by cluster name and timestamp; see [grafanaAnnotationsArtifact].
+         */
+        fun grafanaAnnotationsRoot(accountBucket: String): ClusterS3Path = root(accountBucket).resolve(GRAFANA_ANNOTATIONS_DIR)
+
+        /**
+         * Full path to one Grafana annotations backup artifact in the account bucket.
+         *
+         * The artifact is keyed by cluster name and an epoch-millisecond timestamp, so backups from
+         * repeated teardowns of the same cluster name never collide and remain findable after the
+         * cluster is gone.
+         *
+         * @param accountBucket The account-level S3 bucket.
+         * @param clusterName The cluster the annotations came from.
+         * @param timestampMillis The backup time in epoch milliseconds.
+         */
+        fun grafanaAnnotationsArtifact(
+            accountBucket: String,
+            clusterName: String,
+            timestampMillis: Long,
+        ): ClusterS3Path = grafanaAnnotationsRoot(accountBucket).resolve(clusterName).resolve("annotations-$timestampMillis.json")
     }
 
     // Core Path-like methods

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/di/CommandsModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/di/CommandsModule.kt
@@ -44,6 +44,7 @@ import com.rustyrazorblade.easydblab.commands.cassandra.stress.StressStop
 import com.rustyrazorblade.easydblab.commands.exec.ExecList
 import com.rustyrazorblade.easydblab.commands.exec.ExecRun
 import com.rustyrazorblade.easydblab.commands.exec.ExecStop
+import com.rustyrazorblade.easydblab.commands.grafana.GrafanaAnnotate
 import com.rustyrazorblade.easydblab.commands.grafana.GrafanaUpdateConfig
 import com.rustyrazorblade.easydblab.commands.opensearch.OpenSearchStart
 import com.rustyrazorblade.easydblab.commands.opensearch.OpenSearchStatus
@@ -120,6 +121,7 @@ val commandsModule =
         factory { StressStop() }
 
         // Grafana subcommands
+        factory { GrafanaAnnotate() }
         factory { GrafanaUpdateConfig() }
 
         // OpenSearch subcommands

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/di/CommandsModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/di/CommandsModule.kt
@@ -45,6 +45,7 @@ import com.rustyrazorblade.easydblab.commands.exec.ExecList
 import com.rustyrazorblade.easydblab.commands.exec.ExecRun
 import com.rustyrazorblade.easydblab.commands.exec.ExecStop
 import com.rustyrazorblade.easydblab.commands.grafana.GrafanaAnnotate
+import com.rustyrazorblade.easydblab.commands.grafana.GrafanaBackup
 import com.rustyrazorblade.easydblab.commands.grafana.GrafanaUpdateConfig
 import com.rustyrazorblade.easydblab.commands.opensearch.OpenSearchStart
 import com.rustyrazorblade.easydblab.commands.opensearch.OpenSearchStatus
@@ -122,6 +123,7 @@ val commandsModule =
 
         // Grafana subcommands
         factory { GrafanaAnnotate() }
+        factory { GrafanaBackup() }
         factory { GrafanaUpdateConfig() }
 
         // OpenSearch subcommands

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
@@ -2393,6 +2393,20 @@ sealed interface Event {
         ) : Grafana {
             override fun toDisplayString(): String = "Restarted $kind/$name"
         }
+
+        @Serializable
+        @SerialName("Grafana.AnnotationCreated")
+        data class AnnotationCreated(
+            val id: Long,
+            val text: String,
+            val tags: List<String>,
+            val time: Long,
+        ) : Grafana {
+            override fun toDisplayString(): String {
+                val tagPart = if (tags.isEmpty()) "" else " [${tags.joinToString(", ")}]"
+                return "Created Grafana annotation #$id at $time: \"$text\"$tagPart"
+            }
+        }
     }
 
     // =========================================================================
@@ -2584,6 +2598,24 @@ sealed interface Event {
             override fun toDisplayString(): String = "Warning: Incremental backup failed: $error"
 
             override fun isError(): Boolean = true
+        }
+
+        @Serializable
+        @SerialName("Backup.GrafanaAnnotationsBackupStarting")
+        data class GrafanaAnnotationsBackupStarting(
+            val s3Path: String,
+        ) : Backup {
+            override fun toDisplayString(): String = "Backing up Grafana annotations to $s3Path..."
+        }
+
+        @Serializable
+        @SerialName("Backup.GrafanaAnnotationsBackupComplete")
+        data class GrafanaAnnotationsBackupComplete(
+            val s3Path: String,
+            val annotationCount: Int,
+        ) : Backup {
+            override fun toDisplayString(): String =
+                "Grafana annotations backup completed ($annotationCount annotations): $s3Path"
         }
     }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
@@ -2614,8 +2614,7 @@ sealed interface Event {
             val s3Path: String,
             val annotationCount: Int,
         ) : Backup {
-            override fun toDisplayString(): String =
-                "Grafana annotations backup completed ($annotationCount annotations): $s3Path"
+            override fun toDisplayString(): String = "Grafana annotations backup completed ($annotationCount annotations): $s3Path"
         }
     }
 
@@ -3912,6 +3911,24 @@ sealed interface Event {
         @SerialName("Teardown.ClusterStateMarkedDown")
         data object ClusterStateMarkedDown : Teardown {
             override fun toDisplayString(): String = "Cluster state updated: infrastructure marked as DOWN"
+        }
+
+        @Serializable
+        @SerialName("Teardown.BackupStarting")
+        data object BackupStarting : Teardown {
+            override fun toDisplayString(): String = "Backing up metrics and annotations before teardown (pass --force to skip)..."
+        }
+
+        @Serializable
+        @SerialName("Teardown.BackupFailedAbort")
+        data class BackupFailedAbort(
+            val reason: String,
+        ) : Teardown {
+            override fun toDisplayString(): String =
+                "Pre-teardown backup failed, so no infrastructure was removed: $reason\n" +
+                    "Fix the backup and retry, or pass --force to tear down without backing up."
+
+            override fun isError(): Boolean = true
         }
     }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
@@ -3930,6 +3930,14 @@ sealed interface Event {
 
             override fun isError(): Boolean = true
         }
+
+        @Serializable
+        @SerialName("Teardown.BackupSkipped")
+        data class BackupSkipped(
+            val reason: String,
+        ) : Teardown {
+            override fun toDisplayString(): String = "Skipping the pre-teardown metrics + annotations backup: $reason"
+        }
     }
 
     // =========================================================================

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/McpToolRegistry.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/McpToolRegistry.kt
@@ -63,6 +63,7 @@ open class McpToolRegistry : KoinComponent {
                 com.rustyrazorblade.easydblab.commands.cassandra.stress.StressList::class,
                 com.rustyrazorblade.easydblab.commands.cassandra.stress.StressLogs::class,
                 com.rustyrazorblade.easydblab.commands.cassandra.stress.StressInfo::class,
+                com.rustyrazorblade.easydblab.commands.grafana.GrafanaAnnotate::class,
             )
     }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/McpToolRegistry.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/McpToolRegistry.kt
@@ -64,6 +64,7 @@ open class McpToolRegistry : KoinComponent {
                 com.rustyrazorblade.easydblab.commands.cassandra.stress.StressLogs::class,
                 com.rustyrazorblade.easydblab.commands.cassandra.stress.StressInfo::class,
                 com.rustyrazorblade.easydblab.commands.grafana.GrafanaAnnotate::class,
+                com.rustyrazorblade.easydblab.commands.grafana.GrafanaBackup::class,
             )
     }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyService.kt
@@ -300,8 +300,7 @@ class ProcessSocksProxyService(
      * The loopback addresses `ssh -D` binds: the IPv4 and IPv6 loopback. Both are resolved from their
      * literal forms, so neither depends on name resolution.
      */
-    private fun loopbackProbeAddresses(): List<InetAddress> =
-        listOf(InetAddress.getByName("127.0.0.1"), InetAddress.getByName("::1"))
+    private fun loopbackProbeAddresses(): List<InetAddress> = listOf(InetAddress.getByName("127.0.0.1"), InetAddress.getByName("::1"))
 
     private fun applySystemProperties(port: Int) {
         // Publish ONLY the port under our private property. Never set socksProxyHost/socksProxyPort:

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/GrafanaAnnotation.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/GrafanaAnnotation.kt
@@ -1,0 +1,44 @@
+package com.rustyrazorblade.easydblab.services
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Request body for `POST /api/annotations` on the Grafana HTTP API.
+ *
+ * Field names match Grafana's JSON keys exactly. Null fields are omitted on the wire so a global
+ * annotation (no dashboard/panel scope, no explicit end time) sends only the fields it sets. See
+ * the `grafana annotate` command and [GrafanaDashboardService.createAnnotation].
+ *
+ * @property text The human-readable annotation body.
+ * @property tags Zero or more tags. The core dashboards render global annotations by a tag filter.
+ * @property time Start time in epoch milliseconds.
+ * @property timeEnd Optional end time in epoch milliseconds; when set, Grafana renders a region.
+ * @property dashboardUID Optional dashboard UID to scope the annotation to one dashboard.
+ * @property panelId Optional panel id to scope the annotation to one panel.
+ */
+@Serializable
+data class GrafanaAnnotationRequest(
+    val text: String,
+    val tags: List<String> = emptyList(),
+    val time: Long,
+    val timeEnd: Long? = null,
+    @SerialName("dashboardUID")
+    val dashboardUID: String? = null,
+    val panelId: Int? = null,
+)
+
+/**
+ * Response body Grafana returns from a successful `POST /api/annotations`.
+ *
+ * Grafana replies with the created annotation's id and a confirmation message. Unknown fields are
+ * ignored on decode so a Grafana version that adds fields does not break parsing.
+ *
+ * @property id The id Grafana assigned to the created annotation.
+ * @property message Grafana's confirmation message (e.g. "Annotation added").
+ */
+@Serializable
+data class GrafanaAnnotationResponse(
+    val id: Long,
+    val message: String = "",
+)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/GrafanaAnnotationBackupService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/GrafanaAnnotationBackupService.kt
@@ -1,0 +1,90 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterS3Path
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.events.Event
+import com.rustyrazorblade.easydblab.events.EventBus
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import java.time.Instant
+
+/**
+ * Result of a Grafana annotations backup.
+ *
+ * @property s3Path The account-level S3 path where the annotations JSON was written.
+ * @property annotationCount The number of annotations captured.
+ */
+data class GrafanaAnnotationBackupResult(
+    val s3Path: ClusterS3Path,
+    val annotationCount: Int,
+)
+
+/**
+ * Service that backs up the Grafana annotations of a running cluster to an account-level S3 location.
+ *
+ * The annotations are the A/B config-change markers an operator wants to keep after the ephemeral
+ * cluster is gone. This service captures them over the Grafana HTTP API (`GET /api/annotations`, via
+ * [GrafanaDashboardService.fetchAnnotations]) and uploads the JSON verbatim to a path OUTSIDE the
+ * per-cluster prefix that teardown expires, so a backup is never lost to cluster teardown.
+ */
+interface GrafanaAnnotationBackupService {
+    /**
+     * Captures the cluster's Grafana annotations and uploads them to the account-level S3 location.
+     *
+     * @param controlHost The control node running Grafana.
+     * @param clusterState The cluster state carrying the account-level S3 bucket and cluster name.
+     * @return A [GrafanaAnnotationBackupResult] on success, or a failure Result on any error.
+     */
+    fun backup(
+        controlHost: ClusterHost,
+        clusterState: ClusterState,
+    ): Result<GrafanaAnnotationBackupResult>
+}
+
+/**
+ * Default implementation of [GrafanaAnnotationBackupService].
+ *
+ * @property grafanaDashboardService Reaches the Grafana HTTP API over the proxied client.
+ * @property objectStore Uploads the JSON artifact to S3.
+ * @property eventBus Emits backup lifecycle events.
+ */
+class DefaultGrafanaAnnotationBackupService(
+    private val grafanaDashboardService: GrafanaDashboardService,
+    private val objectStore: ObjectStore,
+    private val eventBus: EventBus,
+) : GrafanaAnnotationBackupService {
+    override fun backup(
+        controlHost: ClusterHost,
+        clusterState: ClusterState,
+    ): Result<GrafanaAnnotationBackupResult> =
+        runCatching {
+            val bucket =
+                clusterState.s3Bucket
+                    ?: error("S3 bucket not configured for cluster '${clusterState.name}'. Run 'easy-db-lab up' first.")
+
+            val artifact =
+                ClusterS3Path.grafanaAnnotationsArtifact(
+                    accountBucket = bucket,
+                    clusterName = clusterState.name,
+                    timestampMillis = Instant.now().toEpochMilli(),
+                )
+
+            eventBus.emit(Event.Backup.GrafanaAnnotationsBackupStarting(artifact.toUri()))
+
+            val annotationsJson = grafanaDashboardService.fetchAnnotations(controlHost)
+            val count = countAnnotations(annotationsJson)
+            objectStore.uploadContent(annotationsJson, artifact)
+
+            eventBus.emit(Event.Backup.GrafanaAnnotationsBackupComplete(artifact.toUri(), count))
+            GrafanaAnnotationBackupResult(s3Path = artifact, annotationCount = count)
+        }
+
+    /**
+     * Counts the annotations in Grafana's JSON response. Grafana returns a JSON array; a non-array
+     * body (unexpected) counts as zero rather than failing the backup, since the artifact is still
+     * uploaded verbatim.
+     */
+    private fun countAnnotations(json: String): Int =
+        runCatching { Json.parseToJsonElement(json).jsonArray.size }.getOrDefault(0)
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/GrafanaAnnotationBackupService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/GrafanaAnnotationBackupService.kt
@@ -85,6 +85,5 @@ class DefaultGrafanaAnnotationBackupService(
      * body (unexpected) counts as zero rather than failing the backup, since the artifact is still
      * uploaded verbatim.
      */
-    private fun countAnnotations(json: String): Int =
-        runCatching { Json.parseToJsonElement(json).jsonArray.size }.getOrDefault(0)
+    private fun countAnnotations(json: String): Int = runCatching { Json.parseToJsonElement(json).jsonArray.size }.getOrDefault(0)
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/GrafanaDashboardService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/GrafanaDashboardService.kt
@@ -18,6 +18,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.File
+import java.io.IOException
 
 /**
  * Service for managing Grafana dashboard manifests.
@@ -54,6 +55,37 @@ interface GrafanaDashboardService {
         controlHost: ClusterHost,
         folderName: String,
     ): Result<Unit>
+
+    /**
+     * Creates a Grafana annotation via `POST /api/annotations` on the control node.
+     *
+     * The call goes over the injected proxied [OkHttpClient]. It throws (it does NOT return a
+     * failure Result) on a non-2xx response or an unreachable endpoint, with a message naming the
+     * Grafana annotation endpoint. This satisfies the acceptance criterion that `grafana annotate`
+     * fails non-zero when Grafana cannot be reached.
+     *
+     * @param controlHost The control node running the Grafana instance.
+     * @param annotation The annotation to create.
+     * @return The Grafana response carrying the created annotation id.
+     * @throws IllegalStateException on a non-2xx response or an unreachable endpoint.
+     */
+    fun createAnnotation(
+        controlHost: ClusterHost,
+        annotation: GrafanaAnnotationRequest,
+    ): GrafanaAnnotationResponse
+
+    /**
+     * Fetches all Grafana annotations via `GET /api/annotations` on the control node.
+     *
+     * Returns the raw JSON response body verbatim so the backup artifact preserves exactly what
+     * Grafana returns. It throws on a non-2xx response or an unreachable endpoint, with a message
+     * naming the Grafana annotation endpoint.
+     *
+     * @param controlHost The control node running the Grafana instance.
+     * @return The raw JSON array of annotations as returned by Grafana.
+     * @throws IllegalStateException on a non-2xx response or an unreachable endpoint.
+     */
+    fun fetchAnnotations(controlHost: ClusterHost): String
 }
 
 /**
@@ -75,6 +107,16 @@ class DefaultGrafanaDashboardService(
         private const val DATASOURCES_CONFIGMAP_NAME = "grafana-datasources"
         private const val DEFAULT_NAMESPACE = "default"
         private val JSON_MEDIA_TYPE = "application/json".toMediaType()
+
+        /**
+         * JSON codec for annotation payloads. Null fields are dropped so a global annotation sends
+         * only the fields it sets, and unknown fields on decode are ignored for forward tolerance.
+         */
+        private val annotationJson =
+            Json {
+                explicitNulls = false
+                ignoreUnknownKeys = true
+            }
     }
 
     override fun createDatasourcesConfigMap(controlHost: ClusterHost): Result<Unit> {
@@ -145,6 +187,47 @@ class DefaultGrafanaDashboardService(
             }
             eventBus.emit(Event.Grafana.DashboardInstalled(title = title))
         }
+
+    override fun createAnnotation(
+        controlHost: ClusterHost,
+        annotation: GrafanaAnnotationRequest,
+    ): GrafanaAnnotationResponse {
+        val endpoint = annotationsEndpoint(controlHost)
+        val body = annotationJson.encodeToString(annotation).toRequestBody(JSON_MEDIA_TYPE)
+        val request = Request.Builder().url(endpoint).post(body).build()
+        val bodyStr =
+            try {
+                okHttpClient.newCall(request).execute().use { response ->
+                    val responseBody = response.body.string()
+                    if (!response.isSuccessful) {
+                        error("Grafana annotation API at $endpoint returned ${response.code}: $responseBody")
+                    }
+                    responseBody
+                }
+            } catch (e: IOException) {
+                throw IllegalStateException("Failed to reach Grafana annotation API at $endpoint: ${e.message}", e)
+            }
+        return annotationJson.decodeFromString<GrafanaAnnotationResponse>(bodyStr)
+    }
+
+    override fun fetchAnnotations(controlHost: ClusterHost): String {
+        val endpoint = annotationsEndpoint(controlHost)
+        val request = Request.Builder().url(endpoint).get().build()
+        return try {
+            okHttpClient.newCall(request).execute().use { response ->
+                val responseBody = response.body.string()
+                if (!response.isSuccessful) {
+                    error("Grafana annotation API at $endpoint returned ${response.code}: $responseBody")
+                }
+                responseBody
+            }
+        } catch (e: IOException) {
+            throw IllegalStateException("Failed to reach Grafana annotation API at $endpoint: ${e.message}", e)
+        }
+    }
+
+    private fun annotationsEndpoint(controlHost: ClusterHost): String =
+        "http://${controlHost.privateIp}:${Constants.K8s.GRAFANA_PORT}/api/annotations"
 
     private fun findOrCreateFolder(
         controlHost: ClusterHost,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/GrafanaDashboardService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/GrafanaDashboardService.kt
@@ -194,7 +194,12 @@ class DefaultGrafanaDashboardService(
     ): GrafanaAnnotationResponse {
         val endpoint = annotationsEndpoint(controlHost)
         val body = annotationJson.encodeToString(annotation).toRequestBody(JSON_MEDIA_TYPE)
-        val request = Request.Builder().url(endpoint).post(body).build()
+        val request =
+            Request
+                .Builder()
+                .url(endpoint)
+                .post(body)
+                .build()
         val bodyStr =
             try {
                 okHttpClient.newCall(request).execute().use { response ->
@@ -212,7 +217,12 @@ class DefaultGrafanaDashboardService(
 
     override fun fetchAnnotations(controlHost: ClusterHost): String {
         val endpoint = annotationsEndpoint(controlHost)
-        val request = Request.Builder().url(endpoint).get().build()
+        val request =
+            Request
+                .Builder()
+                .url(endpoint)
+                .get()
+                .build()
         return try {
             okHttpClient.newCall(request).execute().use { response ->
                 val responseBody = response.body.string()

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/GrafanaDashboardService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/GrafanaDashboardService.kt
@@ -13,6 +13,7 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -77,13 +78,17 @@ interface GrafanaDashboardService {
     /**
      * Fetches all Grafana annotations via `GET /api/annotations` on the control node.
      *
-     * Returns the raw JSON response body verbatim so the backup artifact preserves exactly what
-     * Grafana returns. It throws on a non-2xx response or an unreachable endpoint, with a message
-     * naming the Grafana annotation endpoint.
+     * Requests an explicit high `limit` ([Constants.Grafana.ANNOTATION_FETCH_LIMIT]) so the response
+     * is not silently capped at Grafana's default of 100. Returns the raw JSON response body verbatim
+     * so the backup artifact preserves exactly what Grafana returns. It throws on a non-2xx response
+     * or an unreachable endpoint, with a message naming the Grafana annotation endpoint. It also
+     * throws when the response fills the requested limit exactly, because more annotations may exist
+     * and a truncated capture must never be reported as a complete backup.
      *
      * @param controlHost The control node running the Grafana instance.
      * @return The raw JSON array of annotations as returned by Grafana.
-     * @throws IllegalStateException on a non-2xx response or an unreachable endpoint.
+     * @throws IllegalStateException on a non-2xx response, an unreachable endpoint, or a response that
+     *   fills the requested limit (a possible truncation).
      */
     fun fetchAnnotations(controlHost: ClusterHost): String
 }
@@ -217,23 +222,45 @@ class DefaultGrafanaDashboardService(
 
     override fun fetchAnnotations(controlHost: ClusterHost): String {
         val endpoint = annotationsEndpoint(controlHost)
+        // Grafana defaults the annotations limit to 100 and offers no pagination cursor, so a request
+        // without an explicit limit would capture at most 100 annotations. Ask for a high explicit
+        // limit so the backup captures every annotation on a normal cluster.
+        val url =
+            endpoint
+                .toHttpUrl()
+                .newBuilder()
+                .addQueryParameter("limit", Constants.Grafana.ANNOTATION_FETCH_LIMIT.toString())
+                .build()
         val request =
             Request
                 .Builder()
-                .url(endpoint)
+                .url(url)
                 .get()
                 .build()
-        return try {
-            okHttpClient.newCall(request).execute().use { response ->
-                val responseBody = response.body.string()
-                if (!response.isSuccessful) {
-                    error("Grafana annotation API at $endpoint returned ${response.code}: $responseBody")
+        val responseBody =
+            try {
+                okHttpClient.newCall(request).execute().use { response ->
+                    val body = response.body.string()
+                    if (!response.isSuccessful) {
+                        error("Grafana annotation API at $endpoint returned ${response.code}: $body")
+                    }
+                    body
                 }
-                responseBody
+            } catch (e: IOException) {
+                throw IllegalStateException("Failed to reach Grafana annotation API at $endpoint: ${e.message}", e)
             }
-        } catch (e: IOException) {
-            throw IllegalStateException("Failed to reach Grafana annotation API at $endpoint: ${e.message}", e)
+
+        // If the returned array fills the requested limit exactly, more annotations may exist that this
+        // single call did not return. Treating that as a complete backup would silently drop data, so
+        // fail loudly instead of reporting a truncated capture as success.
+        val count = runCatching { Json.parseToJsonElement(responseBody).jsonArray.size }.getOrDefault(0)
+        if (count >= Constants.Grafana.ANNOTATION_FETCH_LIMIT) {
+            error(
+                "Grafana annotation API at $endpoint returned $count annotations, the maximum this request " +
+                    "asked for; the backup would be truncated. Raise Constants.Grafana.ANNOTATION_FETCH_LIMIT.",
+            )
         }
+        return responseBody
     }
 
     private fun annotationsEndpoint(controlHost: ClusterHost): String =

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
@@ -37,6 +37,7 @@ import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
+import java.time.Duration
 
 /**
  * Koin module for registering business services.
@@ -102,6 +103,21 @@ val servicesModule =
         factory<VictoriaBackupService> { DefaultVictoriaBackupService(get(), get()) }
         factory<GrafanaAnnotationBackupService> {
             DefaultGrafanaAnnotationBackupService(get(), get(), get())
+        }
+        // Couples the metrics + annotations backup for the teardown path. The metrics backup Job
+        // gets a short timeout here (not the standalone default) so a stuck backup does not delay
+        // the abort/`--force` decision at `down`.
+        factory<TeardownBackupService> {
+            DefaultTeardownBackupService(
+                victoriaBackupService =
+                    DefaultVictoriaBackupService(
+                        get(),
+                        get(),
+                        jobTimeout =
+                            Duration.ofSeconds(Constants.Victoria.TEARDOWN_METRICS_BACKUP_TIMEOUT_SECONDS),
+                    ),
+                annotationBackupService = get(),
+            )
         }
         factoryOf(::DefaultVictoriaStreamService) bind VictoriaStreamService::class
         singleOf(::DefaultVictoriaMetricsQueryService) bind VictoriaMetricsQueryService::class

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
@@ -100,6 +100,9 @@ val servicesModule =
         factoryOf(::DefaultOtelSyncService) bind OtelSyncService::class
         factoryOf(::DefaultMetricsRegistryService) bind MetricsRegistryService::class
         factory<VictoriaBackupService> { DefaultVictoriaBackupService(get(), get()) }
+        factory<GrafanaAnnotationBackupService> {
+            DefaultGrafanaAnnotationBackupService(get(), get(), get())
+        }
         factoryOf(::DefaultVictoriaStreamService) bind VictoriaStreamService::class
         singleOf(::DefaultVictoriaMetricsQueryService) bind VictoriaMetricsQueryService::class
         singleOf(::DefaultVictoriaLogsService) bind VictoriaLogsService::class

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/TeardownBackupService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/TeardownBackupService.kt
@@ -1,0 +1,88 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.providers.aws.RetryUtil
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.github.resilience4j.retry.Retry
+
+/**
+ * Runs the metrics backup and the Grafana annotations backup as one coupled operation before a
+ * cluster is torn down.
+ *
+ * The two backups are always attempted together, never one without the other, so a teardown never
+ * keeps metrics while silently dropping annotations (or the reverse). Each backup is retried with
+ * resilience4j to ride out a transient failure. If either backup still fails after its retries, the
+ * whole operation fails; `down` then aborts and removes no infrastructure. See design decisions
+ * D3 and D4 in `openspec/changes/issue-939`.
+ */
+interface TeardownBackupService {
+    /**
+     * Backs up the cluster's metrics and Grafana annotations before teardown.
+     *
+     * @param controlHost The control node running VictoriaMetrics and Grafana.
+     * @param clusterState The cluster state carrying the S3 destinations.
+     * @return A success Result when both backups succeed, or a failure Result aggregating the
+     *   failures when either backup fails after its retries.
+     */
+    fun backupBeforeTeardown(
+        controlHost: ClusterHost,
+        clusterState: ClusterState,
+    ): Result<Unit>
+}
+
+/**
+ * Default implementation of [TeardownBackupService].
+ *
+ * @property victoriaBackupService Backs up VictoriaMetrics data. On the teardown path this is wired
+ *   with a short Job timeout so a stuck backup does not delay the abort/`--force` decision.
+ * @property annotationBackupService Backs up the Grafana annotations to the account-level location.
+ */
+class DefaultTeardownBackupService(
+    private val victoriaBackupService: VictoriaBackupService,
+    private val annotationBackupService: GrafanaAnnotationBackupService,
+) : TeardownBackupService {
+    private val log = KotlinLogging.logger {}
+
+    override fun backupBeforeTeardown(
+        controlHost: ClusterHost,
+        clusterState: ClusterState,
+    ): Result<Unit> {
+        // Both backups are always attempted; neither short-circuits the other. Each result is
+        // captured so a failure in the first does not skip the second.
+        val metricsResult =
+            withRetry("teardown-metrics-backup") {
+                victoriaBackupService.backupMetrics(controlHost, clusterState).getOrThrow()
+            }
+        val annotationsResult =
+            withRetry("teardown-annotations-backup") {
+                annotationBackupService.backup(controlHost, clusterState).getOrThrow()
+            }
+
+        val failures = listOfNotNull(metricsResult.exceptionOrNull(), annotationsResult.exceptionOrNull())
+        if (failures.isEmpty()) {
+            return Result.success(Unit)
+        }
+
+        val combined =
+            IllegalStateException(
+                "Pre-teardown backup failed: " +
+                    failures.joinToString("; ") { it.message ?: it.toString() },
+            )
+        failures.forEach(combined::addSuppressed)
+        return Result.failure(combined)
+    }
+
+    /**
+     * Runs [operation] under a resilience4j retry so a transient backup failure is retried before it
+     * is treated as fatal. Wraps the outcome in a [Result] so the caller can attempt both backups.
+     */
+    private fun <T> withRetry(
+        name: String,
+        operation: () -> T,
+    ): Result<T> {
+        val retry = Retry.of(name, RetryUtil.createNetworkRetryConfig<T>())
+        return runCatching { Retry.decorateSupplier(retry, operation).get() }
+            .onFailure { log.warn(it) { "$name failed after retries" } }
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/VictoriaBackupService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/VictoriaBackupService.kt
@@ -73,12 +73,16 @@ interface VictoriaBackupService {
  * @property k8sService Service for Kubernetes operations
  * @param jobPollInterval How long to wait between backup-job status polls. Defaults to
  *   [JOB_POLL_INTERVAL_MS] so production timing is unchanged; tests inject [Duration.ZERO].
+ * @param jobTimeout How long to wait for a backup Job before giving up. Defaults to
+ *   [JOB_TIMEOUT_SECONDS] for the standalone path; the teardown path injects a short timeout so a
+ *   stuck backup does not delay the abort/`--force` decision.
  */
 class DefaultVictoriaBackupService(
     private val k8sService: K8sService,
     private val eventBus: EventBus,
     private val jobBuilder: VictoriaBackupJobBuilder = VictoriaBackupJobBuilder(),
     private val jobPollInterval: Duration = Duration.ofMillis(JOB_POLL_INTERVAL_MS),
+    private val jobTimeout: Duration = Duration.ofSeconds(JOB_TIMEOUT_SECONDS.toLong()),
 ) : VictoriaBackupService {
     private val log = KotlinLogging.logger {}
 
@@ -226,7 +230,7 @@ class DefaultVictoriaBackupService(
         log.info { "Waiting for backup job $jobName to complete..." }
 
         val startTime = System.currentTimeMillis()
-        val timeoutMs = JOB_TIMEOUT_SECONDS * 1000L
+        val timeoutMs = jobTimeout.toMillis()
 
         while (System.currentTimeMillis() - startTime < timeoutMs) {
             val labelValue =
@@ -263,6 +267,6 @@ class DefaultVictoriaBackupService(
             eventBus.emit(Event.Backup.Waiting)
         }
 
-        error("Backup job $jobName timed out after $JOB_TIMEOUT_SECONDS seconds")
+        error("Backup job $jobName timed out after ${jobTimeout.toSeconds()} seconds")
     }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/DownBackupTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/DownBackupTest.kt
@@ -61,6 +61,26 @@ class DownBackupTest : BaseKoinTest() {
             hosts = mapOf(ServerType.Control to listOf(controlHost)),
         ).apply { markInfrastructureUp() }
 
+    /** A cluster whose infrastructure is DOWN — the backup must be skipped, not attempted. */
+    private fun downClusterState() =
+        ClusterState(
+            name = "perf-test",
+            versions = mutableMapOf(),
+            s3Bucket = "acct-bucket",
+            vpcId = "vpc-123",
+            hosts = mapOf(ServerType.Control to listOf(controlHost)),
+        )
+
+    /** An UP cluster with no control node — the backup has no host to reach, so it must be skipped. */
+    private fun upClusterStateNoControlHost() =
+        ClusterState(
+            name = "perf-test",
+            versions = mutableMapOf(),
+            s3Bucket = "acct-bucket",
+            vpcId = "vpc-123",
+            hosts = emptyMap(),
+        ).apply { markInfrastructureUp() }
+
     override fun additionalTestModules(): List<Module> =
         listOf(
             module {
@@ -85,6 +105,8 @@ class DownBackupTest : BaseKoinTest() {
     }
 
     private fun errorOutput(): String = outputHandler.errors.joinToString("\n") { it.first }
+
+    private fun messageOutput(): String = outputHandler.messages.joinToString("\n")
 
     @Test
     fun `a failed backup aborts teardown with no infrastructure removed`() {
@@ -131,5 +153,67 @@ class DownBackupTest : BaseKoinTest() {
         verify(teardownBackupService, never()).backupBeforeTeardown(any(), any())
         verify(socksProxyService, never()).ensureRunning(any())
         verify(teardownService, times(1)).teardownVpc(eq("vpc-123"), eq(true))
+    }
+
+    @Test
+    fun `infrastructure DOWN skips the backup, says why, and still tears down`() {
+        whenever(clusterStateManager.exists()).thenReturn(true)
+        whenever(clusterStateManager.load()).thenReturn(downClusterState())
+        // Empty preview so the teardown returns immediately after the preview call.
+        whenever(teardownService.teardownVpc(any(), eq(true))).thenReturn(TeardownResult.success(emptyList()))
+
+        Down().apply { autoApprove = true }.execute()
+
+        // No backup is attempted, but the teardown still proceeds — and the skip is observable.
+        verify(teardownBackupService, never()).backupBeforeTeardown(any(), any())
+        verify(socksProxyService, never()).ensureRunning(any())
+        verify(teardownService).teardownVpc(eq("vpc-123"), eq(true))
+        assertThat(messageOutput()).contains("infrastructure is not up")
+    }
+
+    @Test
+    fun `current-cluster teardown with no control host skips the backup rather than throwing`() {
+        whenever(clusterStateManager.exists()).thenReturn(true)
+        whenever(clusterStateManager.load()).thenReturn(upClusterStateNoControlHost())
+        whenever(teardownService.teardownVpc(any(), eq(true))).thenReturn(TeardownResult.success(emptyList()))
+
+        Down().apply { autoApprove = true }.execute()
+
+        verify(teardownBackupService, never()).backupBeforeTeardown(any(), any())
+        verify(socksProxyService, never()).ensureRunning(any())
+        verify(teardownService).teardownVpc(eq("vpc-123"), eq(true))
+        assertThat(messageOutput()).contains("no control node")
+    }
+
+    @Test
+    fun `down --all never runs the pre-teardown backup`() {
+        whenever(teardownService.teardownAllTagged(eq(true), any()))
+            .thenReturn(TeardownResult.success(emptyList()))
+
+        Down()
+            .apply {
+                autoApprove = true
+                teardownAll = true
+            }.execute()
+
+        // --all does not map to a single reachable control node, so the backup never runs.
+        verify(teardownBackupService, never()).backupBeforeTeardown(any(), any())
+        verify(socksProxyService, never()).ensureRunning(any())
+        verify(teardownService).teardownAllTagged(eq(true), any())
+    }
+
+    @Test
+    fun `a tunnel-setup failure aborts teardown with no infrastructure removed`() {
+        whenever(clusterStateManager.exists()).thenReturn(true)
+        whenever(clusterStateManager.load()).thenReturn(upClusterState())
+        // The SOCKS tunnel cannot be established — this must abort the same way a backup failure does,
+        // not escape as a raw stack trace.
+        whenever(socksProxyService.ensureRunning(any()))
+            .thenThrow(RuntimeException("ssh tunnel refused"))
+
+        Down().apply { autoApprove = true }.execute()
+
+        verify(teardownService, never()).teardownVpc(any(), any())
+        assertThat(errorOutput()).contains("no infrastructure was removed")
     }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/DownBackupTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/DownBackupTest.kt
@@ -1,0 +1,135 @@
+package com.rustyrazorblade.easydblab.commands
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
+import com.rustyrazorblade.easydblab.output.OutputHandler
+import com.rustyrazorblade.easydblab.providers.aws.TeardownResult
+import com.rustyrazorblade.easydblab.proxy.SocksProxyService
+import com.rustyrazorblade.easydblab.proxy.SocksProxyState
+import com.rustyrazorblade.easydblab.services.TailscaleService
+import com.rustyrazorblade.easydblab.services.TeardownBackupService
+import com.rustyrazorblade.easydblab.services.aws.AwsInfrastructureService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.Instant
+
+/**
+ * Tests the pre-teardown backup wiring in [Down].
+ *
+ * The backup runs FIRST, before any infrastructure is touched. A backup failure must abort the
+ * teardown with no infrastructure removed, and `--force` must skip the backup and proceed. These
+ * tests drive the whole `execute()` path with the teardown and backup services mocked, and assert
+ * on whether `teardownVpc` is ever reached — that is the observable "no infra removed" signal.
+ */
+class DownBackupTest : BaseKoinTest() {
+    private lateinit var clusterStateManager: ClusterStateManager
+    private lateinit var teardownService: AwsInfrastructureService
+    private lateinit var teardownBackupService: TeardownBackupService
+    private lateinit var socksProxyService: SocksProxyService
+    private lateinit var outputHandler: BufferedOutputHandler
+
+    private val controlHost =
+        ClusterHost(
+            publicIp = "54.1.2.3",
+            privateIp = "10.0.1.5",
+            alias = "control0",
+            availabilityZone = "us-west-2a",
+            instanceId = "i-control",
+        )
+
+    private fun upClusterState() =
+        ClusterState(
+            name = "perf-test",
+            versions = mutableMapOf(),
+            s3Bucket = "acct-bucket",
+            vpcId = "vpc-123",
+            hosts = mapOf(ServerType.Control to listOf(controlHost)),
+        ).apply { markInfrastructureUp() }
+
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                single { mock<ClusterStateManager>() }
+                single { mock<AwsInfrastructureService>() }
+                single { mock<TailscaleService>() }
+                single { mock<TeardownBackupService>() }
+                single { mock<SocksProxyService>() }
+            },
+        )
+
+    @BeforeEach
+    fun setupMocks() {
+        clusterStateManager = getKoin().get()
+        teardownService = getKoin().get()
+        teardownBackupService = getKoin().get()
+        socksProxyService = getKoin().get()
+        outputHandler = getKoin().get<OutputHandler>() as BufferedOutputHandler
+
+        whenever(socksProxyService.ensureRunning(any()))
+            .thenReturn(SocksProxyState(1080, controlHost, Instant.now()))
+    }
+
+    private fun errorOutput(): String = outputHandler.errors.joinToString("\n") { it.first }
+
+    @Test
+    fun `a failed backup aborts teardown with no infrastructure removed`() {
+        whenever(clusterStateManager.exists()).thenReturn(true)
+        whenever(clusterStateManager.load()).thenReturn(upClusterState())
+        whenever(teardownBackupService.backupBeforeTeardown(any(), any()))
+            .thenReturn(Result.failure(IllegalStateException("grafana unreachable")))
+
+        Down().apply { autoApprove = true }.execute()
+
+        // The teardown must never be attempted: no infrastructure was removed.
+        verify(teardownService, never()).teardownVpc(any(), any())
+        assertThat(errorOutput()).contains("no infrastructure was removed")
+    }
+
+    @Test
+    fun `a successful backup runs before the teardown`() {
+        whenever(clusterStateManager.exists()).thenReturn(true)
+        whenever(clusterStateManager.load()).thenReturn(upClusterState())
+        whenever(teardownBackupService.backupBeforeTeardown(any(), any())).thenReturn(Result.success(Unit))
+        // Empty preview so the teardown returns immediately after the preview call.
+        whenever(teardownService.teardownVpc(any(), eq(true))).thenReturn(TeardownResult.success(emptyList()))
+
+        Down().apply { autoApprove = true }.execute()
+
+        // The backup is attempted, and only then is the teardown reached.
+        val order = inOrder(teardownBackupService, teardownService)
+        order.verify(teardownBackupService).backupBeforeTeardown(eq(controlHost), any())
+        order.verify(teardownService).teardownVpc(eq("vpc-123"), eq(true))
+    }
+
+    @Test
+    fun `--force skips the backup and tears down anyway`() {
+        whenever(clusterStateManager.exists()).thenReturn(true)
+        whenever(clusterStateManager.load()).thenReturn(upClusterState())
+        whenever(teardownService.teardownVpc(any(), eq(true))).thenReturn(TeardownResult.success(emptyList()))
+
+        Down()
+            .apply {
+                autoApprove = true
+                force = true
+            }.execute()
+
+        verify(teardownBackupService, never()).backupBeforeTeardown(any(), any())
+        verify(socksProxyService, never()).ensureRunning(any())
+        verify(teardownService, times(1)).teardownVpc(eq("vpc-123"), eq(true))
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/converters/PicoEpochMillisConverterTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/converters/PicoEpochMillisConverterTest.kt
@@ -1,0 +1,72 @@
+package com.rustyrazorblade.easydblab.commands.converters
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import picocli.CommandLine.TypeConversionException
+import java.time.Instant
+
+/**
+ * Tests for [PicoEpochMillisConverter], which parses operator `--time` input to epoch milliseconds.
+ *
+ * The converter has real parsing branches (now, relative offset, ISO instant, raw millis, and an
+ * error path), so each branch is exercised for the value it produces or the failure it raises.
+ */
+class PicoEpochMillisConverterTest {
+    private val converter = PicoEpochMillisConverter()
+
+    @Test
+    fun `empty string resolves to approximately now`() {
+        val before = Instant.now().toEpochMilli()
+        val result = converter.convert("")
+        val after = Instant.now().toEpochMilli()
+        assertThat(result).isBetween(before, after)
+    }
+
+    @Test
+    fun `now keyword resolves to approximately now`() {
+        val before = Instant.now().toEpochMilli()
+        val result = converter.convert("now")
+        val after = Instant.now().toEpochMilli()
+        assertThat(result).isBetween(before, after)
+    }
+
+    @Test
+    fun `raw epoch milliseconds pass through unchanged`() {
+        assertThat(converter.convert("1767225600000")).isEqualTo(1767225600000L)
+    }
+
+    @Test
+    fun `ISO-8601 instant converts to its epoch milliseconds`() {
+        val expected = Instant.parse("2026-01-01T12:00:00Z").toEpochMilli()
+        assertThat(converter.convert("2026-01-01T12:00:00Z")).isEqualTo(expected)
+    }
+
+    @Test
+    fun `negative hour offset resolves before now`() {
+        val now = Instant.now().toEpochMilli()
+        val result = converter.convert("-2h")
+        val twoHoursMs = 2 * 60 * 60 * 1000L
+        assertThat(result).isLessThanOrEqualTo(now - twoHoursMs + TOLERANCE_MS)
+        assertThat(result).isGreaterThanOrEqualTo(now - twoHoursMs - TOLERANCE_MS)
+    }
+
+    @Test
+    fun `positive minute offset resolves after now`() {
+        val now = Instant.now().toEpochMilli()
+        val result = converter.convert("+30m")
+        val thirtyMinutesMs = 30 * 60 * 1000L
+        assertThat(result).isGreaterThanOrEqualTo(now + thirtyMinutesMs - TOLERANCE_MS)
+    }
+
+    @Test
+    fun `unparseable value raises a conversion exception`() {
+        assertThatThrownBy { converter.convert("yesterday") }
+            .isInstanceOf(TypeConversionException::class.java)
+            .hasMessageContaining("yesterday")
+    }
+
+    private companion object {
+        const val TOLERANCE_MS = 5000L
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterS3PathAnnotationsTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterS3PathAnnotationsTest.kt
@@ -1,0 +1,32 @@
+package com.rustyrazorblade.easydblab.configuration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for the Grafana annotations account-level path helpers on [ClusterS3Path].
+ *
+ * The load-bearing invariant is that the artifact lives OUTSIDE the per-cluster `clusters/<name>-<id>/`
+ * prefix that teardown expires; these tests pin that down along with the cluster-name and timestamp
+ * keying so a backup remains findable after the cluster is gone.
+ */
+class ClusterS3PathAnnotationsTest {
+    @Test
+    fun `annotations artifact is keyed under the account-level grafana-annotations root, not a cluster prefix`() {
+        val artifact =
+            ClusterS3Path.grafanaAnnotationsArtifact(
+                accountBucket = "acct-bucket",
+                clusterName = "perf-test",
+                timestampMillis = 1767225600000L,
+            )
+
+        assertThat(artifact.getKey()).isEqualTo("grafana-annotations/perf-test/annotations-1767225600000.json")
+        assertThat(artifact.getKey()).doesNotStartWith("clusters/")
+        assertThat(artifact.toUri()).isEqualTo("s3://acct-bucket/grafana-annotations/perf-test/annotations-1767225600000.json")
+    }
+
+    @Test
+    fun `annotations root sits directly under the bucket`() {
+        assertThat(ClusterS3Path.grafanaAnnotationsRoot("acct-bucket").getKey()).isEqualTo("grafana-annotations")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/McpToolNamespacingTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/McpToolNamespacingTest.kt
@@ -103,6 +103,7 @@ class McpToolNamespacingTest : BaseKoinTest() {
         assertThat(toolNames).contains("cassandra_start")
         assertThat(toolNames).contains("cassandra_stress_start")
         assertThat(toolNames).contains("grafana_annotate")
+        assertThat(toolNames).contains("grafana_backup")
     }
 
     @Test

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/McpToolNamespacingTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/McpToolNamespacingTest.kt
@@ -102,6 +102,7 @@ class McpToolNamespacingTest : BaseKoinTest() {
         assertThat(toolNames).contains("status")
         assertThat(toolNames).contains("cassandra_start")
         assertThat(toolNames).contains("cassandra_stress_start")
+        assertThat(toolNames).contains("grafana_annotate")
     }
 
     @Test

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/CommandExecutorTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/CommandExecutorTest.kt
@@ -552,34 +552,16 @@ class CommandExecutorTest : BaseKoinTest() {
     }
 
     @Test
-    fun `executeTopLevel does not start proxy for Down even when infra is UP and Tailscale is disabled`() {
-        // Given - Down is never annotated with @RequiresProxy: it tears down the tunnel itself
-        // as its first action (clearProxySystemProperties + cleanupSocks5Proxy), so a pre-flight
-        // proxy start would only start a tunnel Down immediately destroys.
-        val controlHost =
-            ClusterHost(
-                publicIp = "1.2.3.4",
-                privateIp = "10.0.0.1",
-                alias = "control0",
-                availabilityZone = "us-west-2a",
-            )
-        val state =
-            ClusterState(
-                name = "test",
-                versions = mutableMapOf(),
-                infrastructureStatus = InfrastructureStatus.UP,
-                tailscaleActive = false,
-                hosts = mapOf(ServerType.Control to listOf(controlHost)),
-            )
-        whenever(mockClusterStateManager.exists()).thenReturn(true)
-        whenever(mockClusterStateManager.load()).thenReturn(state)
-
-        // When - Down's own execute() may fail against this test's minimal AWS mocks; that is
-        // irrelevant here, only whether the proxy pre-flight ran is under test.
-        commandExecutor.execute { Down() }
-
-        // Then
-        verify(mockSocksProxyService, never()).ensureRunning(any())
+    fun `Down carries no RequiresProxy so the executor never pre-flights a tunnel it would tear down`() {
+        // Down must NOT carry @RequiresProxy. Its teardown path kills the tunnel, so an executor
+        // pre-flight would only start a tunnel Down immediately destroys. Down does establish a
+        // short-lived tunnel inside its own execute() to back up metrics and annotations first
+        // (design D3), so this invariant is asserted on the annotation directly rather than on
+        // ensureRunning calls, which Down's own backup path now makes.
+        //
+        // The executor's "no pre-flight without @RequiresProxy" mechanism is covered separately by
+        // `executeTopLevel does not start proxy for a command without RequiresProxy even when infra is UP`.
+        assertThat(Down::class.java.getAnnotation(RequiresProxy::class.java)).isNull()
     }
 
     // ========== TEST COMMAND HELPERS ==========

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/TeardownBackupServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/TeardownBackupServiceTest.kt
@@ -1,0 +1,138 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterS3Path
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [DefaultTeardownBackupService].
+ *
+ * The load-bearing behavior is the coupling: the metrics backup and the annotations backup are
+ * always attempted together, each is retried, and a failure in either one fails the whole operation
+ * so `down` can abort. Hand-written fakes drive the success and failure modes and count invocations.
+ *
+ * Fakes are used rather than Mockito here on purpose: both backup methods return Kotlin's value class
+ * [Result], which Mockito cannot reliably stub — a stubbed `Result.failure(...)` comes back as a
+ * default success and the coupling under test never sees the failure. The fakes return real [Result]
+ * values, so the retry and the failure propagation are exercised for real.
+ */
+class TeardownBackupServiceTest {
+    private val controlHost =
+        ClusterHost(
+            publicIp = "54.1.2.3",
+            privateIp = "10.0.1.5",
+            alias = "control0",
+            availabilityZone = "us-west-2a",
+            instanceId = "i-control",
+        )
+
+    private val clusterState =
+        ClusterState(
+            name = "perf-test",
+            versions = mutableMapOf(),
+            s3Bucket = "acct-bucket",
+        )
+
+    private val metricsResult = VictoriaBackupResult(ClusterS3Path.root("acct-bucket").resolve("m"), "ts")
+    private val annotationsResult =
+        GrafanaAnnotationBackupResult(ClusterS3Path.root("acct-bucket").resolve("a"), 3)
+
+    /**
+     * Returns the queued metrics results in order, clamping to the last once exhausted so a retry
+     * can move from a failure to a success. Counts invocations for retry assertions.
+     */
+    private class FakeVictoriaBackupService(
+        private val results: List<Result<VictoriaBackupResult>>,
+    ) : VictoriaBackupService {
+        var metricsCalls = 0
+            private set
+
+        override fun backupMetrics(
+            controlHost: ClusterHost,
+            clusterState: ClusterState,
+            destinationUri: String?,
+        ): Result<VictoriaBackupResult> {
+            val result = results.getOrElse(metricsCalls) { results.last() }
+            metricsCalls++
+            return result
+        }
+
+        override fun backupLogs(
+            controlHost: ClusterHost,
+            clusterState: ClusterState,
+            destinationUri: String?,
+        ): Result<VictoriaBackupResult> = error("not used")
+    }
+
+    private class FakeAnnotationBackupService(
+        private val result: Result<GrafanaAnnotationBackupResult>,
+    ) : GrafanaAnnotationBackupService {
+        var calls = 0
+            private set
+
+        override fun backup(
+            controlHost: ClusterHost,
+            clusterState: ClusterState,
+        ): Result<GrafanaAnnotationBackupResult> {
+            calls++
+            return result
+        }
+    }
+
+    @Test
+    fun `both backups succeed - success and each attempted once`() {
+        val metrics = FakeVictoriaBackupService(listOf(Result.success(metricsResult)))
+        val annotations = FakeAnnotationBackupService(Result.success(annotationsResult))
+        val service = DefaultTeardownBackupService(metrics, annotations)
+
+        val result = service.backupBeforeTeardown(controlHost, clusterState)
+
+        assertThat(result.isSuccess).isTrue()
+        assertThat(metrics.metricsCalls).isEqualTo(1)
+        assertThat(annotations.calls).isEqualTo(1)
+    }
+
+    @Test
+    fun `metrics backup failing still attempts annotations and fails the whole operation`() {
+        val metrics = FakeVictoriaBackupService(listOf(Result.failure(IllegalStateException("vmbackup exploded"))))
+        val annotations = FakeAnnotationBackupService(Result.success(annotationsResult))
+        val service = DefaultTeardownBackupService(metrics, annotations)
+
+        val result = service.backupBeforeTeardown(controlHost, clusterState)
+
+        // The whole operation fails, but annotations were still attempted (never one without the other).
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).hasMessageContaining("vmbackup exploded")
+        assertThat(annotations.calls).isEqualTo(1)
+    }
+
+    @Test
+    fun `annotations backup failing fails the whole operation even when metrics succeeded`() {
+        val metrics = FakeVictoriaBackupService(listOf(Result.success(metricsResult)))
+        val annotations = FakeAnnotationBackupService(Result.failure(IllegalStateException("grafana unreachable")))
+        val service = DefaultTeardownBackupService(metrics, annotations)
+
+        val result = service.backupBeforeTeardown(controlHost, clusterState)
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).hasMessageContaining("grafana unreachable")
+    }
+
+    @Test
+    fun `a transient metrics failure is retried and then succeeds`() {
+        val metrics =
+            FakeVictoriaBackupService(
+                listOf(Result.failure(IllegalStateException("transient")), Result.success(metricsResult)),
+            )
+        val annotations = FakeAnnotationBackupService(Result.success(annotationsResult))
+        val service = DefaultTeardownBackupService(metrics, annotations)
+
+        val result = service.backupBeforeTeardown(controlHost, clusterState)
+
+        assertThat(result.isSuccess).isTrue()
+        // The first attempt failed, the retry succeeded: proves the retry is real, not decorative.
+        assertThat(metrics.metricsCalls).isGreaterThanOrEqualTo(2)
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/TeardownBackupServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/TeardownBackupServiceTest.kt
@@ -121,6 +121,26 @@ class TeardownBackupServiceTest {
     }
 
     @Test
+    fun `both backups failing aggregates both messages and carries both causes as suppressed`() {
+        val metrics = FakeVictoriaBackupService(listOf(Result.failure(IllegalStateException("vmbackup exploded"))))
+        val annotations = FakeAnnotationBackupService(Result.failure(IllegalStateException("grafana unreachable")))
+        val service = DefaultTeardownBackupService(metrics, annotations)
+
+        val result = service.backupBeforeTeardown(controlHost, clusterState)
+
+        assertThat(result.isFailure).isTrue()
+        val exception = requireNotNull(result.exceptionOrNull())
+        // The combined message names both failures, so an operator sees the whole picture at once.
+        assertThat(exception)
+            .hasMessageContaining("vmbackup exploded")
+            .hasMessageContaining("grafana unreachable")
+        // Both original causes are attached as suppressed, so neither stack trace is lost.
+        assertThat(exception.suppressed).hasSize(2)
+        assertThat(exception.suppressed.map { it.message })
+            .containsExactlyInAnyOrder("vmbackup exploded", "grafana unreachable")
+    }
+
+    @Test
     fun `a transient metrics failure is retried and then succeeds`() {
         val metrics =
             FakeVictoriaBackupService(


### PR DESCRIPTION
Closes #939

Adds `grafana annotate`, an annotations-only Grafana backup to an account-level S3 location, and a backup-first `down` that aborts teardown on backup failure (with `--force` as the escape). Annotations are captured over the Grafana HTTP API (`GET /api/annotations`, up to 5000; the backup fails and uploads nothing beyond that, so a truncated capture is never mistaken for a complete one). Global markers auto-carry the `easydblab` tag and render on the six core dashboards through a provisioned tag-filtered annotation query. At `down`, the coupled metrics + annotations backup runs first, before any infrastructure is torn down; a failure aborts teardown with nothing removed. Import and restore are deferred to a follow-up.

Reviewed by the five-lens panel; approved at round 2 after one fix round. Round 1 raised 5 must-fix findings (2 correctness, 3 missing tests on a decision or transform path); all were fixed with regression-catching tests.

Tests: `./gradlew test` (2741 passed) and `./gradlew integrationTest` (154 passed) on JDK 21.

## Before merge — for your decision

- **Real-AWS run (`requires-aws`).** The backup performs a real S3 upload, which static review and MockWebServer cannot prove. Per `spec-flow/WORKFLOWS.md`, an S3 path warrants a real-AWS run before the merge seam, owner-driven, with the output in this PR. #939 carries no `requires-aws` label. Your call: add the label and drive a live `grafana backup` + `down` run, or accept the integration-tier coverage.
- **Task 3 live read-back.** The tag-filtered annotation query was added to the six core dashboards and reads back statically, but rendering an actual global annotation on a live dashboard, and running `grafana annotate` against a real Grafana, both need a live cluster. tasks.md 3.2 is left open for that reason.
- **Unrelated pre-existing test.** `./gradlew check` is red locally on `:testProfilingReconcile` — 3 bash shell-script tests in `packer/cassandra` profiling scripts this diff never touches. The signature is a macOS `printf` sign-extension artifact; CI on Linux/JDK 21 is green on it. A candidate for a separate issue, not this one's scope.

## Surfaced, non-blocking

- **S1** — tasks.md 3.1 checkbox left unchecked though the dashboard annotation query is present (bookkeeping only).
- **S2** — the pre-teardown backup runs before the interactive teardown confirmation prompt; harmless, satisfies the spec, noted as slightly surprising ordering.
- **S3** — the "run up first" message is duplicated as a literal in two places; could share one source.
- **F3** — the teardown-path short Job timeout has no regression test; an owner-ratified intentional exclusion (ac-coverage.md H1).
- **F5** — the replaced `CommandExecutorTest` asserts annotation absence rather than behavior; acceptable, and guards a documented invariant.
